### PR TITLE
req #2422

### DIFF
--- a/migrations/046_add_swarm_starts.sql
+++ b/migrations/046_add_swarm_starts.sql
@@ -1,0 +1,67 @@
+-- 046_add_swarm_starts.sql
+--
+-- Req #2422: define a swarm-start data type. Each /swarm-start invocation
+-- creates one swarm_starts row capturing the launch metadata + finalize-time
+-- summary, then links every swarm_session it creates via the
+-- swarm_start_sessions junction.
+--
+-- swarm_starts          - execution table per memory/new-data-type-pattern.md.
+--                         No closed flag (instantaneous event), no sort_order
+--                         (chronological by started_at), no category_fk (a
+--                         single launch can span categories), no title (the
+--                         arguments string serves as the label).
+-- swarm_start_sessions  - junction table. Composite PK on the two FKs.
+--                         CASCADE on both sides. Mirrors requirement_sessions.
+--
+-- Captured columns:
+--   arguments       - raw $ARGUMENTS the user typed; "" stored as NULL.
+--   autonomy_filter - planned|implemented|deployed when used (req #2339); NULL otherwise.
+--   auto_start      - 1 when A3 confirmation was bypassed (req #2415).
+--   session_count   - # swarm_sessions created by this invocation.
+--
+-- Finalize-time columns (NULL until skill-finalize writes them):
+--   tokens_input        - skill_total.input from telemetry JSON
+--   tokens_cache_write  - skill_total.cache_write
+--   tokens_cache_read   - skill_total.cache_read
+--   tokens_output       - skill_total.output
+--   wall_seconds        - skill_total.wall_seconds (native value, no transform)
+--   turn_count          - skill_total.turn_count
+--   start_summary       - markdown summary block emitted by the skill at end-of-run
+--   telemetry           - full telemetry text (iterm + per-phase TOKEN_TELEMETRY JSON)
+
+CREATE TABLE swarm_starts (
+    id                INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    arguments         VARCHAR(512)    NULL,
+    autonomy_filter   VARCHAR(16)     NULL,
+    auto_start        TINYINT(1)      NOT NULL DEFAULT 0,
+    session_count     INT             NOT NULL DEFAULT 0,
+    -- Finalize-time token totals (skill_total from telemetry JSON)
+    tokens_input        INT           NULL,
+    tokens_cache_write  INT           NULL,
+    tokens_cache_read   INT           NULL,
+    tokens_output       INT           NULL,
+    wall_seconds        INT           NULL,
+    turn_count          INT           NULL,
+    -- Finalize-time summary and full telemetry blob
+    start_summary       TEXT          NULL,
+    telemetry           TEXT          NULL,
+    started_at        TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    creator_fk        VARCHAR(64)     NOT NULL,
+    create_ts         TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts         TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_swarm_starts_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE swarm_start_sessions (
+    swarm_start_fk  INT             NOT NULL,
+    session_fk      INT             NOT NULL,
+    PRIMARY KEY (swarm_start_fk, session_fk),
+    CONSTRAINT fk_sss_swarm_start
+        FOREIGN KEY (swarm_start_fk) REFERENCES swarm_starts (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_sss_session
+        FOREIGN KEY (session_fk) REFERENCES swarm_sessions (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);

--- a/schema.sql
+++ b/schema.sql
@@ -1,6 +1,6 @@
 -- Darwin Database Schema — Current State
 -- Database: darwin
--- This file reflects the final state of all 25 tables after all migrations.
+-- This file reflects the final state of all 27 tables after all migrations.
 -- It can be run against a fresh MySQL instance to create the complete schema.
 -- Table order respects FK dependencies.
 
@@ -201,6 +201,46 @@ CREATE TABLE IF NOT EXISTS requirement_sessions (
         ON UPDATE CASCADE ON DELETE CASCADE,
     FOREIGN KEY (session_fk)
         REFERENCES swarm_sessions (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+-- swarm_starts: one row per /swarm-start invocation. Execution table — no
+-- closed flag, no sort_order (chronological by started_at), no category_fk
+-- (a launch can span categories), no title (arguments string is the label).
+-- Token / wall / turn / summary / telemetry columns are NULL until skill-finalize
+-- captures them at end-of-run; populated via update_swarm_start.
+CREATE TABLE IF NOT EXISTS swarm_starts (
+    id                  INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    arguments           VARCHAR(512)    NULL,
+    autonomy_filter     VARCHAR(16)     NULL,
+    auto_start          TINYINT(1)      NOT NULL DEFAULT 0,
+    session_count       INT             NOT NULL DEFAULT 0,
+    tokens_input        INT             NULL,
+    tokens_cache_write  INT             NULL,
+    tokens_cache_read   INT             NULL,
+    tokens_output       INT             NULL,
+    wall_seconds        INT             NULL,
+    turn_count          INT             NULL,
+    start_summary       TEXT            NULL,
+    telemetry           TEXT            NULL,
+    started_at          TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    creator_fk          VARCHAR(64)     NOT NULL,
+    create_ts           TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts           TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_swarm_starts_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS swarm_start_sessions (
+    swarm_start_fk  INT             NOT NULL,
+    session_fk      INT             NOT NULL,
+    PRIMARY KEY (swarm_start_fk, session_fk),
+    CONSTRAINT fk_sss_swarm_start
+        FOREIGN KEY (swarm_start_fk) REFERENCES swarm_starts (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_sss_session
+        FOREIGN KEY (session_fk) REFERENCES swarm_sessions (id)
         ON UPDATE CASCADE ON DELETE CASCADE
 );
 

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -1,7 +1,7 @@
 -- Recreate darwin_dev test/dev tables from scratch
 -- Uses production-identical table names (same DDL as schema.sql)
 -- Idempotent: safe to run repeatedly to reset darwin_dev to canonical state
--- All 25 tables in FK-dependency order
+-- All 27 tables in FK-dependency order
 
 USE darwin_dev;
 
@@ -10,7 +10,9 @@ DROP TABLE IF EXISTS test_results, test_runs, test_plan_cases, test_plans,
     feature_test_cases, test_cases, features,
     map_run_partners, map_partners,
     map_views, map_coordinates, map_runs, map_routes,
-    priority_card_order, dev_servers, requirement_sessions,
+    priority_card_order, dev_servers,
+    swarm_start_sessions, swarm_starts,
+    requirement_sessions,
     requirements, swarm_sessions, categories, projects,
     tasks, recurring_tasks, areas, domains, profiles;
 SET FOREIGN_KEY_CHECKS = 1;
@@ -200,6 +202,41 @@ CREATE TABLE requirement_sessions (
         ON UPDATE CASCADE ON DELETE CASCADE,
     FOREIGN KEY (session_fk)
         REFERENCES swarm_sessions (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE swarm_starts (
+    id                  INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    arguments           VARCHAR(512)    NULL,
+    autonomy_filter     VARCHAR(16)     NULL,
+    auto_start          TINYINT(1)      NOT NULL DEFAULT 0,
+    session_count       INT             NOT NULL DEFAULT 0,
+    tokens_input        INT             NULL,
+    tokens_cache_write  INT             NULL,
+    tokens_cache_read   INT             NULL,
+    tokens_output       INT             NULL,
+    wall_seconds        INT             NULL,
+    turn_count          INT             NULL,
+    start_summary       TEXT            NULL,
+    telemetry           TEXT            NULL,
+    started_at          TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    creator_fk          VARCHAR(64)     NOT NULL,
+    create_ts           TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts           TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_swarm_starts_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE swarm_start_sessions (
+    swarm_start_fk  INT             NOT NULL,
+    session_fk      INT             NOT NULL,
+    PRIMARY KEY (swarm_start_fk, session_fk),
+    CONSTRAINT fk_sss_swarm_start
+        FOREIGN KEY (swarm_start_fk) REFERENCES swarm_starts (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_sss_session
+        FOREIGN KEY (session_fk) REFERENCES swarm_sessions (id)
         ON UPDATE CASCADE ON DELETE CASCADE
 );
 

--- a/tests/test_cascades.py
+++ b/tests/test_cascades.py
@@ -539,6 +539,95 @@ def test_delete_swarm_session_cascades_to_requirement_sessions(db_connection, te
     db_connection.rollback()
 
 
+def test_delete_swarm_start_cascades_to_swarm_start_sessions(db_connection):
+    """DELETE swarm_start → associated swarm_start_sessions rows are deleted.
+    The linked swarm_session itself survives."""
+    test_creator = 'cascade-test-swarm-start-1'
+
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO profiles (id, name, email) "
+            "VALUES (%s, %s, %s)",
+            (test_creator, 'Cascade Test Profile', 'cascade@test.com')
+        )
+        cur.execute(
+            "INSERT INTO swarm_starts (arguments, creator_fk) VALUES (%s, %s)",
+            ('swarm 1 2', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        swarm_start_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO swarm_sessions (swarm_status, creator_fk) VALUES (%s, %s)",
+            ('active', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        session_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO swarm_start_sessions (swarm_start_fk, session_fk) VALUES (%s, %s)",
+            (swarm_start_id, session_id)
+        )
+
+        cur.execute("DELETE FROM swarm_starts WHERE id = %s", (swarm_start_id,))
+
+        cur.execute(
+            "SELECT * FROM swarm_start_sessions WHERE swarm_start_fk = %s",
+            (swarm_start_id,)
+        )
+        assert cur.fetchone() is None
+
+        # Linked swarm_session itself survives
+        cur.execute("SELECT id FROM swarm_sessions WHERE id = %s", (session_id,))
+        assert cur.fetchone() is not None
+
+    db_connection.rollback()
+
+
+def test_delete_swarm_session_cascades_to_swarm_start_sessions(db_connection):
+    """DELETE swarm_session → linked swarm_start_sessions rows are deleted.
+    The parent swarm_start row survives."""
+    test_creator = 'cascade-test-swarm-start-2'
+
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO profiles (id, name, email) "
+            "VALUES (%s, %s, %s)",
+            (test_creator, 'Cascade Test Profile', 'cascade@test.com')
+        )
+        cur.execute(
+            "INSERT INTO swarm_starts (arguments, creator_fk) VALUES (%s, %s)",
+            ('swarm', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        swarm_start_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO swarm_sessions (swarm_status, creator_fk) VALUES (%s, %s)",
+            ('active', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        session_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO swarm_start_sessions (swarm_start_fk, session_fk) VALUES (%s, %s)",
+            (swarm_start_id, session_id)
+        )
+
+        cur.execute("DELETE FROM swarm_sessions WHERE id = %s", (session_id,))
+
+        cur.execute(
+            "SELECT * FROM swarm_start_sessions WHERE session_fk = %s",
+            (session_id,)
+        )
+        assert cur.fetchone() is None
+
+        cur.execute("SELECT id FROM swarm_starts WHERE id = %s", (swarm_start_id,))
+        assert cur.fetchone() is not None
+
+    db_connection.rollback()
+
+
 def test_delete_profile_cascades_to_roadmap_tables(db_connection, test_category_id):
     """DELETE profile → cascades through projects→categories, requirements, swarm_sessions.
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -426,6 +426,29 @@ def test_swarm_session_fk_invalid_creator(db_connection):
     db_connection.rollback()
 
 
+def test_swarm_start_fk_invalid_creator(db_connection):
+    """INSERT swarm_start with non-existent creator_fk → IntegrityError"""
+    with db_connection.cursor() as cur:
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO swarm_starts (creator_fk) VALUES (%s)",
+                ('nonexistent-profile-id',)
+            )
+    db_connection.rollback()
+
+
+def test_swarm_start_session_fk_invalid_swarm_start(db_connection):
+    """INSERT swarm_start_session with non-existent swarm_start_fk → IntegrityError"""
+    with db_connection.cursor() as cur:
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO swarm_start_sessions (swarm_start_fk, session_fk) "
+                "VALUES (%s, %s)",
+                (999999, 999999)
+            )
+    db_connection.rollback()
+
+
 # ---------------------------------------------------------------------------
 # Roadmap table NOT NULL tests
 # ---------------------------------------------------------------------------

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -542,6 +542,97 @@ def test_requirement_sessions_columns(db_connection):
     assert columns['session_fk']['Key'] == 'PRI'
 
 
+def test_swarm_starts_columns(db_connection):
+    """Verify swarm_starts column definitions match migration 046.
+
+    Expected columns:
+    - id: INT, PRI, AUTO_INCREMENT
+    - arguments: VARCHAR(512), NULL
+    - autonomy_filter: VARCHAR(16), NULL
+    - auto_start: TINYINT(1), NOT NULL, DEFAULT 0
+    - session_count: INT, NOT NULL, DEFAULT 0
+    - tokens_input / tokens_cache_write / tokens_cache_read / tokens_output: INT, NULL
+    - wall_seconds: INT, NULL
+    - turn_count: INT, NULL
+    - start_summary: TEXT, NULL
+    - telemetry: TEXT, NULL
+    - started_at: TIMESTAMP, NOT NULL, DEFAULT CURRENT_TIMESTAMP
+    - creator_fk: VARCHAR(64), NOT NULL, MUL
+    - create_ts / update_ts: TIMESTAMP, NULL
+    """
+    with db_connection.cursor() as cur:
+        cur.execute("DESCRIBE swarm_starts")
+        columns = {row['Field']: row for row in cur.fetchall()}
+
+    expected_fields = ['id', 'arguments', 'autonomy_filter',
+                       'auto_start', 'session_count',
+                       'tokens_input', 'tokens_cache_write', 'tokens_cache_read',
+                       'tokens_output', 'wall_seconds', 'turn_count',
+                       'start_summary', 'telemetry',
+                       'started_at', 'creator_fk', 'create_ts', 'update_ts']
+    assert set(columns.keys()) == set(expected_fields)
+
+    assert columns['id']['Type'] == 'int'
+    assert columns['id']['Key'] == 'PRI'
+    assert columns['id']['Extra'] == 'auto_increment'
+
+    assert columns['arguments']['Type'] == 'varchar(512)'
+    assert columns['arguments']['Null'] == 'YES'
+
+    assert columns['autonomy_filter']['Type'] == 'varchar(16)'
+    assert columns['autonomy_filter']['Null'] == 'YES'
+
+    assert columns['auto_start']['Type'] == 'tinyint(1)'
+    assert columns['auto_start']['Null'] == 'NO'
+    assert columns['auto_start']['Default'] == '0'
+
+    assert columns['session_count']['Type'] == 'int'
+    assert columns['session_count']['Null'] == 'NO'
+    assert columns['session_count']['Default'] == '0'
+
+    # Token / timing / count columns are NULL until skill-finalize populates them.
+    for col in ('tokens_input', 'tokens_cache_write', 'tokens_cache_read',
+                'tokens_output', 'wall_seconds', 'turn_count'):
+        assert columns[col]['Type'] == 'int', col
+        assert columns[col]['Null'] == 'YES', col
+
+    assert columns['start_summary']['Type'] == 'text'
+    assert columns['start_summary']['Null'] == 'YES'
+
+    assert columns['telemetry']['Type'] == 'text'
+    assert columns['telemetry']['Null'] == 'YES'
+
+    assert 'timestamp' in columns['started_at']['Type']
+    assert columns['started_at']['Null'] == 'NO'
+
+    assert columns['creator_fk']['Type'] == 'varchar(64)'
+    assert columns['creator_fk']['Null'] == 'NO'
+    assert columns['creator_fk']['Key'] == 'MUL'
+
+
+def test_swarm_start_sessions_columns(db_connection):
+    """Verify swarm_start_sessions junction table column definitions.
+
+    Expected columns:
+    - swarm_start_fk: INT, PRI, NOT NULL
+    - session_fk: INT, PRI, NOT NULL
+    """
+    with db_connection.cursor() as cur:
+        cur.execute("DESCRIBE swarm_start_sessions")
+        columns = {row['Field']: row for row in cur.fetchall()}
+
+    expected_fields = ['swarm_start_fk', 'session_fk']
+    assert set(columns.keys()) == set(expected_fields)
+
+    assert columns['swarm_start_fk']['Type'] == 'int'
+    assert columns['swarm_start_fk']['Null'] == 'NO'
+    assert columns['swarm_start_fk']['Key'] == 'PRI'
+
+    assert columns['session_fk']['Type'] == 'int'
+    assert columns['session_fk']['Null'] == 'NO'
+    assert columns['session_fk']['Key'] == 'PRI'
+
+
 def test_dev_servers_columns(db_connection):
     """Verify dev_servers column definitions match schema.sql.
 
@@ -1204,7 +1295,7 @@ def test_test_results_columns(db_connection):
 
 
 def test_table_count(db_connection):
-    """Verify darwin_dev database contains all 25 expected tables."""
+    """Verify darwin_dev database contains all 27 expected tables."""
     with db_connection.cursor() as cur:
         cur.execute("SHOW TABLES")
         tables = {row['Tables_in_darwin_dev'] for row in cur.fetchall()}
@@ -1219,6 +1310,8 @@ def test_table_count(db_connection):
         'features', 'test_cases', 'feature_test_cases',
         'test_plans', 'test_plan_cases',
         'test_runs', 'test_results',
+        # Req #2422 — swarm-start data type
+        'swarm_starts', 'swarm_start_sessions',
     }
     assert expected_tables == tables, \
         f"Unexpected tables: {tables - expected_tables}, missing: {expected_tables - tables}"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -71,6 +71,10 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         'test_runs',
         'features',
         'user_integrations',
+        # Req #2422 — swarm_start_sessions before swarm_starts so the longer
+        # match wins under the longest-first replace order.
+        'swarm_start_sessions',
+        'swarm_starts',
         'requirement_sessions',
         'priority_sessions',     # pre-038 name (for RENAME TABLE in migration 038)
         'priority_card_order',
@@ -129,6 +133,9 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         'fk_test_runs_plan', 'fk_test_runs_creator',
         'fk_test_results_run', 'fk_test_results_case', 'fk_test_results_creator',
         'uq_run_case',
+        # Migration 046
+        'fk_swarm_starts_creator',
+        'fk_sss_swarm_start', 'fk_sss_session',
     ]
     for cname in named_constraints:
         sql = sql.replace(cname, f'{table_prefix}_{cname}')
@@ -216,6 +223,8 @@ ALL_TABLE_SUFFIXES = [
     'user_integrations', 'map_run_partners', 'map_partners',
     'map_views', 'map_coordinates', 'map_runs', 'map_routes',
     'priority_card_order', 'dev_servers',
+    # Req #2422 — junction first, then parent (FK-safe drop order).
+    'swarm_start_sessions', 'swarm_starts',
     'requirement_sessions', 'priority_sessions',  # pre-038 name
     'requirements', 'priorities',                  # pre-038 name
     'swarm_sessions', 'categories', 'projects',
@@ -367,6 +376,8 @@ def test_migration_sequence_applies(db_connection, migration_test_prefix):
             'features', 'test_cases', 'feature_test_cases',
             'test_plans', 'test_plan_cases',
             'test_runs', 'test_results',
+            # Req #2422 — swarm-start data type
+            'swarm_starts', 'swarm_start_sessions',
         ]
     }
     assert tables == expected_tables, \


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-05-07T00:10:01Z
- wip(DarwinSQL): 2026-05-07T00:09:27Z
- chore: init swarm session feature/2422-swarm-start-data-type-1

## Files changed
```
 migrations/046_add_swarm_starts.sql | 67 ++++++++++++++++++++++++++
 schema.sql                          | 42 ++++++++++++++++-
 scripts/recreate_darwin_dev.sql     | 41 +++++++++++++++-
 tests/test_cascades.py              | 89 +++++++++++++++++++++++++++++++++++
 tests/test_constraints.py           | 23 +++++++++
 tests/test_data_types.py            | 93 +++++++++++++++++++++++++++++++++++++
 tests/test_migrations.py            | 11 +++++
 7 files changed, 363 insertions(+), 3 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)