### PR TITLE
Add sort_mode column to areas (migration 008)

### DIFF
--- a/migrations/008_add_sort_mode_to_areas.sql
+++ b/migrations/008_add_sort_mode_to_areas.sql
@@ -1,0 +1,6 @@
+-- Migration 008: Add sort_mode column to areas tables
+-- Persists per-area sort mode preference (priority vs hand) in the database
+-- instead of localStorage. Default 'priority' matches existing behavior.
+
+ALTER TABLE areas ADD COLUMN sort_mode VARCHAR(8) NOT NULL DEFAULT 'priority';
+ALTER TABLE areas2 ADD COLUMN sort_mode VARCHAR(8) NOT NULL DEFAULT 'priority';

--- a/schema.sql
+++ b/schema.sql
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS areas (
     creator_fk      VARCHAR(64)     NOT NULL,
     closed          TINYINT         NOT NULL DEFAULT 0,
     sort_order      SMALLINT        NULL,
+    sort_mode       VARCHAR(8)      NOT NULL DEFAULT 'priority',
     create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
     update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (creator_fk)


### PR DESCRIPTION
## Summary
- Add `sort_mode VARCHAR(8) NOT NULL DEFAULT 'priority'` to areas table
- Migration 008 applies to both `areas` (prod) and `areas2` (test)
- Schema.sql updated to reflect current state
- Companion to Darwin PR #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)