### PR TITLE
Rename Priorities to Requirements — Migration 038

### DIFF
--- a/migrations/038_rename_priorities_to_requirements.sql
+++ b/migrations/038_rename_priorities_to_requirements.sql
@@ -1,0 +1,17 @@
+-- Rename "priorities" to "requirements" throughout the roadmap/swarm system.
+-- Task-level priority (tasks.priority, recurring_tasks.priority, priority_card_order) is UNCHANGED.
+
+-- 1. Rename tables
+RENAME TABLE priorities TO requirements;
+RENAME TABLE priority_sessions TO requirement_sessions;
+
+-- 2. Rename columns
+ALTER TABLE requirements CHANGE COLUMN priority_status requirement_status VARCHAR(16) NOT NULL DEFAULT 'idle';
+ALTER TABLE requirement_sessions CHANGE COLUMN priority_fk requirement_fk INT NOT NULL;
+
+-- 3. Migrate source_ref values in swarm_sessions
+UPDATE swarm_sessions SET source_ref = CONCAT('requirement:', SUBSTRING(source_ref, 10))
+WHERE source_ref LIKE 'priority:%';
+
+-- 4. Update section comment (schema.sql only — not a DDL operation)
+-- Section header: "Roadmap / priority tracking" → "Roadmap / requirement tracking"

--- a/schema.sql
+++ b/schema.sql
@@ -101,7 +101,7 @@ CREATE TABLE IF NOT EXISTS tasks (
 );
 
 -- ============================================================================
