### PR TITLE
Disallow requirements without a category (MCP + SQL NOT NULL)

### DIFF
--- a/migrations/041_category_fk_not_null.sql
+++ b/migrations/041_category_fk_not_null.sql
@@ -1,0 +1,49 @@
+-- 041_category_fk_not_null.sql
+--
+-- Enforce requirements.category_fk NOT NULL (req #2217). Three requirements
+-- (#2191, #2195, #2196) became invisible in the UI because they had NULL
+-- category_fk; lock the door so no future row can be uncategorized.
+--
+-- Because category_fk becomes NOT NULL, the old ON DELETE SET NULL FK action
+-- is illegal. Re-create the FK with ON DELETE RESTRICT — deleting a category
+-- with live requirements will now be rejected. darwin-mcp db.delete_category
+-- catches the IntegrityError and surfaces a readable ValueError.
+--
+-- Pre-flight: 311 uncategorized E2E test artifacts were deleted from prod on
+-- 2026-04-17 before this migration (all title LIKE 'e2e-%', creator was
+-- e2e-test@test.invalid or e2e-worker-1@test.invalid). darwin_dev was
+-- already clean.
+
+-- Guard: abort if any NULL rows still exist.
+SET @null_count = (SELECT COUNT(*) FROM requirements WHERE category_fk IS NULL);
+SET @sql = IF(@null_count > 0,
+    CONCAT('SIGNAL SQLSTATE ''45000'' SET MESSAGE_TEXT = ''migration 041 aborted: ',
+           @null_count, ' requirements have NULL category_fk'''),
+    'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Drop the existing unnamed FK (category_fk → categories.id). Look up by
+-- column so we don't rely on MySQL's auto-generated constraint name.
+SET @fk_name = (
+    SELECT CONSTRAINT_NAME
+      FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+     WHERE TABLE_SCHEMA = DATABASE()
+       AND TABLE_NAME = 'requirements'
+       AND COLUMN_NAME = 'category_fk'
+       AND REFERENCED_TABLE_NAME = 'categories'
+       AND REFERENCED_COLUMN_NAME = 'id'
+     LIMIT 1
+);
+SET @sql = CONCAT('ALTER TABLE requirements DROP FOREIGN KEY ', @fk_name);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Flip column to NOT NULL.
+ALTER TABLE requirements MODIFY COLUMN category_fk INT NOT NULL;
+
+-- Re-add FK with a stable name and ON DELETE RESTRICT.
+ALTER TABLE requirements
+ADD CONSTRAINT fk_requirements_category
+    FOREIGN KEY (category_fk)
+    REFERENCES categories(id)
+    ON UPDATE CASCADE
+    ON DELETE RESTRICT;

--- a/schema.sql
+++ b/schema.sql
@@ -146,7 +146,7 @@ CREATE TABLE IF NOT EXISTS requirements (
     completed_at    TIMESTAMP       NULL,
     deferred_at     TIMESTAMP       NULL,
     project_fk      INT             NULL,
-    category_fk     INT             NULL,
+    category_fk     INT             NOT NULL,
     creator_fk      VARCHAR(64)     NOT NULL,
     sort_order      SMALLINT        NULL,
     create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
@@ -156,9 +156,10 @@ CREATE TABLE IF NOT EXISTS requirements (
     FOREIGN KEY (project_fk)
         REFERENCES projects (id)
         ON UPDATE CASCADE ON DELETE SET NULL,
-    FOREIGN KEY (category_fk)
+    CONSTRAINT fk_requirements_category
+        FOREIGN KEY (category_fk)
         REFERENCES categories (id)
-        ON UPDATE CASCADE ON DELETE SET NULL,
+        ON UPDATE CASCADE ON DELETE RESTRICT,
     FOREIGN KEY (creator_fk)
         REFERENCES profiles (id)
         ON UPDATE CASCADE ON DELETE CASCADE

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -147,7 +147,7 @@ CREATE TABLE requirements (
     started_at      TIMESTAMP       NULL,
     completed_at    TIMESTAMP       NULL,
     project_fk      INT             NULL,
-    category_fk     INT             NULL,
+    category_fk     INT             NOT NULL,
     creator_fk      VARCHAR(64)     NOT NULL,
     sort_order      SMALLINT        NULL,
     create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
@@ -155,9 +155,10 @@ CREATE TABLE requirements (
     FOREIGN KEY (project_fk)
         REFERENCES projects (id)
         ON UPDATE CASCADE ON DELETE SET NULL,
-    FOREIGN KEY (category_fk)
+    CONSTRAINT fk_requirements_category
+        FOREIGN KEY (category_fk)
         REFERENCES categories (id)
-        ON UPDATE CASCADE ON DELETE SET NULL,
+        ON UPDATE CASCADE ON DELETE RESTRICT,
     FOREIGN KEY (creator_fk)
         REFERENCES profiles (id)
         ON UPDATE CASCADE ON DELETE CASCADE

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,6 +101,35 @@ def seed_test_profile(db_connection, test_creator_fk):
 
 
 # ---------------------------------------------------------------------------
+# Shared project/category fixtures for requirement tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def test_category_id(db_connection, test_creator_fk, seed_test_profile):
+    """Session-scoped project + category so requirement tests have a valid category_fk.
+
+    Cleanup happens in seed_test_profile teardown (DELETE FROM categories, projects).
+    """
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO projects (project_name, creator_fk) VALUES (%s, %s)",
+            ('Schema Test Project', test_creator_fk),
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        project_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO categories (category_name, project_fk, creator_fk) "
+            "VALUES (%s, %s, %s)",
+            ('Schema Test Category', project_id, test_creator_fk),
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        category_id = cur.fetchone()['id']
+    db_connection.commit()
+    return category_id
+
+
+# ---------------------------------------------------------------------------
 # Migration test helpers
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cascades.py
+++ b/tests/test_cascades.py
@@ -5,6 +5,8 @@ Verifies that deleting parent records automatically cascades to children
 as defined in the schema (profiles→domains→areas→tasks).
 Each test uses transactions with rollback to keep darwin_dev test DB clean.
 """
+import pymysql
+import pytest
 
 
 # ---------------------------------------------------------------------------
@@ -373,8 +375,13 @@ def test_delete_project_cascades_to_categories(db_connection):
     db_connection.rollback()
 
 
-def test_delete_category_sets_requirement_fk_null(db_connection):
-    """DELETE category → requirements.category_fk set to NULL (ON DELETE SET NULL)"""
+def test_delete_category_with_requirements_rejected(db_connection):
+    """DELETE category with live requirements → IntegrityError (ON DELETE RESTRICT, req #2217).
+
+    This replaces the old SET NULL semantics (pre-migration 041). Deleting a category
+    that still has requirements linked to it is now blocked — callers must move or
+    delete the requirements first.
+    """
     test_creator = 'cascade-test-category-1'
 
     with db_connection.cursor() as cur:
@@ -403,22 +410,47 @@ def test_delete_category_sets_requirement_fk_null(db_connection):
             "VALUES (%s, %s, %s)",
             ('Cascade Test Requirement', category_id, test_creator)
         )
-        cur.execute("SELECT LAST_INSERT_ID() AS id")
-        requirement_id = cur.fetchone()['id']
 
-        # Delete category
-        cur.execute("DELETE FROM categories WHERE id = %s", (category_id,))
-
-        # Requirement survives but category_fk is NULL
-        cur.execute("SELECT category_fk FROM requirements WHERE id = %s", (requirement_id,))
-        row = cur.fetchone()
-        assert row is not None
-        assert row['category_fk'] is None
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute("DELETE FROM categories WHERE id = %s", (category_id,))
 
     db_connection.rollback()
 
 
-def test_delete_requirement_cascades_to_requirement_sessions(db_connection):
+def test_delete_empty_category_succeeds(db_connection):
+    """DELETE empty category → succeeds (RESTRICT only blocks when requirements exist)."""
+    test_creator = 'cascade-test-category-empty'
+
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO profiles (id, name, email) "
+            "VALUES (%s, %s, %s)",
+            (test_creator, 'Cascade Test Profile', 'cascade@test.com')
+        )
+        cur.execute(
+            "INSERT INTO projects (project_name, creator_fk) VALUES (%s, %s)",
+            ('Cascade Test Project', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        project_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO categories (category_name, project_fk, creator_fk) "
+            "VALUES (%s, %s, %s)",
+            ('Empty Category', project_id, test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        category_id = cur.fetchone()['id']
+
+        cur.execute("DELETE FROM categories WHERE id = %s", (category_id,))
+
+        cur.execute("SELECT id FROM categories WHERE id = %s", (category_id,))
+        assert cur.fetchone() is None
+
+    db_connection.rollback()
+
+
+def test_delete_requirement_cascades_to_requirement_sessions(db_connection, test_category_id):
     """DELETE requirement → associated requirement_sessions rows are deleted"""
     test_creator = 'cascade-test-requirement-1'
 
@@ -429,8 +461,8 @@ def test_delete_requirement_cascades_to_requirement_sessions(db_connection):
             (test_creator, 'Cascade Test Profile', 'cascade@test.com')
         )
         cur.execute(
-            "INSERT INTO requirements (title, creator_fk) VALUES (%s, %s)",
-            ('Cascade Test Requirement', test_creator)
+            "INSERT INTO requirements (title, creator_fk, category_fk) VALUES (%s, %s, %s)",
+            ('Cascade Test Requirement', test_creator, test_category_id)
         )
         cur.execute("SELECT LAST_INSERT_ID() AS id")
         requirement_id = cur.fetchone()['id']
@@ -460,7 +492,7 @@ def test_delete_requirement_cascades_to_requirement_sessions(db_connection):
     db_connection.rollback()
 
 
-def test_delete_swarm_session_cascades_to_requirement_sessions(db_connection):
+def test_delete_swarm_session_cascades_to_requirement_sessions(db_connection, test_category_id):
     """DELETE swarm_session → associated requirement_sessions rows are deleted,
     dev_servers.session_fk set to NULL"""
     test_creator = 'cascade-test-session-1'
@@ -479,8 +511,8 @@ def test_delete_swarm_session_cascades_to_requirement_sessions(db_connection):
         session_id = cur.fetchone()['id']
 
         cur.execute(
-            "INSERT INTO requirements (title, creator_fk) VALUES (%s, %s)",
-            ('Cascade Test Requirement', test_creator)
+            "INSERT INTO requirements (title, creator_fk, category_fk) VALUES (%s, %s, %s)",
+            ('Cascade Test Requirement', test_creator, test_category_id)
         )
         cur.execute("SELECT LAST_INSERT_ID() AS id")
         requirement_id = cur.fetchone()['id']
@@ -507,8 +539,13 @@ def test_delete_swarm_session_cascades_to_requirement_sessions(db_connection):
     db_connection.rollback()
 
 
-def test_delete_profile_cascades_to_roadmap_tables(db_connection):
-    """DELETE profile → cascades through projects→categories, requirements, swarm_sessions"""
+def test_delete_profile_cascades_to_roadmap_tables(db_connection, test_category_id):
+    """DELETE profile → cascades through projects→categories, requirements, swarm_sessions.
+
+    Requirement references a category owned by a different creator (the session
+    test_creator_fk), so the profile cascade deletes this profile's requirements
+    without tripping the RESTRICT FK on that other creator's category.
+    """
     test_creator = 'cascade-test-roadmap-full'
 
     with db_connection.cursor() as cur:
@@ -525,8 +562,8 @@ def test_delete_profile_cascades_to_roadmap_tables(db_connection):
         project_id = cur.fetchone()['id']
 
         cur.execute(
-            "INSERT INTO requirements (title, creator_fk) VALUES (%s, %s)",
-            ('Cascade Test Requirement', test_creator)
+            "INSERT INTO requirements (title, creator_fk, category_fk) VALUES (%s, %s, %s)",
+            ('Cascade Test Requirement', test_creator, test_category_id)
         )
         cur.execute("SELECT LAST_INSERT_ID() AS id")
         requirement_id = cur.fetchone()['id']
@@ -538,7 +575,9 @@ def test_delete_profile_cascades_to_roadmap_tables(db_connection):
         cur.execute("SELECT LAST_INSERT_ID() AS id")
         session_id = cur.fetchone()['id']
 
-        # Delete profile — should cascade to all owned records
+        # Delete profile — should cascade to all owned records. The category
+        # referenced by the requirement is owned by a different creator, so
+        # the cascade here only touches this profile's rows.
         cur.execute("DELETE FROM profiles WHERE id = %s", (test_creator,))
 
         cur.execute("SELECT id FROM projects WHERE id = %s", (project_id,))

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -390,14 +390,14 @@ def test_category_fk_invalid_project(db_connection, test_creator_fk):
     db_connection.rollback()
 
 
-def test_requirement_fk_invalid_creator(db_connection):
+def test_requirement_fk_invalid_creator(db_connection, test_category_id):
     """INSERT requirement with non-existent creator_fk → IntegrityError"""
     with db_connection.cursor() as cur:
         with pytest.raises(pymysql.IntegrityError):
             cur.execute(
-                "INSERT INTO requirements (title, creator_fk) "
-                "VALUES (%s, %s)",
-                ('orphan requirement', 'nonexistent-profile-id')
+                "INSERT INTO requirements (title, creator_fk, category_fk) "
+                "VALUES (%s, %s, %s)",
+                ('orphan requirement', 'nonexistent-profile-id', test_category_id)
             )
     db_connection.rollback()
 
@@ -462,14 +462,26 @@ def test_category_name_not_null(db_connection, test_creator_fk, seed_test_profil
     db_connection.rollback()
 
 
-def test_requirement_title_not_null(db_connection, test_creator_fk):
+def test_requirement_title_not_null(db_connection, test_creator_fk, test_category_id):
     """INSERT requirement with title=NULL → error"""
+    with db_connection.cursor() as cur:
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO requirements (title, creator_fk, category_fk) "
+                "VALUES (%s, %s, %s)",
+                (None, test_creator_fk, test_category_id)
+            )
+    db_connection.rollback()
+
+
+def test_requirement_category_fk_not_null(db_connection, test_creator_fk):
+    """INSERT requirement without category_fk → pymysql.IntegrityError (req #2217)"""
     with db_connection.cursor() as cur:
         with pytest.raises(pymysql.IntegrityError):
             cur.execute(
                 "INSERT INTO requirements (title, creator_fk) "
                 "VALUES (%s, %s)",
-                (None, test_creator_fk)
+                ('no-category', test_creator_fk),
             )
     db_connection.rollback()
 
@@ -490,12 +502,12 @@ def test_swarm_status_not_null(db_connection, test_creator_fk):
 # Roadmap table default value tests
 # ---------------------------------------------------------------------------
 
-def test_requirement_status_default(db_connection, test_creator_fk):
+def test_requirement_status_default(db_connection, test_creator_fk, test_category_id):
     """INSERT requirement without requirement_status → defaults to 'authoring' (migration 039)"""
     with db_connection.cursor() as cur:
         cur.execute(
-            "INSERT INTO requirements (title, creator_fk) VALUES (%s, %s)",
-            ('test requirement default', test_creator_fk)
+            "INSERT INTO requirements (title, creator_fk, category_fk) VALUES (%s, %s, %s)",
+            ('test requirement default', test_creator_fk, test_category_id)
         )
         cur.execute("SELECT LAST_INSERT_ID() AS id")
         requirement_id = cur.fetchone()['id']

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -428,7 +428,7 @@ def test_requirements_columns(db_connection):
     assert columns['project_fk']['Key'] == 'MUL'
 
     assert columns['category_fk']['Type'] == 'int'
-    assert columns['category_fk']['Null'] == 'YES'
+    assert columns['category_fk']['Null'] == 'NO'  # req #2217 / migration 041
     assert columns['category_fk']['Key'] == 'MUL'
 
     assert columns['creator_fk']['Type'] == 'varchar(64)'


### PR DESCRIPTION
## Summary
- feat: disallow-requirements-without-a-1 — chore: init swarm session feature/disallow-requirements-without-a-1
- chore: init swarm session feature/disallow-requirements-without-a-1

## Files changed
```
 migrations/041_category_fk_not_null.sql | 49 ++++++++++++++++++++
 schema.sql                              |  7 +--
 scripts/recreate_darwin_dev.sql         |  7 +--
 tests/conftest.py                       | 29 ++++++++++++
 tests/test_cascades.py                  | 79 ++++++++++++++++++++++++---------
 tests/test_constraints.py               | 30 +++++++++----
 tests/test_data_types.py                |  2 +-
 7 files changed, 167 insertions(+), 36 deletions(-)
```

## Testing
Tests: skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)