### PR TITLE
req #2417

### DIFF
--- a/migrations/046_add_requirements_sort_order_back.sql
+++ b/migrations/046_add_requirements_sort_order_back.sql
@@ -1,0 +1,29 @@
+-- Re-add the requirements.sort_order column (req #2417).
+--
+-- Migration 045 dropped this column on the rationale that requirement-#
+-- addressing had supplanted position-based addressing for /swarm-start. That
+-- was correct for /swarm-start, but it also disabled the "Hand Sort" menu
+-- option in the SwarmView category card — selecting Hand Sort persisted
+-- categories.sort_mode='hand' but the only consumer (RequirementRow's
+-- useDrag/useDrop) had been removed alongside the column, so dragging a row
+-- did nothing.
+--
+-- Req #2417 restores in-card hand-sort drag-and-drop. The column is added back
+-- with the same shape it had pre-045: SMALLINT NULL DEFAULT NULL. Existing
+-- rows stay NULL (no lazy-fill); the UI's requirementHandSort treats NULL as
+-- +infinity so id-order remains the visible default until the user explicitly
+-- drags a row, at which point CategoryCard bulk-PUTs the new sort_order
+-- values for every requirement in that category.
+--
+-- /swarm-start and the cross-implementation sort scripts (scripts/swarm/sort-
+-- process.sh, darwin-mcp get_swarm_launch_data, the MCP requirements
+-- resources, etc.) keep ORDER BY id ASC — none of them re-acquire a
+-- sort_order dependency. This column is **only** consumed by the SwarmView
+-- card's hand-sort path.
+--
+-- Deploy sequence: this DDL is safe to apply ahead of the Darwin frontend +
+-- Lambda-Rest changes (the column simply becomes available; nothing reads it
+-- until the new code ships). Lambda-Rest's PUT/POST handlers are generic over
+-- columns, so no Lambda redeploy is required for the column itself.
+
+ALTER TABLE requirements ADD COLUMN sort_order SMALLINT NULL DEFAULT NULL;

--- a/schema.sql
+++ b/schema.sql
@@ -152,6 +152,8 @@ CREATE TABLE IF NOT EXISTS requirements (
     update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
     coordination_type VARCHAR(16)   NULL DEFAULT 'implemented',
                                             -- planned | implemented | deployed (default: implemented)
+    sort_order      SMALLINT        NULL DEFAULT NULL,
+                                            -- in-card hand-sort position (req #2417); NULL = unranked, falls to id-order
     FOREIGN KEY (project_fk)
         REFERENCES projects (id)
         ON UPDATE CASCADE ON DELETE SET NULL,

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -374,7 +374,7 @@ def test_categories_columns(db_connection):
 def test_requirements_columns(db_connection):
     """Verify requirements column definitions match schema.sql.
 
-    Expected columns (post migration 045 — sort_order dropped):
+    Expected columns (migration 046 re-adds sort_order; req #2417):
     - id: INT, PRI, AUTO_INCREMENT
     - title: VARCHAR(256), NOT NULL
     - description: TEXT, NULL
@@ -388,6 +388,7 @@ def test_requirements_columns(db_connection):
     - create_ts: TIMESTAMP, NULL
     - update_ts: TIMESTAMP, NULL
     - coordination_type: VARCHAR(16), NULL, DEFAULT 'implemented'
+    - sort_order: SMALLINT, NULL, DEFAULT NULL  (req #2417 — in-card hand sort)
     """
     with db_connection.cursor() as cur:
         cur.execute("DESCRIBE requirements")
@@ -396,7 +397,7 @@ def test_requirements_columns(db_connection):
     expected_fields = ['id', 'title', 'description', 'requirement_status',
                        'started_at', 'completed_at', 'deferred_at', 'project_fk', 'category_fk',
                        'creator_fk', 'create_ts', 'update_ts',
-                       'coordination_type']
+                       'coordination_type', 'sort_order']
     assert set(columns.keys()) == set(expected_fields)
 
     assert columns['id']['Type'] == 'int'
@@ -437,6 +438,10 @@ def test_requirements_columns(db_connection):
     assert columns['coordination_type']['Type'] == 'varchar(16)'
     assert columns['coordination_type']['Null'] == 'YES'
     assert columns['coordination_type']['Default'] == 'implemented'
+
+    assert columns['sort_order']['Type'] == 'smallint'
+    assert columns['sort_order']['Null'] == 'YES'
+    assert columns['sort_order']['Default'] is None
 
 
 def test_swarm_sessions_columns(db_connection):


### PR DESCRIPTION
## Summary
- wip(2417-DarwinSQL): final save before swarm-complete
- chore: init swarm session feature/2417-hand-sort-is-broken-1

## Files changed
```
 .../046_add_requirements_sort_order_back.sql       | 29 ++++++++++++++++++++++
 schema.sql                                         |  2 ++
 tests/test_data_types.py                           |  9 +++++--
 3 files changed, 38 insertions(+), 2 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)