### PR TITLE
req #2405

### DIFF
--- a/migrations/045_drop_requirements_sort_order.sql
+++ b/migrations/045_drop_requirements_sort_order.sql
@@ -1,0 +1,23 @@
+-- Drop the requirements.sort_order column.
+--
+-- The original swarm design let users drag-reorder requirements within a
+-- category card and addressed them by position (sort_order ASC) for
+-- /swarm-start. Subsequent UX work made requirement-# addressing the primary
+-- interaction, and position-based ordering became dead weight.
+--
+-- After this migration, all consumers that previously sorted requirements by
+-- sort_order sort by id ASC (requirement # / natural creation order):
+--   - darwin-mcp list_requirements   — ORDER BY id ASC
+--   - darwin-mcp get_swarm_launch_data — ORDER BY p.id ASC
+--   - Darwin UI processSort.js        — swarm_ready sorted by id
+--   - Darwin UI requirementSort.js    — siblingHandSort removed; id-tiebreak
+--   - scripts/swarm/sort-process.sh   — sort_key() uses id for swarm_ready
+--
+-- The categories.sort_order column (orders category CARDS) is a separate
+-- concept and is NOT touched by this migration.
+--
+-- Deploy sequence: Darwin frontend + darwin-mcp must deploy BEFORE this DDL
+-- runs on production. Stale callers sending `fields=...,sort_order,...` will
+-- get `Unknown column` errors otherwise. See req #2405 for full notes.
+
+ALTER TABLE requirements DROP COLUMN sort_order;

--- a/schema.sql
+++ b/schema.sql
@@ -148,7 +148,6 @@ CREATE TABLE IF NOT EXISTS requirements (
     project_fk      INT             NULL,
     category_fk     INT             NOT NULL,
     creator_fk      VARCHAR(64)     NOT NULL,
-    sort_order      SMALLINT        NULL,
     create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
     update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
     coordination_type VARCHAR(16)   NULL DEFAULT 'implemented',

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -151,7 +151,6 @@ CREATE TABLE requirements (
     project_fk      INT             NULL,
     category_fk     INT             NOT NULL,
     creator_fk      VARCHAR(64)     NOT NULL,
-    sort_order      SMALLINT        NULL,
     create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
     update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (project_fk)

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -374,7 +374,7 @@ def test_categories_columns(db_connection):
 def test_requirements_columns(db_connection):
     """Verify requirements column definitions match schema.sql.
 
-    Expected columns (post migration 039):
+    Expected columns (post migration 045 — sort_order dropped):
     - id: INT, PRI, AUTO_INCREMENT
     - title: VARCHAR(256), NOT NULL
     - description: TEXT, NULL
@@ -385,7 +385,6 @@ def test_requirements_columns(db_connection):
     - project_fk: INT, NULL, MUL
     - category_fk: INT, NULL, MUL
     - creator_fk: VARCHAR(64), NOT NULL, MUL
-    - sort_order: SMALLINT, NULL
     - create_ts: TIMESTAMP, NULL
     - update_ts: TIMESTAMP, NULL
     - coordination_type: VARCHAR(16), NULL, DEFAULT 'implemented'
@@ -396,7 +395,7 @@ def test_requirements_columns(db_connection):
 
     expected_fields = ['id', 'title', 'description', 'requirement_status',
                        'started_at', 'completed_at', 'deferred_at', 'project_fk', 'category_fk',
-                       'creator_fk', 'sort_order', 'create_ts', 'update_ts',
+                       'creator_fk', 'create_ts', 'update_ts',
                        'coordination_type']
     assert set(columns.keys()) == set(expected_fields)
 
@@ -434,9 +433,6 @@ def test_requirements_columns(db_connection):
     assert columns['creator_fk']['Type'] == 'varchar(64)'
     assert columns['creator_fk']['Null'] == 'NO'
     assert columns['creator_fk']['Key'] == 'MUL'
-
-    assert columns['sort_order']['Type'] == 'smallint'
-    assert columns['sort_order']['Null'] == 'YES'
 
     assert columns['coordination_type']['Type'] == 'varchar(16)'
     assert columns['coordination_type']['Null'] == 'YES'


### PR DESCRIPTION
## Summary
- wip(2405-DarwinSQL): drop requirements.sort_order migration 045
- chore: init swarm session feature/2405-remove-category-sort-concept-across-1

## Files changed
```
 migrations/045_drop_requirements_sort_order.sql | 23 +++++++++++++++++++++++
 schema.sql                                      |  1 -
 scripts/recreate_darwin_dev.sql                 |  1 -
 tests/test_data_types.py                        |  8 ++------
 4 files changed, 25 insertions(+), 8 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)