--- Roadmap / priority tracking (darwin-mcp)
+-- Roadmap / requirement tracking (darwin-mcp)
 -- ============================================================================
 
 CREATE TABLE IF NOT EXISTS projects (
@@ -136,11 +136,11 @@ CREATE TABLE IF NOT EXISTS categories (
         ON UPDATE CASCADE ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS priorities (
+CREATE TABLE IF NOT EXISTS requirements (
     id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
     title           VARCHAR(256)    NOT NULL,
     description     TEXT            NULL,
-    priority_status VARCHAR(16)     NOT NULL DEFAULT 'idle',
+    requirement_status VARCHAR(16)  NOT NULL DEFAULT 'idle',
     started_at      TIMESTAMP       NULL,
     completed_at    TIMESTAMP       NULL,
     deferred_at     TIMESTAMP       NULL,
@@ -190,12 +190,12 @@ CREATE TABLE IF NOT EXISTS swarm_sessions (
         ON UPDATE CASCADE ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS priority_sessions (
-    priority_fk     INT             NOT NULL,
+CREATE TABLE IF NOT EXISTS requirement_sessions (
+    requirement_fk  INT             NOT NULL,
     session_fk      INT             NOT NULL,
-    PRIMARY KEY (priority_fk, session_fk),
-    FOREIGN KEY (priority_fk)
-        REFERENCES priorities (id)
+    PRIMARY KEY (requirement_fk, session_fk),
+    FOREIGN KEY (requirement_fk)
+        REFERENCES requirements (id)
         ON UPDATE CASCADE ON DELETE CASCADE,
     FOREIGN KEY (session_fk)
         REFERENCES swarm_sessions (id)

--- a/scripts/cleanup_darwin_dev.py
+++ b/scripts/cleanup_darwin_dev.py
@@ -43,7 +43,7 @@ TARGET_DATABASE = 'darwin_dev'
 # GUARDRAIL 3: Only known tables
 # ============================================================================
 VALID_TABLES = ('profiles', 'domains', 'areas', 'tasks', 'projects', 'categories',
-                'priorities', 'priority_sessions', 'swarm_sessions', 'dev_servers',
+                'requirements', 'requirement_sessions', 'swarm_sessions', 'dev_servers',
                 'priority_card_order')
 
 # Test data identification patterns

--- a/scripts/cleanup_e2e.py
+++ b/scripts/cleanup_e2e.py
@@ -2,8 +2,8 @@
 """
 Cleanup orphaned E2E test data from darwin_dev or darwin database.
 
-E2E tests create domains, areas, tasks, projects, categories, priorities,
-swarm_sessions, and priority_sessions. When tests are interrupted (Ctrl+C,
+E2E tests create domains, areas, tasks, projects, categories, requirements,
+swarm_sessions, and requirement_sessions. When tests are interrupted (Ctrl+C,
 timeout, crash), afterAll cleanup never runs and stale data accumulates.
 
 This script targets all 9 E2E test user creator_fk UUIDs (8 workers + original).
@@ -56,19 +56,19 @@ E2E_CREATOR_FKS = [
 # ============================================================================
 # GUARDRAIL 3: Only known tables, in FK-safe deletion order
 # ============================================================================
-# priority_sessions → swarm_sessions → priorities → categories → projects → domains
-# (areas/tasks cascade from domains; priorities cascade from categories)
+# requirement_sessions → swarm_sessions → requirements → categories → projects → domains
+# (areas/tasks cascade from domains; requirements cascade from categories)
 CLEANUP_TABLES = [
-    'priority_sessions',
+    'requirement_sessions',
     'swarm_sessions',
-    'priorities',
+    'requirements',
     'categories',
     'projects',
     'domains',
 ]
 
 # Tables that use session_fk instead of creator_fk
-SESSION_FK_TABLES = {'priority_sessions'}
+SESSION_FK_TABLES = {'requirement_sessions'}
 
 
 def get_connection(database):
@@ -104,7 +104,7 @@ def find_e2e_data(conn):
 
         for table in CLEANUP_TABLES:
             if table in SESSION_FK_TABLES:
-                continue  # priority_sessions counted via session lookup
+                continue  # requirement_sessions counted via session lookup
 
             with conn.cursor() as cur:
                 try:
@@ -146,7 +146,7 @@ def delete_e2e_data(conn, dry_run=True):
         print(f"  {info['label']} ({creator_fk})")
         tables = info['tables']
 
-        # First handle priority_sessions via swarm_sessions for this creator
+        # First handle requirement_sessions via swarm_sessions for this creator
         if 'swarm_sessions' in tables:
             with conn.cursor() as cur:
                 try:
@@ -159,20 +159,20 @@ def delete_e2e_data(conn, dry_run=True):
                     if session_ids:
                         placeholders = ','.join(['%s'] * len(session_ids))
                         cur.execute(
-                            f"SELECT COUNT(*) AS cnt FROM priority_sessions WHERE session_fk IN ({placeholders})",
+                            f"SELECT COUNT(*) AS cnt FROM requirement_sessions WHERE session_fk IN ({placeholders})",
                             session_ids,
                         )
                         ps_count = cur.fetchone()['cnt']
 
                         if ps_count > 0:
                             if dry_run:
-                                print(f"    WOULD DELETE {ps_count} rows from priority_sessions")
+                                print(f"    WOULD DELETE {ps_count} rows from requirement_sessions")
                             else:
                                 deleted = cur.execute(
-                                    f"DELETE FROM priority_sessions WHERE session_fk IN ({placeholders})",
+                                    f"DELETE FROM requirement_sessions WHERE session_fk IN ({placeholders})",
                                     session_ids,
                                 )
-                                print(f"    DELETED {deleted} rows from priority_sessions")
+                                print(f"    DELETED {deleted} rows from requirement_sessions")
                                 total_deleted += deleted
                 except pymysql.err.ProgrammingError:
                     pass  # Table doesn't exist

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -8,8 +8,8 @@ USE darwin_dev;
 SET FOREIGN_KEY_CHECKS = 0;
 DROP TABLE IF EXISTS map_run_partners, map_partners,
     map_views, map_coordinates, map_runs, map_routes,
-    priority_card_order, dev_servers, priority_sessions,
-    priorities, swarm_sessions, categories, projects,
+    priority_card_order, dev_servers, requirement_sessions,
+    requirements, swarm_sessions, categories, projects,
     tasks, recurring_tasks, areas, domains, profiles;
 SET FOREIGN_KEY_CHECKS = 1;
 
@@ -104,7 +104,7 @@ CREATE TABLE tasks (
         ON DELETE SET NULL
 );
 
--- Roadmap / priority tracking
+-- Roadmap / requirement tracking
 
 CREATE TABLE projects (
     id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
@@ -138,7 +138,7 @@ CREATE TABLE categories (
         ON UPDATE CASCADE ON DELETE CASCADE
 );
 
-CREATE TABLE priorities (
+CREATE TABLE requirements (
     id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
     title           VARCHAR(256)    NOT NULL,
     description     TEXT            NULL,
@@ -190,12 +190,12 @@ CREATE TABLE swarm_sessions (
         ON UPDATE CASCADE ON DELETE CASCADE
 );
 
-CREATE TABLE priority_sessions (
-    priority_fk     INT             NOT NULL,
+CREATE TABLE requirement_sessions (
+    requirement_fk  INT             NOT NULL,
     session_fk      INT             NOT NULL,
-    PRIMARY KEY (priority_fk, session_fk),
-    FOREIGN KEY (priority_fk)
-        REFERENCES priorities (id)
+    PRIMARY KEY (requirement_fk, session_fk),
+    FOREIGN KEY (requirement_fk)
+        REFERENCES requirements (id)
         ON UPDATE CASCADE ON DELETE CASCADE,
     FOREIGN KEY (session_fk)
         REFERENCES swarm_sessions (id)

--- a/scripts/seed_darwin_dev.py
+++ b/scripts/seed_darwin_dev.py
@@ -146,7 +146,7 @@ def create_tables(conn):
             )
         """)
 
-        # Roadmap / priority tracking tables
+        # Roadmap / requirement tracking tables
 
         cur.execute("""
             CREATE TABLE IF NOT EXISTS projects (
@@ -184,7 +184,7 @@ def create_tables(conn):
         """)
 
         cur.execute("""
-            CREATE TABLE IF NOT EXISTS priorities (
+            CREATE TABLE IF NOT EXISTS requirements (
                 id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
                 title           VARCHAR(256)    NOT NULL,
                 description     TEXT            NULL,
@@ -236,12 +236,12 @@ def create_tables(conn):
         """)
 
         cur.execute("""
-            CREATE TABLE IF NOT EXISTS priority_sessions (
-                priority_fk     INT             NOT NULL,
+            CREATE TABLE IF NOT EXISTS requirement_sessions (
+                requirement_fk  INT             NOT NULL,
                 session_fk      INT             NOT NULL,
-                PRIMARY KEY (priority_fk, session_fk),
-                FOREIGN KEY (priority_fk)
-                    REFERENCES priorities (id)
+                PRIMARY KEY (requirement_fk, session_fk),
+                FOREIGN KEY (requirement_fk)
+                    REFERENCES requirements (id)
                     ON UPDATE CASCADE ON DELETE CASCADE,
                 FOREIGN KEY (session_fk)
                     REFERENCES swarm_sessions (id)
@@ -285,7 +285,7 @@ def create_tables(conn):
         """)
 
         print("Tables created: profiles, domains, areas, tasks, projects, categories, "
-              "priorities, swarm_sessions, priority_sessions, dev_servers, priority_card_order")
+              "requirements, swarm_sessions, requirement_sessions, dev_servers, priority_card_order")
 
 
 def grant_claude_ro(conn):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,10 +86,10 @@ def seed_test_profile(db_connection, test_creator_fk):
                     "(SELECT id FROM map_runs WHERE creator_fk = %s)", (test_creator_fk,))
         cur.execute("DELETE FROM map_runs WHERE creator_fk = %s", (test_creator_fk,))
         cur.execute("DELETE FROM map_routes WHERE creator_fk = %s", (test_creator_fk,))
-        cur.execute("DELETE FROM priority_sessions WHERE priority_fk IN "
-                    "(SELECT id FROM priorities WHERE creator_fk = %s)", (test_creator_fk,))
+        cur.execute("DELETE FROM requirement_sessions WHERE requirement_fk IN "
+                    "(SELECT id FROM requirements WHERE creator_fk = %s)", (test_creator_fk,))
         cur.execute("DELETE FROM dev_servers WHERE creator_fk = %s", (test_creator_fk,))
-        cur.execute("DELETE FROM priorities WHERE creator_fk = %s", (test_creator_fk,))
+        cur.execute("DELETE FROM requirements WHERE creator_fk = %s", (test_creator_fk,))
         cur.execute("DELETE FROM swarm_sessions WHERE creator_fk = %s", (test_creator_fk,))
         cur.execute("DELETE FROM categories WHERE creator_fk = %s", (test_creator_fk,))
         cur.execute("DELETE FROM projects WHERE creator_fk = %s", (test_creator_fk,))

--- a/tests/test_cascades.py
+++ b/tests/test_cascades.py
@@ -373,8 +373,8 @@ def test_delete_project_cascades_to_categories(db_connection):
     db_connection.rollback()
 
 
-def test_delete_category_sets_priority_fk_null(db_connection):
-    """DELETE category → priorities.category_fk set to NULL (ON DELETE SET NULL)"""
+def test_delete_category_sets_requirement_fk_null(db_connection):
+    """DELETE category → requirements.category_fk set to NULL (ON DELETE SET NULL)"""
     test_creator = 'cascade-test-category-1'
 
     with db_connection.cursor() as cur:
@@ -399,18 +399,18 @@ def test_delete_category_sets_priority_fk_null(db_connection):
         category_id = cur.fetchone()['id']
 
         cur.execute(
-            "INSERT INTO priorities (title, category_fk, creator_fk) "
+            "INSERT INTO requirements (title, category_fk, creator_fk) "
             "VALUES (%s, %s, %s)",
-            ('Cascade Test Priority', category_id, test_creator)
+            ('Cascade Test Requirement', category_id, test_creator)
         )
         cur.execute("SELECT LAST_INSERT_ID() AS id")
-        priority_id = cur.fetchone()['id']
+        requirement_id = cur.fetchone()['id']
 
         # Delete category
         cur.execute("DELETE FROM categories WHERE id = %s", (category_id,))
 
-        # Priority survives but category_fk is NULL
-        cur.execute("SELECT category_fk FROM priorities WHERE id = %s", (priority_id,))
+        # Requirement survives but category_fk is NULL
+        cur.execute("SELECT category_fk FROM requirements WHERE id = %s", (requirement_id,))
         row = cur.fetchone()
         assert row is not None
         assert row['category_fk'] is None
@@ -418,9 +418,9 @@ def test_delete_category_sets_priority_fk_null(db_connection):
     db_connection.rollback()
 
 
-def test_delete_priority_cascades_to_priority_sessions(db_connection):
-    """DELETE priority → associated priority_sessions rows are deleted"""
-    test_creator = 'cascade-test-priority-1'
+def test_delete_requirement_cascades_to_requirement_sessions(db_connection):
+    """DELETE requirement → associated requirement_sessions rows are deleted"""
+    test_creator = 'cascade-test-requirement-1'
 
     with db_connection.cursor() as cur:
         cur.execute(
@@ -429,11 +429,11 @@ def test_delete_priority_cascades_to_priority_sessions(db_connection):
             (test_creator, 'Cascade Test Profile', 'cascade@test.com')
         )
         cur.execute(
-            "INSERT INTO priorities (title, creator_fk) VALUES (%s, %s)",
-            ('Cascade Test Priority', test_creator)
+            "INSERT INTO requirements (title, creator_fk) VALUES (%s, %s)",
+            ('Cascade Test Requirement', test_creator)
         )
         cur.execute("SELECT LAST_INSERT_ID() AS id")
-        priority_id = cur.fetchone()['id']
+        requirement_id = cur.fetchone()['id']
 
         cur.execute(
             "INSERT INTO swarm_sessions (swarm_status, creator_fk) VALUES (%s, %s)",
@@ -443,25 +443,25 @@ def test_delete_priority_cascades_to_priority_sessions(db_connection):
         session_id = cur.fetchone()['id']
 
         cur.execute(
-            "INSERT INTO priority_sessions (priority_fk, session_fk) VALUES (%s, %s)",
-            (priority_id, session_id)
+            "INSERT INTO requirement_sessions (requirement_fk, session_fk) VALUES (%s, %s)",
+            (requirement_id, session_id)
         )
 
-        # Delete priority
-        cur.execute("DELETE FROM priorities WHERE id = %s", (priority_id,))
+        # Delete requirement
+        cur.execute("DELETE FROM requirements WHERE id = %s", (requirement_id,))
 
-        # Verify priority_session link is gone
+        # Verify requirement_session link is gone
         cur.execute(
-            "SELECT * FROM priority_sessions WHERE priority_fk = %s AND session_fk = %s",
-            (priority_id, session_id)
+            "SELECT * FROM requirement_sessions WHERE requirement_fk = %s AND session_fk = %s",
+            (requirement_id, session_id)
         )
         assert cur.fetchone() is None
 
     db_connection.rollback()
 
 
-def test_delete_swarm_session_cascades_to_priority_sessions(db_connection):
-    """DELETE swarm_session → associated priority_sessions rows are deleted,
+def test_delete_swarm_session_cascades_to_requirement_sessions(db_connection):
+    """DELETE swarm_session → associated requirement_sessions rows are deleted,
     dev_servers.session_fk set to NULL"""
     test_creator = 'cascade-test-session-1'
 
@@ -479,36 +479,36 @@ def test_delete_swarm_session_cascades_to_priority_sessions(db_connection):
         session_id = cur.fetchone()['id']
 
         cur.execute(
-            "INSERT INTO priorities (title, creator_fk) VALUES (%s, %s)",
-            ('Cascade Test Priority', test_creator)
+            "INSERT INTO requirements (title, creator_fk) VALUES (%s, %s)",
+            ('Cascade Test Requirement', test_creator)
         )
         cur.execute("SELECT LAST_INSERT_ID() AS id")
-        priority_id = cur.fetchone()['id']
+        requirement_id = cur.fetchone()['id']
 
         cur.execute(
-            "INSERT INTO priority_sessions (priority_fk, session_fk) VALUES (%s, %s)",
-            (priority_id, session_id)
+            "INSERT INTO requirement_sessions (requirement_fk, session_fk) VALUES (%s, %s)",
+            (requirement_id, session_id)
         )
 
         # Delete swarm session
         cur.execute("DELETE FROM swarm_sessions WHERE id = %s", (session_id,))
 
-        # Verify priority_session link is gone
+        # Verify requirement_session link is gone
         cur.execute(
-            "SELECT * FROM priority_sessions WHERE session_fk = %s",
+            "SELECT * FROM requirement_sessions WHERE session_fk = %s",
             (session_id,)
         )
         assert cur.fetchone() is None
 
-        # Priority itself survives
-        cur.execute("SELECT id FROM priorities WHERE id = %s", (priority_id,))
+        # Requirement itself survives
+        cur.execute("SELECT id FROM requirements WHERE id = %s", (requirement_id,))
         assert cur.fetchone() is not None
 
     db_connection.rollback()
 
 
 def test_delete_profile_cascades_to_roadmap_tables(db_connection):
-    """DELETE profile → cascades through projects→categories, priorities, swarm_sessions"""
+    """DELETE profile → cascades through projects→categories, requirements, swarm_sessions"""
     test_creator = 'cascade-test-roadmap-full'
 
     with db_connection.cursor() as cur:
@@ -525,11 +525,11 @@ def test_delete_profile_cascades_to_roadmap_tables(db_connection):
         project_id = cur.fetchone()['id']
 
         cur.execute(
-            "INSERT INTO priorities (title, creator_fk) VALUES (%s, %s)",
-            ('Cascade Test Priority', test_creator)
+            "INSERT INTO requirements (title, creator_fk) VALUES (%s, %s)",
+            ('Cascade Test Requirement', test_creator)
         )
         cur.execute("SELECT LAST_INSERT_ID() AS id")
-        priority_id = cur.fetchone()['id']
+        requirement_id = cur.fetchone()['id']
 
         cur.execute(
             "INSERT INTO swarm_sessions (swarm_status, creator_fk) VALUES (%s, %s)",
@@ -543,7 +543,7 @@ def test_delete_profile_cascades_to_roadmap_tables(db_connection):
 
         cur.execute("SELECT id FROM projects WHERE id = %s", (project_id,))
         assert cur.fetchone() is None
-        cur.execute("SELECT id FROM priorities WHERE id = %s", (priority_id,))
+        cur.execute("SELECT id FROM requirements WHERE id = %s", (requirement_id,))
         assert cur.fetchone() is None
         cur.execute("SELECT id FROM swarm_sessions WHERE id = %s", (session_id,))
         assert cur.fetchone() is None

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -390,24 +390,24 @@ def test_category_fk_invalid_project(db_connection, test_creator_fk):
     db_connection.rollback()
 
 
-def test_priority_fk_invalid_creator(db_connection):
-    """INSERT priority with non-existent creator_fk → IntegrityError"""
+def test_requirement_fk_invalid_creator(db_connection):
+    """INSERT requirement with non-existent creator_fk → IntegrityError"""
     with db_connection.cursor() as cur:
         with pytest.raises(pymysql.IntegrityError):
             cur.execute(
-                "INSERT INTO priorities (title, creator_fk) "
+                "INSERT INTO requirements (title, creator_fk) "
                 "VALUES (%s, %s)",
-                ('orphan priority', 'nonexistent-profile-id')
+                ('orphan requirement', 'nonexistent-profile-id')
             )
     db_connection.rollback()
 
 
-def test_priority_session_fk_invalid_priority(db_connection):
-    """INSERT priority_session with non-existent priority_fk → IntegrityError"""
+def test_requirement_session_fk_invalid_requirement(db_connection):
+    """INSERT requirement_session with non-existent requirement_fk → IntegrityError"""
     with db_connection.cursor() as cur:
         with pytest.raises(pymysql.IntegrityError):
             cur.execute(
-                "INSERT INTO priority_sessions (priority_fk, session_fk) "
+                "INSERT INTO requirement_sessions (requirement_fk, session_fk) "
                 "VALUES (%s, %s)",
                 (999999, 999999)
             )
@@ -462,12 +462,12 @@ def test_category_name_not_null(db_connection, test_creator_fk, seed_test_profil
     db_connection.rollback()
 
 
-def test_priority_title_not_null(db_connection, test_creator_fk):
-    """INSERT priority with title=NULL → error"""
+def test_requirement_title_not_null(db_connection, test_creator_fk):
+    """INSERT requirement with title=NULL → error"""
     with db_connection.cursor() as cur:
         with pytest.raises(pymysql.IntegrityError):
             cur.execute(
-                "INSERT INTO priorities (title, creator_fk) "
+                "INSERT INTO requirements (title, creator_fk) "
                 "VALUES (%s, %s)",
                 (None, test_creator_fk)
             )
@@ -490,21 +490,20 @@ def test_swarm_status_not_null(db_connection, test_creator_fk):
 # Roadmap table default value tests
 # ---------------------------------------------------------------------------
 
-def test_priority_closed_default(db_connection, test_creator_fk):
-    """INSERT priority without closed → defaults to 0"""
+def test_requirement_status_default(db_connection, test_creator_fk):
+    """INSERT requirement without requirement_status → defaults to 'idle'"""
     with db_connection.cursor() as cur:
         cur.execute(
-            "INSERT INTO priorities (title, creator_fk) VALUES (%s, %s)",
-            ('test priority default', test_creator_fk)
+            "INSERT INTO requirements (title, creator_fk) VALUES (%s, %s)",
+            ('test requirement default', test_creator_fk)
         )
         cur.execute("SELECT LAST_INSERT_ID() AS id")
-        priority_id = cur.fetchone()['id']
+        requirement_id = cur.fetchone()['id']
 
-        cur.execute("SELECT closed, in_progress, scheduled FROM priorities WHERE id = %s",
-                    (priority_id,))
+        cur.execute("SELECT requirement_status, scheduled FROM requirements WHERE id = %s",
+                    (requirement_id,))
         row = cur.fetchone()
-        assert row['closed'] == 0
-        assert row['in_progress'] == 0
+        assert row['requirement_status'] == 'idle'
         assert row['scheduled'] == 0
 
     db_connection.rollback()

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -371,14 +371,14 @@ def test_categories_columns(db_connection):
     assert columns['closed']['Default'] == '0'
 
 
-def test_priorities_columns(db_connection):
-    """Verify priorities column definitions match schema.sql.
+def test_requirements_columns(db_connection):
+    """Verify requirements column definitions match schema.sql.
 
     Expected columns:
     - id: INT, PRI, AUTO_INCREMENT
     - title: VARCHAR(256), NOT NULL
     - description: TEXT, NULL
-    - priority_status: VARCHAR(16), NOT NULL, DEFAULT 'idle'
+    - requirement_status: VARCHAR(16), NOT NULL, DEFAULT 'idle'
     - started_at: TIMESTAMP, NULL
     - completed_at: TIMESTAMP, NULL
     - deferred_at: TIMESTAMP, NULL
@@ -391,10 +391,10 @@ def test_priorities_columns(db_connection):
     - scheduled: TINYINT, NOT NULL, DEFAULT 0
     """
     with db_connection.cursor() as cur:
-        cur.execute("DESCRIBE priorities")
+        cur.execute("DESCRIBE requirements")
         columns = {row['Field']: row for row in cur.fetchall()}
 
-    expected_fields = ['id', 'title', 'description', 'priority_status',
+    expected_fields = ['id', 'title', 'description', 'requirement_status',
                        'started_at', 'completed_at', 'deferred_at', 'project_fk', 'category_fk',
                        'creator_fk', 'sort_order', 'create_ts', 'update_ts', 'scheduled']
     assert set(columns.keys()) == set(expected_fields)
@@ -409,9 +409,9 @@ def test_priorities_columns(db_connection):
     assert columns['description']['Type'] == 'text'
     assert columns['description']['Null'] == 'YES'
 
-    assert columns['priority_status']['Type'] == 'varchar(16)'
-    assert columns['priority_status']['Null'] == 'NO'
-    assert columns['priority_status']['Default'] == 'idle'
+    assert columns['requirement_status']['Type'] == 'varchar(16)'
+    assert columns['requirement_status']['Null'] == 'NO'
+    assert columns['requirement_status']['Default'] == 'idle'
 
     assert 'timestamp' in columns['deferred_at']['Type']
     assert columns['deferred_at']['Null'] == 'YES'
@@ -522,23 +522,23 @@ def test_swarm_sessions_columns(db_connection):
     assert columns['creator_fk']['Key'] == 'MUL'
 
 
-def test_priority_sessions_columns(db_connection):
-    """Verify priority_sessions column definitions match schema.sql.
+def test_requirement_sessions_columns(db_connection):
+    """Verify requirement_sessions column definitions match schema.sql.
 
     Expected columns:
-    - priority_fk: INT, PRI, NOT NULL
+    - requirement_fk: INT, PRI, NOT NULL
     - session_fk: INT, PRI, NOT NULL
     """
     with db_connection.cursor() as cur:
-        cur.execute("DESCRIBE priority_sessions")
+        cur.execute("DESCRIBE requirement_sessions")
         columns = {row['Field']: row for row in cur.fetchall()}
 
-    expected_fields = ['priority_fk', 'session_fk']
+    expected_fields = ['requirement_fk', 'session_fk']
     assert set(columns.keys()) == set(expected_fields)
 
-    assert columns['priority_fk']['Type'] == 'int'
-    assert columns['priority_fk']['Null'] == 'NO'
-    assert columns['priority_fk']['Key'] == 'PRI'
+    assert columns['requirement_fk']['Type'] == 'int'
+    assert columns['requirement_fk']['Null'] == 'NO'
+    assert columns['requirement_fk']['Key'] == 'PRI'
 
     assert columns['session_fk']['Type'] == 'int'
     assert columns['session_fk']['Null'] == 'NO'
@@ -975,7 +975,7 @@ def test_table_count(db_connection):
 
     expected_tables = {
         'profiles', 'domains', 'areas', 'recurring_tasks', 'tasks',
-        'projects', 'categories', 'priorities', 'priority_sessions',
+        'projects', 'categories', 'requirements', 'requirement_sessions',
         'swarm_sessions', 'dev_servers', 'priority_card_order',
         'map_routes', 'map_runs', 'map_coordinates', 'map_views',
         'map_partners', 'map_run_partners',

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -12,7 +12,7 @@ Test workflow:
 4. DROP temporary tables after test cleanup
 
 Dependency note: Migrations 009-015 modify tables (projects, categories,
-swarm_sessions, priorities) that were originally created ad-hoc on production.
+swarm_sessions, requirements) that were originally created ad-hoc on production.
 Migration 016 retroactively tracks those table definitions. Tests must apply
 016 before 009-015 to satisfy FK dependencies.
 """
@@ -59,15 +59,21 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
     # (e.g., 'tasks' inside 'recurring_tasks') while preserving FK constraint
     # name replacement (e.g., 'domains_ibfk_1' → 'mig_xxx_domains_ibfk_1').
     table_names = [
+        'user_integrations',
+        'requirement_sessions',
+        'priority_sessions',     # pre-038 name (for RENAME TABLE in migration 038)
         'priority_card_order',
-        'priority_sessions',
-        'swarm_sessions',
+        'map_run_partners',
         'map_coordinates',
+        'swarm_sessions',
         'recurring_tasks',
+        'map_partners',
         'dev_servers',
+        'requirements',
+        'priorities',            # pre-038 name (for RENAME TABLE in migration 038)
         'categories',
         'map_routes',
-        'priorities',
+        'map_views',
         'map_runs',
         'profiles',
         'projects',
@@ -164,9 +170,12 @@ def _get_dependency_ordered_migrations():
 # recurring_tasks must be dropped before tasks (tasks.recurring_task_fk → recurring_tasks)
 # map_coordinates → map_runs → map_routes (FK chain)
 ALL_TABLE_SUFFIXES = [
+    'user_integrations', 'map_run_partners', 'map_partners',
     'map_views', 'map_coordinates', 'map_runs', 'map_routes',
-    'priority_card_order', 'dev_servers', 'priority_sessions',
-    'priorities', 'swarm_sessions', 'categories', 'projects',
+    'priority_card_order', 'dev_servers',
+    'requirement_sessions', 'priority_sessions',  # pre-038 name
+    'requirements', 'priorities',                  # pre-038 name
+    'swarm_sessions', 'categories', 'projects',
     'tasks', 'recurring_tasks', 'areas', 'domains', 'profiles',
 ]
 
@@ -235,6 +244,7 @@ def test_migration_016_creates_roadmap_tables(db_connection, migration_test_pref
     016 requires profiles.id as VARCHAR(64) (from migration 004) for FK
     compatibility with creator_fk columns.
     Creates: projects, categories, swarm_sessions, priorities, priority_sessions
+    (016 uses original names; migration 038 renames them to requirements/requirement_sessions)
     """
     migrations_dir = _get_migrations_dir()
     # Apply core migrations 001-008 first (004 converts profiles.id INT→VARCHAR(64))
@@ -254,6 +264,8 @@ def test_migration_016_creates_roadmap_tables(db_connection, migration_test_pref
         )
         tables = {row['TABLE_NAME'] for row in cur.fetchall()}
 
+    # 016 creates tables with original names (priorities, priority_sessions)
+    # Migration 038 renames them later in the full sequence
     expected_tables = {
         f"{migration_test_prefix}_profiles",
         f"{migration_test_prefix}_domains",
@@ -301,12 +313,13 @@ def test_migration_sequence_applies(db_connection, migration_test_prefix):
         f"{migration_test_prefix}_{suffix}"
         for suffix in [
             'profiles', 'domains', 'areas', 'tasks',
-            'projects', 'categories', 'priorities',
-            'swarm_sessions', 'priority_sessions',
+            'projects', 'categories', 'requirements',
+            'swarm_sessions', 'requirement_sessions',
             'dev_servers', 'priority_card_order',
             'recurring_tasks',
             'map_routes', 'map_runs', 'map_coordinates',
-            'map_views',
+            'map_views', 'map_partners', 'map_run_partners',
+            'user_integrations',
         ]
     }
     assert tables == expected_tables, \


### PR DESCRIPTION
## Summary
- Migration 038: RENAME TABLE priorities→requirements, priority_sessions→requirement_sessions
- ALTER COLUMN priority_status→requirement_status, priority_fk→requirement_fk
- UPDATE swarm_sessions.source_ref from priority: to requirement: prefix
- Updated schema.sql, all scripts, all tests

## References
- Darwin PR: https://github.com/BillWilliams79/Darwin/pull/327
- Lambda-Rest PR: https://github.com/BillWilliams79/AWS-Lambda-REST-API/pull/27

🤖 Generated with [Claude Code](https://claude.com/claude-code)