### PR TITLE
req #2380

### DIFF
--- a/migrations/042_add_features_testcases.sql
+++ b/migrations/042_add_features_testcases.sql
@@ -1,0 +1,73 @@
+-- 042_add_features_testcases.sql
+--
+-- Req #2380 Phase 1: add the features + test_cases + feature_test_cases
+-- tables for the Swarm Features & Test Cases registry.
+--
+-- features           — behavioral specifications (title + markdown description
+--                      + feature_status draft|active|deprecated + category_fk)
+-- test_cases         — verification procedures (title + preconditions + steps
+--                      + expected + test_type manual|automated|hybrid + tags
+--                      + category_fk). title is also the authoritative automation
+--                      traceability key (Playwright describe/it names match).
+-- feature_test_cases — junction, many-to-many. Composite PK, no id column.
+--
+-- FK policy:
+--   category_fk → categories(id)  ON DELETE RESTRICT  (mirrors migration 041)
+--   creator_fk  → profiles(id)    ON DELETE CASCADE
+--   junction both sides           ON DELETE CASCADE
+--
+-- No schema-level CHECK constraints on the enum-style columns — Darwin validates
+-- in the application layer (MCP + Lambda-Rest).
+
+CREATE TABLE features (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title           VARCHAR(256)    NOT NULL,
+    description     TEXT            NOT NULL,
+    feature_status  VARCHAR(16)     NOT NULL DEFAULT 'draft',   -- draft|active|deprecated
+    category_fk     INT             NOT NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    closed          TINYINT(1)      NOT NULL DEFAULT 0,
+    sort_order      SMALLINT        NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_features_category
+        FOREIGN KEY (category_fk) REFERENCES categories (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_features_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE test_cases (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title           VARCHAR(256)    NOT NULL,
+    preconditions   TEXT            NULL,
+    steps           TEXT            NOT NULL,
+    expected        TEXT            NOT NULL,
+    test_type       VARCHAR(16)     NOT NULL DEFAULT 'manual',  -- manual|automated|hybrid
+    tags            VARCHAR(512)    NULL,
+    category_fk     INT             NOT NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    closed          TINYINT(1)      NOT NULL DEFAULT 0,
+    sort_order      SMALLINT        NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_test_cases_category
+        FOREIGN KEY (category_fk) REFERENCES categories (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_test_cases_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE feature_test_cases (
+    feature_fk      INT             NOT NULL,
+    test_case_fk    INT             NOT NULL,
+    PRIMARY KEY (feature_fk, test_case_fk),
+    CONSTRAINT fk_ftc_feature
+        FOREIGN KEY (feature_fk) REFERENCES features (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_ftc_case
+        FOREIGN KEY (test_case_fk) REFERENCES test_cases (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);

--- a/migrations/043_add_testplans.sql
+++ b/migrations/043_add_testplans.sql
@@ -1,0 +1,46 @@
+-- 043_add_testplans.sql
+--
+-- Req #2380 Phase 2: add the test_plans + test_plan_cases tables.
+-- Depends on migration 042 (Phase 1 tables) being live.
+--
+-- test_plans       — organizational grouping of test_cases (title + optional
+--                    markdown description + category_fk). A plan is executed
+--                    by a test_run (Phase 3).
+-- test_plan_cases  — junction with execution ordering (sort_order).
+--                    Composite PK, no id column.
+--
+-- FK policy:
+--   category_fk  → categories(id)  ON DELETE RESTRICT
+--   creator_fk   → profiles(id)    ON DELETE CASCADE
+--   junction both sides            ON DELETE CASCADE
+
+CREATE TABLE test_plans (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title           VARCHAR(256)    NOT NULL,
+    description     TEXT            NULL,
+    category_fk     INT             NOT NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    closed          TINYINT(1)      NOT NULL DEFAULT 0,
+    sort_order      SMALLINT        NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_test_plans_category
+        FOREIGN KEY (category_fk) REFERENCES categories (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_test_plans_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE test_plan_cases (
+    test_plan_fk    INT             NOT NULL,
+    test_case_fk    INT             NOT NULL,
+    sort_order      SMALLINT        NULL,
+    PRIMARY KEY (test_plan_fk, test_case_fk),
+    CONSTRAINT fk_tpc_plan
+        FOREIGN KEY (test_plan_fk) REFERENCES test_plans (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_tpc_case
+        FOREIGN KEY (test_case_fk) REFERENCES test_cases (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);

--- a/migrations/044_add_testruns.sql
+++ b/migrations/044_add_testruns.sql
@@ -1,0 +1,64 @@
+-- 044_add_testruns.sql
+--
+-- Req #2380 Phase 3: add the test_runs + test_results tables.
+-- Depends on migration 043 (Phase 2 tables) being live.
+--
+-- test_runs    — one execution of a test_plan. run_status in_progress|completed|
+--                aborted. started_at set on creation; completed_at set on
+--                terminal status. No closed column (execution tables close via
+--                terminal status); no sort_order (chronological by started_at).
+-- test_results — one per (run, case). result_status passed|failed|blocked|
+--                skipped|not_run. UNIQUE (test_run_fk, test_case_fk) enforces
+--                one result per case per run. executed_at set when the result
+--                is actually recorded (nullable until then).
+--
+-- FK policy:
+--   test_runs.test_plan_fk     → test_plans(id)  ON DELETE RESTRICT
+--                                (a plan with run history cannot be deleted)
+--   test_runs.creator_fk       → profiles(id)   ON DELETE CASCADE
+--   test_results.test_run_fk   → test_runs(id)   ON DELETE CASCADE
+--                                (deleting a run deletes its results)
+--   test_results.test_case_fk  → test_cases(id)  ON DELETE RESTRICT
+--                                (cannot delete a case with results on record)
+--   test_results.creator_fk    → profiles(id)   ON DELETE CASCADE
+
+CREATE TABLE test_runs (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    test_plan_fk    INT             NOT NULL,
+    run_status      VARCHAR(16)     NOT NULL DEFAULT 'in_progress', -- in_progress|completed|aborted
+    started_at      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at    TIMESTAMP       NULL,
+    notes           TEXT            NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_test_runs_plan
+        FOREIGN KEY (test_plan_fk) REFERENCES test_plans (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_test_runs_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE test_results (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    test_run_fk     INT             NOT NULL,
+    test_case_fk    INT             NOT NULL,
+    result_status   VARCHAR(16)     NOT NULL DEFAULT 'not_run',     -- passed|failed|blocked|skipped|not_run
+    actual          TEXT            NULL,
+    notes           TEXT            NULL,
+    executed_at     TIMESTAMP       NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_test_results_run
+        FOREIGN KEY (test_run_fk) REFERENCES test_runs (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_test_results_case
+        FOREIGN KEY (test_case_fk) REFERENCES test_cases (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_test_results_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT uq_run_case UNIQUE KEY (test_run_fk, test_case_fk)
+);

--- a/schema.sql
+++ b/schema.sql
@@ -1,6 +1,6 @@
 -- Darwin Database Schema — Current State
 -- Database: darwin
--- This file reflects the final state of all 17 tables after all migrations.
+-- This file reflects the final state of all 25 tables after all migrations.
 -- It can be run against a fresh MySQL instance to create the complete schema.
 -- Table order respects FK dependencies.
 
@@ -336,4 +336,136 @@ CREATE TABLE IF NOT EXISTS map_run_partners (
     FOREIGN KEY (map_partner_fk)
         REFERENCES map_partners (id)
         ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+-- ============================================================================
+-- Swarm Features & Test Cases registry (req #2380 — migrations 042/043/044)
+-- Phase 1: features + test_cases + feature_test_cases
+-- Phase 2: test_plans + test_plan_cases
+-- Phase 3: test_runs + test_results
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS features (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title           VARCHAR(256)    NOT NULL,
+    description     TEXT            NOT NULL,
+    feature_status  VARCHAR(16)     NOT NULL DEFAULT 'draft',   -- draft|active|deprecated
+    category_fk     INT             NOT NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    closed          TINYINT(1)      NOT NULL DEFAULT 0,
+    sort_order      SMALLINT        NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_features_category
+        FOREIGN KEY (category_fk) REFERENCES categories (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_features_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS test_cases (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title           VARCHAR(256)    NOT NULL,
+    preconditions   TEXT            NULL,
+    steps           TEXT            NOT NULL,
+    expected        TEXT            NOT NULL,
+    test_type       VARCHAR(16)     NOT NULL DEFAULT 'manual',  -- manual|automated|hybrid
+    tags            VARCHAR(512)    NULL,
+    category_fk     INT             NOT NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    closed          TINYINT(1)      NOT NULL DEFAULT 0,
+    sort_order      SMALLINT        NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_test_cases_category
+        FOREIGN KEY (category_fk) REFERENCES categories (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_test_cases_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS feature_test_cases (
+    feature_fk      INT             NOT NULL,
+    test_case_fk    INT             NOT NULL,
+    PRIMARY KEY (feature_fk, test_case_fk),
+    CONSTRAINT fk_ftc_feature
+        FOREIGN KEY (feature_fk) REFERENCES features (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_ftc_case
+        FOREIGN KEY (test_case_fk) REFERENCES test_cases (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS test_plans (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title           VARCHAR(256)    NOT NULL,
+    description     TEXT            NULL,
+    category_fk     INT             NOT NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    closed          TINYINT(1)      NOT NULL DEFAULT 0,
+    sort_order      SMALLINT        NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_test_plans_category
+        FOREIGN KEY (category_fk) REFERENCES categories (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_test_plans_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS test_plan_cases (
+    test_plan_fk    INT             NOT NULL,
+    test_case_fk    INT             NOT NULL,
+    sort_order      SMALLINT        NULL,
+    PRIMARY KEY (test_plan_fk, test_case_fk),
+    CONSTRAINT fk_tpc_plan
+        FOREIGN KEY (test_plan_fk) REFERENCES test_plans (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_tpc_case
+        FOREIGN KEY (test_case_fk) REFERENCES test_cases (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS test_runs (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    test_plan_fk    INT             NOT NULL,
+    run_status      VARCHAR(16)     NOT NULL DEFAULT 'in_progress', -- in_progress|completed|aborted
+    started_at      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at    TIMESTAMP       NULL,
+    notes           TEXT            NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_test_runs_plan
+        FOREIGN KEY (test_plan_fk) REFERENCES test_plans (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_test_runs_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS test_results (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    test_run_fk     INT             NOT NULL,
+    test_case_fk    INT             NOT NULL,
+    result_status   VARCHAR(16)     NOT NULL DEFAULT 'not_run',     -- passed|failed|blocked|skipped|not_run
+    actual          TEXT            NULL,
+    notes           TEXT            NULL,
+    executed_at     TIMESTAMP       NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_test_results_run
+        FOREIGN KEY (test_run_fk) REFERENCES test_runs (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_test_results_case
+        FOREIGN KEY (test_case_fk) REFERENCES test_cases (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_test_results_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT uq_run_case UNIQUE KEY (test_run_fk, test_case_fk)
 );

--- a/scripts/add-api-route.sh
+++ b/scripts/add-api-route.sh
@@ -1,15 +1,28 @@
 #!/bin/bash
-# add-api-route.sh — Add a new /darwin/{table_name} route to Darwin API Gateway
+# add-api-route.sh — Add a new /{database}/{table_name} route to Darwin API Gateway
 #
 # Usage:
-#   ./add-api-route.sh <table_name>           # create route
-#   ./add-api-route.sh --dry-run <table_name> # print commands without executing
-#   ./add-api-route.sh --list                 # list existing resources
+#   ./add-api-route.sh <table_name>                              # create /darwin route (prod)
+#   ./add-api-route.sh --database=darwin_dev <table_name>        # create /darwin_dev route (dev)
+#   ./add-api-route.sh --database=darwin --no-deploy <table>     # skip stage deployment
+#   ./add-api-route.sh --dry-run <table_name>                    # print commands without executing
+#   ./add-api-route.sh --list                                    # list existing resources
 #
 # Requires: darwinroot credentials loaded via . ~/.darwin-credentials/aws_credentials.sh
 #
-# Creates two methods: ANY (Cognito-authenticated) + OPTIONS (CORS preflight)
-# Adds Lambda resource policy and deploys to eng stage.
+# Creates two methods: ANY (Cognito-authenticated) + OPTIONS (CORS preflight).
+# Optionally adds Lambda resource policy and deploys to eng stage.
+#
+# Req #2380 changes (2026-04-21):
+#   - --database={darwin|darwin_dev}: select prod or dev parent resource.
+#     darwin_dev skips the Lambda resource policy step because the existing
+#     apigateway-darwin_dev-wildcard statement covers all /darwin_dev/* routes.
+#   - --no-deploy: suppress the per-route create-deployment. Used when batching
+#     many route creations so a single final deploy covers them all.
+#   - /darwin/ table routes no longer need per-table Lambda permission statements
+#     after req #2380 consolidated /darwin/* to a wildcard (Step 4 of req #2380).
+#     Step 9 is retained for operational completeness when the wildcard is absent,
+#     but add-permission will NO-OP safely via --no-skip-if-exists check below.
 
 set -eo pipefail
 
@@ -17,8 +30,9 @@ set -eo pipefail
 # Constants
 # ---------------------------------------------------------------------------
 API_ID="k5j0ftr527"
-PARENT_ID="6k3i3k"            # /darwin resource
-AUTHORIZER_ID="vd4o3k"        # DarwinAppAuthorizer (COGNITO_USER_POOLS)
+PARENT_ID_DARWIN="6k3i3k"           # /darwin resource
+PARENT_ID_DARWIN_DEV="l80osi"       # /darwin_dev resource
+AUTHORIZER_ID="vd4o3k"              # DarwinAppAuthorizer (COGNITO_USER_POOLS)
 LAMBDA_ARN="arn:aws:lambda:us-west-1:617853379785:function:RestApi-MySql-Lambda"
 ACCOUNT_ID="617853379785"
 REGION="us-west-1"
@@ -33,15 +47,29 @@ CORS_ALLOW_ORIGIN="'*'"
 # ---------------------------------------------------------------------------
 DRY_RUN=0
 LIST_MODE=0
+NO_DEPLOY=0
+DATABASE="darwin"       # default: prod
 TABLE_NAME=""
 
 for arg in "$@"; do
     case "$arg" in
         --dry-run) DRY_RUN=1 ;;
         --list) LIST_MODE=1 ;;
+        --no-deploy) NO_DEPLOY=1 ;;
+        --database=*) DATABASE="${arg#--database=}" ;;
         *) TABLE_NAME="$arg" ;;
     esac
 done
+
+# Validate database selection + map to parent resource ID.
+case "$DATABASE" in
+    darwin)     PARENT_ID="$PARENT_ID_DARWIN" ;;
+    darwin_dev) PARENT_ID="$PARENT_ID_DARWIN_DEV" ;;
+    *)
+        echo "ERROR: --database must be 'darwin' or 'darwin_dev' (got '$DATABASE')" >&2
+        exit 2
+        ;;
+esac
 
 # ---------------------------------------------------------------------------
 # List mode
@@ -55,7 +83,7 @@ if [ "$LIST_MODE" -eq 1 ]; then
 fi
 
 if [ -z "$TABLE_NAME" ]; then
-    echo "Usage: $0 [--dry-run] [--list] <table_name>"
+    echo "Usage: $0 [--dry-run] [--list] [--database=darwin|darwin_dev] [--no-deploy] <table_name>"
     exit 1
 fi
 
@@ -70,13 +98,14 @@ run() {
     fi
 }
 
-echo "==> Adding API Gateway route: /darwin/${TABLE_NAME}"
+echo "==> Adding API Gateway route: /${DATABASE}/${TABLE_NAME}"
 [ "$DRY_RUN" -eq 1 ] && echo "    (dry-run mode — no changes will be made)"
+[ "$NO_DEPLOY" -eq 1 ] && echo "    (--no-deploy: stage deployment will be skipped)"
 
 # ---------------------------------------------------------------------------
 # Step 1: Create resource
 # ---------------------------------------------------------------------------
-echo "Step 1: Creating resource /darwin/${TABLE_NAME}..."
+echo "Step 1: Creating resource /${DATABASE}/${TABLE_NAME}..."
 if [ "$DRY_RUN" -eq 0 ]; then
     RESOURCE_ID=$(aws apigateway create-resource \
         --rest-api-id "$API_ID" \
@@ -182,26 +211,56 @@ fi
 
 # ---------------------------------------------------------------------------
 # Step 9: Lambda resource policy
+#
+# Skipped for /darwin_dev/: apigateway-darwin_dev-wildcard already covers all
+# /darwin_dev/* source ARNs.
+#
+# For /darwin/: after req #2380 consolidated to apigateway-darwin-wildcard, a
+# per-table statement is redundant. We still attempt add-permission for
+# operational completeness (in case the wildcard is reverted), but we tolerate
+# the "already exists or covered" case by checking for ResourceConflictException.
 # ---------------------------------------------------------------------------
-echo "Step 9: Adding Lambda resource policy..."
-STATEMENT_ID="apigateway-darwin-${TABLE_NAME}"
-SOURCE_ARN="arn:aws:execute-api:${REGION}:${ACCOUNT_ID}:${API_ID}/*/*/darwin/${TABLE_NAME}"
-run "aws lambda add-permission \
-    --function-name \"$LAMBDA_ARN\" \
-    --statement-id \"$STATEMENT_ID\" \
-    --action lambda:InvokeFunction \
-    --principal apigateway.amazonaws.com \
-    --source-arn \"$SOURCE_ARN\""
+if [ "$DATABASE" = "darwin_dev" ]; then
+    echo "Step 9: SKIP (darwin_dev covered by apigateway-darwin_dev-wildcard)."
+else
+    echo "Step 9: Adding Lambda resource policy (darwin per-table)..."
+    STATEMENT_ID="apigateway-${DATABASE}-${TABLE_NAME}"
+    SOURCE_ARN="arn:aws:execute-api:${REGION}:${ACCOUNT_ID}:${API_ID}/*/*/${DATABASE}/${TABLE_NAME}"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "[DRY-RUN] aws lambda add-permission --statement-id $STATEMENT_ID --source-arn $SOURCE_ARN"
+    else
+        # Tolerate ResourceConflictException (wildcard already covers or statement
+        # exists from a prior run) — continue on that case only.
+        if ! aws lambda add-permission \
+            --function-name "$LAMBDA_ARN" \
+            --statement-id "$STATEMENT_ID" \
+            --action lambda:InvokeFunction \
+            --principal apigateway.amazonaws.com \
+            --source-arn "$SOURCE_ARN" 2>/tmp/add-permission-err; then
+            if grep -q 'ResourceConflictException' /tmp/add-permission-err 2>/dev/null; then
+                echo "    (existing statement or wildcard — ok, continuing)"
+            else
+                echo "    ERROR from add-permission:" >&2
+                cat /tmp/add-permission-err >&2
+                exit 1
+            fi
+        fi
+    fi
+fi
 
 # ---------------------------------------------------------------------------
-# Step 10: Deploy to eng stage
+# Step 10: Deploy to eng stage (skipped when --no-deploy)
 # ---------------------------------------------------------------------------
-echo "Step 10: Deploying to stage '${STAGE}'..."
-run "aws apigateway create-deployment \
-    --rest-api-id \"$API_ID\" \
-    --stage-name \"$STAGE\" \
-    --description \"Add /darwin/${TABLE_NAME} route\""
+if [ "$NO_DEPLOY" -eq 1 ]; then
+    echo "Step 10: SKIP (--no-deploy). Remember to run create-deployment after batching."
+else
+    echo "Step 10: Deploying to stage '${STAGE}'..."
+    run "aws apigateway create-deployment \
+        --rest-api-id \"$API_ID\" \
+        --stage-name \"$STAGE\" \
+        --description \"Add /${DATABASE}/${TABLE_NAME} route\""
+fi
 
 echo ""
-echo "==> Route /darwin/${TABLE_NAME} created successfully."
-echo "    URL: https://${API_ID}.execute-api.${REGION}.amazonaws.com/${STAGE}/darwin/${TABLE_NAME}"
+echo "==> Route /${DATABASE}/${TABLE_NAME} created successfully."
+echo "    URL: https://${API_ID}.execute-api.${REGION}.amazonaws.com/${STAGE}/${DATABASE}/${TABLE_NAME}"

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -1,12 +1,14 @@
 -- Recreate darwin_dev test/dev tables from scratch
 -- Uses production-identical table names (same DDL as schema.sql)
 -- Idempotent: safe to run repeatedly to reset darwin_dev to canonical state
--- All 18 tables in FK-dependency order
+-- All 25 tables in FK-dependency order
 
 USE darwin_dev;
 
 SET FOREIGN_KEY_CHECKS = 0;
-DROP TABLE IF EXISTS map_run_partners, map_partners,
+DROP TABLE IF EXISTS test_results, test_runs, test_plan_cases, test_plans,
+    feature_test_cases, test_cases, features,
+    map_run_partners, map_partners,
     map_views, map_coordinates, map_runs, map_routes,
     priority_card_order, dev_servers, requirement_sessions,
     requirements, swarm_sessions, categories, projects,
@@ -327,4 +329,131 @@ CREATE TABLE map_run_partners (
     FOREIGN KEY (map_partner_fk)
         REFERENCES map_partners (id)
         ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+-- Swarm Features & Test Cases registry (req #2380)
+
+CREATE TABLE features (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title           VARCHAR(256)    NOT NULL,
+    description     TEXT            NOT NULL,
+    feature_status  VARCHAR(16)     NOT NULL DEFAULT 'draft',
+    category_fk     INT             NOT NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    closed          TINYINT(1)      NOT NULL DEFAULT 0,
+    sort_order      SMALLINT        NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_features_category
+        FOREIGN KEY (category_fk) REFERENCES categories (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_features_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE test_cases (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title           VARCHAR(256)    NOT NULL,
+    preconditions   TEXT            NULL,
+    steps           TEXT            NOT NULL,
+    expected        TEXT            NOT NULL,
+    test_type       VARCHAR(16)     NOT NULL DEFAULT 'manual',
+    tags            VARCHAR(512)    NULL,
+    category_fk     INT             NOT NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    closed          TINYINT(1)      NOT NULL DEFAULT 0,
+    sort_order      SMALLINT        NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_test_cases_category
+        FOREIGN KEY (category_fk) REFERENCES categories (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_test_cases_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE feature_test_cases (
+    feature_fk      INT             NOT NULL,
+    test_case_fk    INT             NOT NULL,
+    PRIMARY KEY (feature_fk, test_case_fk),
+    CONSTRAINT fk_ftc_feature
+        FOREIGN KEY (feature_fk) REFERENCES features (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_ftc_case
+        FOREIGN KEY (test_case_fk) REFERENCES test_cases (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE test_plans (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title           VARCHAR(256)    NOT NULL,
+    description     TEXT            NULL,
+    category_fk     INT             NOT NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    closed          TINYINT(1)      NOT NULL DEFAULT 0,
+    sort_order      SMALLINT        NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_test_plans_category
+        FOREIGN KEY (category_fk) REFERENCES categories (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_test_plans_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE test_plan_cases (
+    test_plan_fk    INT             NOT NULL,
+    test_case_fk    INT             NOT NULL,
+    sort_order      SMALLINT        NULL,
+    PRIMARY KEY (test_plan_fk, test_case_fk),
+    CONSTRAINT fk_tpc_plan
+        FOREIGN KEY (test_plan_fk) REFERENCES test_plans (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_tpc_case
+        FOREIGN KEY (test_case_fk) REFERENCES test_cases (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE test_runs (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    test_plan_fk    INT             NOT NULL,
+    run_status      VARCHAR(16)     NOT NULL DEFAULT 'in_progress',
+    started_at      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at    TIMESTAMP       NULL,
+    notes           TEXT            NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_test_runs_plan
+        FOREIGN KEY (test_plan_fk) REFERENCES test_plans (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_test_runs_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE test_results (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    test_run_fk     INT             NOT NULL,
+    test_case_fk    INT             NOT NULL,
+    result_status   VARCHAR(16)     NOT NULL DEFAULT 'not_run',
+    actual          TEXT            NULL,
+    notes           TEXT            NULL,
+    executed_at     TIMESTAMP       NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_test_results_run
+        FOREIGN KEY (test_run_fk) REFERENCES test_runs (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_test_results_case
+        FOREIGN KEY (test_case_fk) REFERENCES test_cases (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_test_results_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT uq_run_case UNIQUE KEY (test_run_fk, test_case_fk)
 );

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,18 @@ def seed_test_profile(db_connection, test_creator_fk):
         cur.execute("DELETE FROM dev_servers WHERE creator_fk = %s", (test_creator_fk,))
         cur.execute("DELETE FROM requirements WHERE creator_fk = %s", (test_creator_fk,))
         cur.execute("DELETE FROM swarm_sessions WHERE creator_fk = %s", (test_creator_fk,))
+        # Req #2380: features/test_cases/test_plans RESTRICT on categories,
+        # so delete these BEFORE categories. test_results and test_runs also
+        # clean up explicitly to handle tests that commit mid-run.
+        cur.execute("DELETE FROM test_results WHERE creator_fk = %s", (test_creator_fk,))
+        cur.execute("DELETE FROM test_runs WHERE creator_fk = %s", (test_creator_fk,))
+        cur.execute("DELETE FROM test_plan_cases WHERE test_plan_fk IN "
+                    "(SELECT id FROM test_plans WHERE creator_fk = %s)", (test_creator_fk,))
+        cur.execute("DELETE FROM test_plans WHERE creator_fk = %s", (test_creator_fk,))
+        cur.execute("DELETE FROM feature_test_cases WHERE feature_fk IN "
+                    "(SELECT id FROM features WHERE creator_fk = %s)", (test_creator_fk,))
+        cur.execute("DELETE FROM test_cases WHERE creator_fk = %s", (test_creator_fk,))
+        cur.execute("DELETE FROM features WHERE creator_fk = %s", (test_creator_fk,))
         cur.execute("DELETE FROM categories WHERE creator_fk = %s", (test_creator_fk,))
         cur.execute("DELETE FROM projects WHERE creator_fk = %s", (test_creator_fk,))
         cur.execute("DELETE FROM tasks WHERE creator_fk = %s", (test_creator_fk,))

--- a/tests/test_cascades.py
+++ b/tests/test_cascades.py
@@ -654,3 +654,289 @@ def test_delete_area_does_not_affect_sibling_areas(db_connection):
         assert cur.fetchone() is not None
 
     db_connection.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Req #2380 — Swarm Features & Test Cases registry CASCADE/RESTRICT
+# ---------------------------------------------------------------------------
+
+def _setup_validation_creator(cur, prefix):
+    """Create a dedicated profile + project + category for a cascade test scenario.
+
+    Returns (creator, project_id, category_id). Caller is responsible for
+    rollback (tests use the usual rollback pattern).
+    """
+    creator = f'{prefix}-{__import__("uuid").uuid4().hex[:6]}'
+    cur.execute(
+        "INSERT INTO profiles (id, name, email) VALUES (%s, %s, %s)",
+        (creator, 'Validation Cascade', f'{creator}@test.com')
+    )
+    cur.execute(
+        "INSERT INTO projects (project_name, creator_fk) VALUES (%s, %s)",
+        ('validation cascade project', creator)
+    )
+    cur.execute("SELECT LAST_INSERT_ID() AS id")
+    project_id = cur.fetchone()['id']
+    cur.execute(
+        "INSERT INTO categories (category_name, project_fk, creator_fk) "
+        "VALUES (%s, %s, %s)",
+        ('validation cascade category', project_id, creator)
+    )
+    cur.execute("SELECT LAST_INSERT_ID() AS id")
+    category_id = cur.fetchone()['id']
+    return creator, project_id, category_id
+
+
+def test_delete_category_with_features_rejected(db_connection):
+    """DELETE category with live features → IntegrityError (ON DELETE RESTRICT)."""
+    with db_connection.cursor() as cur:
+        creator, _project, category_id = _setup_validation_creator(cur, 'cascade-feat-cat')
+        cur.execute(
+            "INSERT INTO features (title, description, category_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s)",
+            ('blocker feature', 'd', category_id, creator)
+        )
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute("DELETE FROM categories WHERE id = %s", (category_id,))
+    db_connection.rollback()
+
+
+def test_delete_category_with_test_cases_rejected(db_connection):
+    """DELETE category with live test_cases → IntegrityError (ON DELETE RESTRICT)."""
+    with db_connection.cursor() as cur:
+        creator, _project, category_id = _setup_validation_creator(cur, 'cascade-tc-cat')
+        cur.execute(
+            "INSERT INTO test_cases (title, steps, expected, category_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            ('blocker case', '1', 'ok', category_id, creator)
+        )
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute("DELETE FROM categories WHERE id = %s", (category_id,))
+    db_connection.rollback()
+
+
+def test_delete_category_with_test_plans_rejected(db_connection):
+    """DELETE category with live test_plans → IntegrityError (ON DELETE RESTRICT)."""
+    with db_connection.cursor() as cur:
+        creator, _project, category_id = _setup_validation_creator(cur, 'cascade-plan-cat')
+        cur.execute(
+            "INSERT INTO test_plans (title, category_fk, creator_fk) VALUES (%s, %s, %s)",
+            ('blocker plan', category_id, creator)
+        )
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute("DELETE FROM categories WHERE id = %s", (category_id,))
+    db_connection.rollback()
+
+
+def test_delete_feature_cascades_to_feature_test_cases(db_connection):
+    """DELETE feature → CASCADE removes its feature_test_cases rows."""
+    with db_connection.cursor() as cur:
+        creator, _project, category_id = _setup_validation_creator(cur, 'cascade-feat-del')
+        cur.execute(
+            "INSERT INTO features (title, description, category_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s)",
+            ('feat', 'd', category_id, creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        feature_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO test_cases (title, steps, expected, category_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            ('case', '1', 'ok', category_id, creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        case_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO feature_test_cases (feature_fk, test_case_fk) VALUES (%s, %s)",
+            (feature_id, case_id)
+        )
+
+        cur.execute("DELETE FROM features WHERE id = %s", (feature_id,))
+
+        cur.execute(
+            "SELECT COUNT(*) AS c FROM feature_test_cases "
+            "WHERE feature_fk = %s OR test_case_fk = %s",
+            (feature_id, case_id)
+        )
+        assert cur.fetchone()['c'] == 0  # CASCADE removed the junction row
+        # Test case itself is untouched
+        cur.execute("SELECT id FROM test_cases WHERE id = %s", (case_id,))
+        assert cur.fetchone() is not None
+    db_connection.rollback()
+
+
+def test_delete_test_case_cascades_to_feature_test_cases(db_connection):
+    """DELETE test_case → CASCADE removes its feature_test_cases rows."""
+    with db_connection.cursor() as cur:
+        creator, _project, category_id = _setup_validation_creator(cur, 'cascade-case-del')
+        cur.execute(
+            "INSERT INTO features (title, description, category_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s)",
+            ('feat', 'd', category_id, creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        feature_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO test_cases (title, steps, expected, category_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            ('case', '1', 'ok', category_id, creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        case_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO feature_test_cases (feature_fk, test_case_fk) VALUES (%s, %s)",
+            (feature_id, case_id)
+        )
+
+        cur.execute("DELETE FROM test_cases WHERE id = %s", (case_id,))
+
+        cur.execute(
+            "SELECT COUNT(*) AS c FROM feature_test_cases WHERE test_case_fk = %s",
+            (case_id,)
+        )
+        assert cur.fetchone()['c'] == 0
+        # Feature itself untouched
+        cur.execute("SELECT id FROM features WHERE id = %s", (feature_id,))
+        assert cur.fetchone() is not None
+    db_connection.rollback()
+
+
+def test_delete_test_plan_with_runs_rejected(db_connection):
+    """DELETE test_plan with live test_runs → IntegrityError (ON DELETE RESTRICT).
+
+    A plan with run history cannot be deleted; the caller must close or archive first.
+    """
+    with db_connection.cursor() as cur:
+        creator, _project, category_id = _setup_validation_creator(cur, 'cascade-plan-run')
+        cur.execute(
+            "INSERT INTO test_plans (title, category_fk, creator_fk) VALUES (%s, %s, %s)",
+            ('plan with history', category_id, creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        plan_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO test_runs (test_plan_fk, creator_fk) VALUES (%s, %s)",
+            (plan_id, creator)
+        )
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute("DELETE FROM test_plans WHERE id = %s", (plan_id,))
+    db_connection.rollback()
+
+
+def test_delete_test_run_cascades_to_results(db_connection):
+    """DELETE test_run → CASCADE removes its test_results rows."""
+    with db_connection.cursor() as cur:
+        creator, _project, category_id = _setup_validation_creator(cur, 'cascade-run-del')
+        cur.execute(
+            "INSERT INTO test_plans (title, category_fk, creator_fk) VALUES (%s, %s, %s)",
+            ('plan', category_id, creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        plan_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO test_cases (title, steps, expected, category_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            ('case', '1', 'ok', category_id, creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        case_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO test_runs (test_plan_fk, creator_fk) VALUES (%s, %s)",
+            (plan_id, creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        run_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO test_results "
+            "(test_run_fk, test_case_fk, result_status, creator_fk) "
+            "VALUES (%s, %s, %s, %s)",
+            (run_id, case_id, 'passed', creator)
+        )
+
+        cur.execute("DELETE FROM test_runs WHERE id = %s", (run_id,))
+
+        cur.execute("SELECT COUNT(*) AS c FROM test_results WHERE test_run_fk = %s", (run_id,))
+        assert cur.fetchone()['c'] == 0  # CASCADE removed results
+        # Case is untouched
+        cur.execute("SELECT id FROM test_cases WHERE id = %s", (case_id,))
+        assert cur.fetchone() is not None
+    db_connection.rollback()
+
+
+def test_delete_test_case_with_results_rejected(db_connection):
+    """DELETE test_case with live test_results → IntegrityError (ON DELETE RESTRICT).
+
+    Protects historical run data: cannot remove a test_case that already has
+    recorded outcomes.
+    """
+    with db_connection.cursor() as cur:
+        creator, _project, category_id = _setup_validation_creator(cur, 'cascade-case-result')
+        cur.execute(
+            "INSERT INTO test_plans (title, category_fk, creator_fk) VALUES (%s, %s, %s)",
+            ('plan', category_id, creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        plan_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO test_cases (title, steps, expected, category_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            ('case with result', '1', 'ok', category_id, creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        case_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO test_runs (test_plan_fk, creator_fk) VALUES (%s, %s)",
+            (plan_id, creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        run_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO test_results "
+            "(test_run_fk, test_case_fk, result_status, creator_fk) "
+            "VALUES (%s, %s, %s, %s)",
+            (run_id, case_id, 'failed', creator)
+        )
+
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute("DELETE FROM test_cases WHERE id = %s", (case_id,))
+    db_connection.rollback()
+
+
+def test_delete_test_plan_cascades_to_plan_cases(db_connection):
+    """DELETE test_plan (when no runs exist) → CASCADE removes its test_plan_cases rows."""
+    with db_connection.cursor() as cur:
+        creator, _project, category_id = _setup_validation_creator(cur, 'cascade-plan-cases')
+        cur.execute(
+            "INSERT INTO test_plans (title, category_fk, creator_fk) VALUES (%s, %s, %s)",
+            ('plan to delete', category_id, creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        plan_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO test_cases (title, steps, expected, category_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            ('case', '1', 'ok', category_id, creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        case_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO test_plan_cases (test_plan_fk, test_case_fk, sort_order) "
+            "VALUES (%s, %s, 1)",
+            (plan_id, case_id)
+        )
+
+        cur.execute("DELETE FROM test_plans WHERE id = %s", (plan_id,))
+
+        cur.execute(
+            "SELECT COUNT(*) AS c FROM test_plan_cases WHERE test_plan_fk = %s",
+            (plan_id,)
+        )
+        assert cur.fetchone()['c'] == 0  # CASCADE removed the junction row
+        # Case itself is untouched
+        cur.execute("SELECT id FROM test_cases WHERE id = %s", (case_id,))
+        assert cur.fetchone() is not None
+    db_connection.rollback()

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -722,3 +722,300 @@ def test_map_run_stopped_time_default(db_connection, test_creator_fk):
         assert row['stopped_time_sec'] == 0
 
     db_connection.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Req #2380 — Swarm Features & Test Cases registry (migrations 042/043/044)
+# ---------------------------------------------------------------------------
+
+# FK invalid-parent rejection tests
+
+def test_feature_fk_invalid_category(db_connection, test_creator_fk, seed_test_profile):
+    """INSERT feature with non-existent category_fk → IntegrityError"""
+    with db_connection.cursor() as cur:
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO features (title, description, category_fk, creator_fk) "
+                "VALUES (%s, %s, %s, %s)",
+                ('orphan feature', 'desc', 999999, test_creator_fk)
+            )
+    db_connection.rollback()
+
+
+def test_feature_fk_invalid_creator(db_connection, test_category_id):
+    """INSERT feature with non-existent creator_fk → IntegrityError"""
+    with db_connection.cursor() as cur:
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO features (title, description, category_fk, creator_fk) "
+                "VALUES (%s, %s, %s, %s)",
+                ('orphan', 'desc', test_category_id, 'nonexistent-profile-id')
+            )
+    db_connection.rollback()
+
+
+def test_test_case_fk_invalid_category(db_connection, test_creator_fk, seed_test_profile):
+    """INSERT test_case with non-existent category_fk → IntegrityError"""
+    with db_connection.cursor() as cur:
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO test_cases (title, steps, expected, category_fk, creator_fk) "
+                "VALUES (%s, %s, %s, %s, %s)",
+                ('orphan case', '1. step', 'passes', 999999, test_creator_fk)
+            )
+    db_connection.rollback()
+
+
+def test_test_plan_fk_invalid_category(db_connection, test_creator_fk, seed_test_profile):
+    """INSERT test_plan with non-existent category_fk → IntegrityError"""
+    with db_connection.cursor() as cur:
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO test_plans (title, category_fk, creator_fk) "
+                "VALUES (%s, %s, %s)",
+                ('orphan plan', 999999, test_creator_fk)
+            )
+    db_connection.rollback()
+
+
+def test_test_run_fk_invalid_plan(db_connection, test_creator_fk, seed_test_profile):
+    """INSERT test_run with non-existent test_plan_fk → IntegrityError"""
+    with db_connection.cursor() as cur:
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO test_runs (test_plan_fk, run_status, creator_fk) "
+                "VALUES (%s, %s, %s)",
+                (999999, 'in_progress', test_creator_fk)
+            )
+    db_connection.rollback()
+
+
+def test_test_result_fk_invalid_run(db_connection, test_creator_fk, seed_test_profile):
+    """INSERT test_result with non-existent test_run_fk → IntegrityError"""
+    with db_connection.cursor() as cur:
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO test_results "
+                "(test_run_fk, test_case_fk, result_status, creator_fk) "
+                "VALUES (%s, %s, %s, %s)",
+                (999999, 999999, 'passed', test_creator_fk)
+            )
+    db_connection.rollback()
+
+
+# NOT NULL constraint tests
+
+def test_feature_title_not_null(db_connection, test_creator_fk, test_category_id):
+    """INSERT feature with title=NULL → IntegrityError"""
+    with db_connection.cursor() as cur:
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO features (title, description, category_fk, creator_fk) "
+                "VALUES (%s, %s, %s, %s)",
+                (None, 'desc', test_category_id, test_creator_fk)
+            )
+    db_connection.rollback()
+
+
+def test_feature_description_not_null(db_connection, test_creator_fk, test_category_id):
+    """INSERT feature with description=NULL → IntegrityError (features.description is NOT NULL)."""
+    with db_connection.cursor() as cur:
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO features (title, description, category_fk, creator_fk) "
+                "VALUES (%s, %s, %s, %s)",
+                ('title', None, test_category_id, test_creator_fk)
+            )
+    db_connection.rollback()
+
+
+def test_test_case_steps_not_null(db_connection, test_creator_fk, test_category_id):
+    """INSERT test_case with steps=NULL → IntegrityError"""
+    with db_connection.cursor() as cur:
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO test_cases (title, steps, expected, category_fk, creator_fk) "
+                "VALUES (%s, %s, %s, %s, %s)",
+                ('t', None, 'e', test_category_id, test_creator_fk)
+            )
+    db_connection.rollback()
+
+
+def test_test_case_expected_not_null(db_connection, test_creator_fk, test_category_id):
+    """INSERT test_case with expected=NULL → IntegrityError"""
+    with db_connection.cursor() as cur:
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO test_cases (title, steps, expected, category_fk, creator_fk) "
+                "VALUES (%s, %s, %s, %s, %s)",
+                ('t', '1.step', None, test_category_id, test_creator_fk)
+            )
+    db_connection.rollback()
+
+
+# Default value tests
+
+def test_feature_status_default(db_connection, test_creator_fk, test_category_id):
+    """INSERT feature without feature_status → defaults to 'draft'."""
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO features (title, description, category_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s)",
+            ('default-status-check', 'desc', test_category_id, test_creator_fk)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        feature_id = cur.fetchone()['id']
+        cur.execute("SELECT feature_status FROM features WHERE id = %s", (feature_id,))
+        row = cur.fetchone()
+        assert row['feature_status'] == 'draft'
+    db_connection.rollback()
+
+
+def test_test_case_type_default(db_connection, test_creator_fk, test_category_id):
+    """INSERT test_case without test_type → defaults to 'manual'."""
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO test_cases (title, steps, expected, category_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            ('type-default', '1.step', 'pass', test_category_id, test_creator_fk)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        tc_id = cur.fetchone()['id']
+        cur.execute("SELECT test_type FROM test_cases WHERE id = %s", (tc_id,))
+        assert cur.fetchone()['test_type'] == 'manual'
+    db_connection.rollback()
+
+
+def test_test_run_status_default(db_connection, test_creator_fk, test_category_id):
+    """INSERT test_run without run_status → defaults to 'in_progress'."""
+    with db_connection.cursor() as cur:
+        # Need a plan first
+        cur.execute(
+            "INSERT INTO test_plans (title, category_fk, creator_fk) VALUES (%s, %s, %s)",
+            ('plan-for-run-default', test_category_id, test_creator_fk)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        plan_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO test_runs (test_plan_fk, creator_fk) VALUES (%s, %s)",
+            (plan_id, test_creator_fk)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        run_id = cur.fetchone()['id']
+        cur.execute("SELECT run_status, started_at FROM test_runs WHERE id = %s", (run_id,))
+        row = cur.fetchone()
+        assert row['run_status'] == 'in_progress'
+        assert row['started_at'] is not None  # NOT NULL DEFAULT CURRENT_TIMESTAMP
+    db_connection.rollback()
+
+
+def test_test_result_status_default(db_connection, test_creator_fk, test_category_id):
+    """INSERT test_result without result_status → defaults to 'not_run'."""
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO test_plans (title, category_fk, creator_fk) VALUES (%s, %s, %s)",
+            ('plan-for-result-default', test_category_id, test_creator_fk)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        plan_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO test_cases (title, steps, expected, category_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            ('case-for-result', '1', 'ok', test_category_id, test_creator_fk)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        case_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO test_runs (test_plan_fk, creator_fk) VALUES (%s, %s)",
+            (plan_id, test_creator_fk)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        run_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO test_results (test_run_fk, test_case_fk, creator_fk) "
+            "VALUES (%s, %s, %s)",
+            (run_id, case_id, test_creator_fk)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        result_id = cur.fetchone()['id']
+        cur.execute("SELECT result_status, executed_at FROM test_results WHERE id = %s",
+                    (result_id,))
+        row = cur.fetchone()
+        assert row['result_status'] == 'not_run'
+        assert row['executed_at'] is None  # nullable, not set until result recorded
+    db_connection.rollback()
+
+
+# UNIQUE (test_run_fk, test_case_fk) enforcement
+
+def test_test_results_unique_run_case(db_connection, test_creator_fk, test_category_id):
+    """Second INSERT test_result with same (test_run_fk, test_case_fk) → IntegrityError.
+
+    Enforces uq_run_case: a test_run has at most one test_result per test_case.
+    """
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO test_plans (title, category_fk, creator_fk) VALUES (%s, %s, %s)",
+            ('plan-uq-check', test_category_id, test_creator_fk)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        plan_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO test_cases (title, steps, expected, category_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            ('case-uq', '1', 'ok', test_category_id, test_creator_fk)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        case_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO test_runs (test_plan_fk, creator_fk) VALUES (%s, %s)",
+            (plan_id, test_creator_fk)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        run_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO test_results (test_run_fk, test_case_fk, result_status, creator_fk) "
+            "VALUES (%s, %s, %s, %s)",
+            (run_id, case_id, 'passed', test_creator_fk)
+        )
+        # Second insert with same (run, case) must fail
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO test_results (test_run_fk, test_case_fk, result_status, creator_fk) "
+                "VALUES (%s, %s, %s, %s)",
+                (run_id, case_id, 'failed', test_creator_fk)
+            )
+    db_connection.rollback()
+
+
+# Junction-table composite PK uniqueness
+
+def test_feature_test_cases_composite_pk(db_connection, test_creator_fk, test_category_id):
+    """Second INSERT feature_test_cases with same (feature_fk, test_case_fk) → IntegrityError."""
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO features (title, description, category_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s)",
+            ('f-dup', 'd', test_category_id, test_creator_fk)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        f_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO test_cases (title, steps, expected, category_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            ('tc-dup', '1', 'ok', test_category_id, test_creator_fk)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        tc_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO feature_test_cases (feature_fk, test_case_fk) VALUES (%s, %s)",
+            (f_id, tc_id)
+        )
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO feature_test_cases (feature_fk, test_case_fk) VALUES (%s, %s)",
+                (f_id, tc_id)
+            )
+    db_connection.rollback()

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -968,8 +968,247 @@ def test_map_run_partners_columns(db_connection):
     assert 'timestamp' in columns['create_ts']['Type']
 
 
+def test_features_columns(db_connection):
+    """Verify features column definitions match schema.sql (migration 042)."""
+    with db_connection.cursor() as cur:
+        cur.execute("DESCRIBE features")
+        columns = {row['Field']: row for row in cur.fetchall()}
+
+    expected_fields = ['id', 'title', 'description', 'feature_status',
+                       'category_fk', 'creator_fk', 'closed', 'sort_order',
+                       'create_ts', 'update_ts']
+    assert set(columns.keys()) == set(expected_fields), \
+        f"Unexpected columns: {set(columns.keys()) - set(expected_fields)}"
+
+    assert columns['id']['Type'] == 'int'
+    assert columns['id']['Key'] == 'PRI'
+    assert columns['id']['Extra'] == 'auto_increment'
+
+    assert columns['title']['Type'] == 'varchar(256)'
+    assert columns['title']['Null'] == 'NO'
+
+    assert columns['description']['Type'] == 'text'
+    assert columns['description']['Null'] == 'NO'
+
+    assert columns['feature_status']['Type'] == 'varchar(16)'
+    assert columns['feature_status']['Null'] == 'NO'
+    assert columns['feature_status']['Default'] == 'draft'
+
+    assert columns['category_fk']['Type'] == 'int'
+    assert columns['category_fk']['Null'] == 'NO'
+
+    assert columns['creator_fk']['Type'] == 'varchar(64)'
+    assert columns['creator_fk']['Null'] == 'NO'
+
+    assert 'tinyint' in columns['closed']['Type']
+    assert columns['closed']['Null'] == 'NO'
+    assert columns['closed']['Default'] == '0'
+
+    assert columns['sort_order']['Type'] == 'smallint'
+    assert columns['sort_order']['Null'] == 'YES'
+
+    assert 'timestamp' in columns['create_ts']['Type']
+    assert columns['create_ts']['Default'] == 'CURRENT_TIMESTAMP'
+    assert 'timestamp' in columns['update_ts']['Type']
+    assert columns['update_ts']['Extra'] == 'on update CURRENT_TIMESTAMP'
+
+
+def test_test_cases_columns(db_connection):
+    """Verify test_cases column definitions match schema.sql (migration 042)."""
+    with db_connection.cursor() as cur:
+        cur.execute("DESCRIBE test_cases")
+        columns = {row['Field']: row for row in cur.fetchall()}
+
+    expected_fields = ['id', 'title', 'preconditions', 'steps', 'expected',
+                       'test_type', 'tags', 'category_fk', 'creator_fk',
+                       'closed', 'sort_order', 'create_ts', 'update_ts']
+    assert set(columns.keys()) == set(expected_fields), \
+        f"Unexpected columns: {set(columns.keys()) - set(expected_fields)}"
+
+    assert columns['id']['Type'] == 'int'
+    assert columns['id']['Extra'] == 'auto_increment'
+
+    assert columns['title']['Type'] == 'varchar(256)'
+    assert columns['title']['Null'] == 'NO'
+
+    assert columns['preconditions']['Type'] == 'text'
+    assert columns['preconditions']['Null'] == 'YES'  # optional (smoke tests may have none)
+
+    assert columns['steps']['Type'] == 'text'
+    assert columns['steps']['Null'] == 'NO'
+
+    assert columns['expected']['Type'] == 'text'
+    assert columns['expected']['Null'] == 'NO'
+
+    assert columns['test_type']['Type'] == 'varchar(16)'
+    assert columns['test_type']['Null'] == 'NO'
+    assert columns['test_type']['Default'] == 'manual'
+
+    assert columns['tags']['Type'] == 'varchar(512)'
+    assert columns['tags']['Null'] == 'YES'
+
+    assert columns['category_fk']['Type'] == 'int'
+    assert columns['category_fk']['Null'] == 'NO'
+
+    assert columns['creator_fk']['Type'] == 'varchar(64)'
+    assert columns['creator_fk']['Null'] == 'NO'
+
+    assert 'tinyint' in columns['closed']['Type']
+    assert columns['closed']['Default'] == '0'
+
+    assert columns['sort_order']['Type'] == 'smallint'
+    assert columns['sort_order']['Null'] == 'YES'
+
+
+def test_feature_test_cases_columns(db_connection):
+    """Verify feature_test_cases junction (migration 042) — composite PK, no id."""
+    with db_connection.cursor() as cur:
+        cur.execute("DESCRIBE feature_test_cases")
+        columns = {row['Field']: row for row in cur.fetchall()}
+
+    expected_fields = ['feature_fk', 'test_case_fk']
+    assert set(columns.keys()) == set(expected_fields), \
+        f"Unexpected columns: {set(columns.keys()) - set(expected_fields)}"
+
+    # Both FKs are primary key parts (composite PK)
+    assert columns['feature_fk']['Type'] == 'int'
+    assert columns['feature_fk']['Null'] == 'NO'
+    assert columns['feature_fk']['Key'] == 'PRI'
+
+    assert columns['test_case_fk']['Type'] == 'int'
+    assert columns['test_case_fk']['Null'] == 'NO'
+    # MySQL reports non-leading composite PK columns as 'MUL'
+    assert columns['test_case_fk']['Key'] in ('PRI', 'MUL')
+
+
+def test_test_plans_columns(db_connection):
+    """Verify test_plans column definitions match schema.sql (migration 043)."""
+    with db_connection.cursor() as cur:
+        cur.execute("DESCRIBE test_plans")
+        columns = {row['Field']: row for row in cur.fetchall()}
+
+    expected_fields = ['id', 'title', 'description', 'category_fk',
+                       'creator_fk', 'closed', 'sort_order',
+                       'create_ts', 'update_ts']
+    assert set(columns.keys()) == set(expected_fields)
+
+    assert columns['id']['Extra'] == 'auto_increment'
+    assert columns['title']['Type'] == 'varchar(256)'
+    assert columns['title']['Null'] == 'NO'
+    assert columns['description']['Type'] == 'text'
+    assert columns['description']['Null'] == 'YES'  # nullable (distinct from features.description)
+    assert columns['category_fk']['Null'] == 'NO'
+    assert columns['creator_fk']['Null'] == 'NO'
+    assert columns['closed']['Default'] == '0'
+    assert columns['sort_order']['Null'] == 'YES'
+
+
+def test_test_plan_cases_columns(db_connection):
+    """Verify test_plan_cases junction (migration 043) — composite PK + sort_order."""
+    with db_connection.cursor() as cur:
+        cur.execute("DESCRIBE test_plan_cases")
+        columns = {row['Field']: row for row in cur.fetchall()}
+
+    expected_fields = ['test_plan_fk', 'test_case_fk', 'sort_order']
+    assert set(columns.keys()) == set(expected_fields)
+
+    assert columns['test_plan_fk']['Null'] == 'NO'
+    assert columns['test_plan_fk']['Key'] == 'PRI'
+
+    assert columns['test_case_fk']['Null'] == 'NO'
+    assert columns['test_case_fk']['Key'] in ('PRI', 'MUL')
+
+    assert columns['sort_order']['Type'] == 'smallint'
+    assert columns['sort_order']['Null'] == 'YES'
+
+
+def test_test_runs_columns(db_connection):
+    """Verify test_runs column definitions match schema.sql (migration 044).
+
+    Execution table — has started_at/completed_at, NO closed, NO sort_order.
+    """
+    with db_connection.cursor() as cur:
+        cur.execute("DESCRIBE test_runs")
+        columns = {row['Field']: row for row in cur.fetchall()}
+
+    expected_fields = ['id', 'test_plan_fk', 'run_status', 'started_at',
+                       'completed_at', 'notes', 'creator_fk',
+                       'create_ts', 'update_ts']
+    assert set(columns.keys()) == set(expected_fields), \
+        f"Unexpected columns: {set(columns.keys()) - set(expected_fields)}"
+
+    assert 'closed' not in columns, "test_runs is an execution table; must NOT have a closed column"
+    assert 'sort_order' not in columns, "test_runs is chronological by started_at"
+
+    assert columns['id']['Extra'] == 'auto_increment'
+
+    assert columns['test_plan_fk']['Type'] == 'int'
+    assert columns['test_plan_fk']['Null'] == 'NO'
+
+    assert columns['run_status']['Type'] == 'varchar(16)'
+    assert columns['run_status']['Null'] == 'NO'
+    assert columns['run_status']['Default'] == 'in_progress'
+
+    assert 'timestamp' in columns['started_at']['Type']
+    assert columns['started_at']['Null'] == 'NO'
+    assert columns['started_at']['Default'] == 'CURRENT_TIMESTAMP'
+
+    assert 'timestamp' in columns['completed_at']['Type']
+    assert columns['completed_at']['Null'] == 'YES'
+
+    assert columns['notes']['Type'] == 'text'
+    assert columns['notes']['Null'] == 'YES'
+
+    assert columns['creator_fk']['Null'] == 'NO'
+
+
+def test_test_results_columns(db_connection):
+    """Verify test_results column definitions match schema.sql (migration 044).
+
+    Execution table — has executed_at, NO closed, NO sort_order. UNIQUE (run, case).
+    """
+    with db_connection.cursor() as cur:
+        cur.execute("DESCRIBE test_results")
+        columns = {row['Field']: row for row in cur.fetchall()}
+
+    expected_fields = ['id', 'test_run_fk', 'test_case_fk', 'result_status',
+                       'actual', 'notes', 'executed_at', 'creator_fk',
+                       'create_ts', 'update_ts']
+    assert set(columns.keys()) == set(expected_fields), \
+        f"Unexpected columns: {set(columns.keys()) - set(expected_fields)}"
+
+    assert 'closed' not in columns, "test_results is an execution table"
+    assert 'sort_order' not in columns
+
+    assert columns['id']['Extra'] == 'auto_increment'
+
+    assert columns['test_run_fk']['Type'] == 'int'
+    assert columns['test_run_fk']['Null'] == 'NO'
+
+    assert columns['test_case_fk']['Type'] == 'int'
+    assert columns['test_case_fk']['Null'] == 'NO'
+
+    assert columns['result_status']['Type'] == 'varchar(16)'
+    assert columns['result_status']['Null'] == 'NO'
+    assert columns['result_status']['Default'] == 'not_run'
+
+    assert columns['actual']['Type'] == 'text'
+    assert columns['actual']['Null'] == 'YES'
+
+    assert 'timestamp' in columns['executed_at']['Type']
+    assert columns['executed_at']['Null'] == 'YES'  # populated when recorded
+
+    # Verify UNIQUE constraint uq_run_case
+    with db_connection.cursor() as cur:
+        cur.execute("SHOW INDEX FROM test_results WHERE Key_name = 'uq_run_case'")
+        rows = cur.fetchall()
+    columns_in_unique = {r['Column_name'] for r in rows}
+    assert columns_in_unique == {'test_run_fk', 'test_case_fk'}, \
+        f"uq_run_case UNIQUE should cover (test_run_fk, test_case_fk), got {columns_in_unique}"
+
+
 def test_table_count(db_connection):
-    """Verify darwin_dev database contains all 18 expected tables."""
+    """Verify darwin_dev database contains all 25 expected tables."""
     with db_connection.cursor() as cur:
         cur.execute("SHOW TABLES")
         tables = {row['Tables_in_darwin_dev'] for row in cur.fetchall()}
@@ -980,6 +1219,10 @@ def test_table_count(db_connection):
         'swarm_sessions', 'dev_servers', 'priority_card_order',
         'map_routes', 'map_runs', 'map_coordinates', 'map_views',
         'map_partners', 'map_run_partners',
+        # Req #2380 — Swarm Features & Test Cases registry
+        'features', 'test_cases', 'feature_test_cases',
+        'test_plans', 'test_plan_cases',
+        'test_runs', 'test_results',
     }
     assert expected_tables == tables, \
         f"Unexpected tables: {tables - expected_tables}, missing: {expected_tables - tables}"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -59,6 +59,17 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
     # (e.g., 'tasks' inside 'recurring_tasks') while preserving FK constraint
     # name replacement (e.g., 'domains_ibfk_1' → 'mig_xxx_domains_ibfk_1').
     table_names = [
+        # Req #2380 — Swarm Features & Test Cases registry (migrations 042/043/044).
+        # Listed longest-first within this group to avoid partial matches
+        # (e.g., 'test_cases' inside 'feature_test_cases' is blocked by the
+        # regex lookbehind, but longest-first preserves future safety.)
+        'feature_test_cases',
+        'test_plan_cases',
+        'test_results',
+        'test_plans',
+        'test_cases',
+        'test_runs',
+        'features',
         'user_integrations',
         'requirement_sessions',
         'priority_sessions',     # pre-038 name (for RENAME TABLE in migration 038)
@@ -96,6 +107,31 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         # (?=_ibfk|\b) = followed by _ibfk (FK name) or word boundary (standalone)
         pattern = r'(?<![a-zA-Z_])' + re.escape(name) + r'(?=_ibfk|\b)'
         sql = re.sub(pattern, f'{table_prefix}_{name}', sql)
+
+    # Prefix explicitly-named FK/UNIQUE constraint names (migration 041+ convention).
+    # MySQL 8.0+ enforces FK constraint-name uniqueness per schema, so prefix-test
+    # runs of migrations that name their constraints (e.g. 041's fk_requirements_category,
+    # 042's fk_features_category) need the constraint names to vary per test prefix.
+    # Pattern: any CONSTRAINT name matching fk_*_* or uq_*_* gets a prefix inserted.
+    # Simple str.replace is safe — the constraint names are unique tokens and never
+    # appear as column fragments inside other identifiers.
+    named_constraints = [
+        # Migration 041
+        'fk_requirements_category',
+        # Migration 042
+        'fk_features_category', 'fk_features_creator',
+        'fk_test_cases_category', 'fk_test_cases_creator',
+        'fk_ftc_feature', 'fk_ftc_case',
+        # Migration 043
+        'fk_test_plans_category', 'fk_test_plans_creator',
+        'fk_tpc_plan', 'fk_tpc_case',
+        # Migration 044
+        'fk_test_runs_plan', 'fk_test_runs_creator',
+        'fk_test_results_run', 'fk_test_results_case', 'fk_test_results_creator',
+        'uq_run_case',
+    ]
+    for cname in named_constraints:
+        sql = sql.replace(cname, f'{table_prefix}_{cname}')
 
     # Remove SQL comments (both -- and # style)
     lines = []
@@ -170,6 +206,13 @@ def _get_dependency_ordered_migrations():
 # recurring_tasks must be dropped before tasks (tasks.recurring_task_fk → recurring_tasks)
 # map_coordinates → map_runs → map_routes (FK chain)
 ALL_TABLE_SUFFIXES = [
+    # Req #2380 validation registry — FK-safe drop order (leaves first).
+    # test_results → test_runs CASCADE; test_runs → test_plans RESTRICT;
+    # feature_test_cases/test_plan_cases CASCADE from both sides;
+    # test_results → test_cases RESTRICT (so test_results must drop before test_cases).
+    'test_results', 'test_runs',
+    'test_plan_cases', 'feature_test_cases',
+    'test_plans', 'test_cases', 'features',
     'user_integrations', 'map_run_partners', 'map_partners',
     'map_views', 'map_coordinates', 'map_runs', 'map_routes',
     'priority_card_order', 'dev_servers',
@@ -320,6 +363,10 @@ def test_migration_sequence_applies(db_connection, migration_test_prefix):
             'map_routes', 'map_runs', 'map_coordinates',
             'map_views', 'map_partners', 'map_run_partners',
             'user_integrations',
+            # Req #2380 — Swarm Features & Test Cases registry
+            'features', 'test_cases', 'feature_test_cases',
+            'test_plans', 'test_plan_cases',
+            'test_runs', 'test_results',
         ]
     }
     assert tables == expected_tables, \


### PR DESCRIPTION
## Summary
- feat: migrations 042/043/044 — features/test_cases/test_plans/test_runs/test_results (req #2380)
- chore: init swarm session feature/2380-swarm-validation-1

## Files changed
```
 migrations/042_add_features_testcases.sql |  73 ++++++++
 migrations/043_add_testplans.sql          |  46 +++++
 migrations/044_add_testruns.sql           |  64 +++++++
 schema.sql                                | 134 +++++++++++++-
 scripts/add-api-route.sh                  | 115 +++++++++---
 scripts/recreate_darwin_dev.sql           | 133 ++++++++++++-
 tests/conftest.py                         |  12 ++
 tests/test_cascades.py                    | 286 ++++++++++++++++++++++++++++
 tests/test_constraints.py                 | 297 ++++++++++++++++++++++++++++++
 tests/test_data_types.py                  | 245 +++++++++++++++++++++++-
 tests/test_migrations.py                  |  47 +++++
 11 files changed, 1420 insertions(+), 32 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)