### PR TITLE
Add sort_order column to tasks table

### DIFF
--- a/migrations/007_add_sort_order_to_tasks.sql
+++ b/migrations/007_add_sort_order_to_tasks.sql
@@ -1,0 +1,3 @@
+-- Migration 007: Add sort_order column to tasks table
+-- Supports hand-sort mode: user-defined task ordering within area cards
+ALTER TABLE tasks ADD COLUMN sort_order SMALLINT NULL;

--- a/schema.sql
+++ b/schema.sql
@@ -57,6 +57,7 @@ CREATE TABLE IF NOT EXISTS tasks (
     create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
     update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
     done_ts         TIMESTAMP       NULL,
+    sort_order      SMALLINT        NULL,
     FOREIGN KEY (creator_fk)
         REFERENCES profiles (id)
         ON UPDATE CASCADE ON DELETE CASCADE,


### PR DESCRIPTION
## Summary
- Migration 007: `ALTER TABLE tasks ADD COLUMN sort_order SMALLINT NULL`
- Updated schema.sql to include sort_order in tasks DDL
- Supports hand-sort mode for user-defined task ordering within area cards

## Files changed
- `migrations/007_add_sort_order_to_tasks.sql` — NEW: ALTER TABLE migration
- `schema.sql` — add sort_order SMALLINT NULL after done_ts

## Testing
- Column already applied to production (`darwin`) and test (`darwin2`) databases
- 46/47 E2E tests pass with sort_order in use

## Deploy notes
- Schema change already deployed — this PR captures the DDL for the repo

## References
- Related PR: BillWilliams79/Darwin#29 (frontend implementation)
- Roadmap item #5: Task sorting options

🤖 Generated with [Claude Code](https://claude.com/claude-code)