### PR TITLE
req #2497

### DIFF
--- a/migrations/048_add_swarm_completes.sql
+++ b/migrations/048_add_swarm_completes.sql
@@ -1,0 +1,79 @@
+-- 048_add_swarm_completes.sql
+--
+-- Req #2497: define a swarm-complete data type. Each /swarm-complete (and
+-- /primary-ai-swarm-complete) invocation creates one swarm_completes row
+-- capturing the closeout metadata + finalize-time summary, then links every
+-- swarm_session it closed via the swarm_complete_sessions junction.
+--
+-- Parallels req #2422's swarm_starts table — same execution-table shape per
+-- memory/new-data-type-pattern.md (no closed flag, no sort_order, no title,
+-- no category_fk). The closeout side deviates from the launch side in
+-- exactly six fields (see CLAUDE.md / memory/swarm-completes.md):
+--   skill_name        which closeout skill ran (swarm-start has only one)
+--   coordination_type planned|implemented|deployed (NULL for primary-ai)
+--   status            in_progress|ok|error (closeout can fail mid-flight)
+--   completed_at      finalize timestamp (launch is instantaneous)
+--   complete_summary  mirrors the swarm_sessions.complete_summary column
+--   no auto_start     closeout has no A3-style confirmation gate
+--
+-- swarm_completes          execution table.
+-- swarm_complete_sessions  junction table. Composite PK on the two FKs.
+--                          CASCADE on both sides. Mirrors swarm_start_sessions.
+--
+-- Captured at create time (when swarm-complete-record.sh fires):
+--   skill_name         swarm-complete | primary-ai-swarm-complete
+--   arguments          raw $ARGUMENTS the user typed; "" stored as NULL
+--   coordination_type  from the worker manifest (planned|implemented|deployed);
+--                      NULL for /primary-ai-swarm-complete (primary has no manifest)
+--   status             defaults to 'in_progress'; finalize writes 'ok' or 'error'
+--   session_count      # swarm_sessions being closed (1 in the typical case)
+--
+-- Finalize-time columns (NULL at create; populated by the skill's finalize step):
+--   tokens_input        skill_total.input from telemetry JSON
+--   tokens_cache_write  skill_total.cache_write
+--   tokens_cache_read   skill_total.cache_read
+--   tokens_output       skill_total.output
+--   wall_seconds        skill_total.wall_seconds (native value, no transform)
+--   turn_count          skill_total.turn_count
+--   complete_summary    markdown summary block emitted by the skill at end-of-run
+--   telemetry           full telemetry text (iterm + per-phase TOKEN_TELEMETRY JSON)
+--   completed_at        ISO timestamp when finalize wrote (server-side NOW())
+
+CREATE TABLE swarm_completes (
+    id                  INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    skill_name          VARCHAR(64)     NOT NULL,
+    arguments           VARCHAR(512)    NULL,
+    coordination_type   VARCHAR(16)     NULL,
+    status              VARCHAR(16)     NOT NULL DEFAULT 'in_progress',
+    session_count       INT             NOT NULL DEFAULT 0,
+    -- Finalize-time token totals (skill_total from telemetry JSON)
+    tokens_input        INT             NULL,
+    tokens_cache_write  INT             NULL,
+    tokens_cache_read   INT             NULL,
+    tokens_output       INT             NULL,
+    wall_seconds        INT             NULL,
+    turn_count          INT             NULL,
+    -- Finalize-time summary and full telemetry blob
+    complete_summary    TEXT            NULL,
+    telemetry           TEXT            NULL,
+    started_at          TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at        TIMESTAMP       NULL,
+    creator_fk          VARCHAR(64)     NOT NULL,
+    create_ts           TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts           TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_swarm_completes_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE swarm_complete_sessions (
+    swarm_complete_fk   INT             NOT NULL,
+    session_fk          INT             NOT NULL,
+    PRIMARY KEY (swarm_complete_fk, session_fk),
+    CONSTRAINT fk_scs_swarm_complete
+        FOREIGN KEY (swarm_complete_fk) REFERENCES swarm_completes (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_scs_session
+        FOREIGN KEY (session_fk) REFERENCES swarm_sessions (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);

--- a/migrations/058_add_swarm_completes.sql
+++ b/migrations/058_add_swarm_completes.sql
@@ -1,4 +1,4 @@
--- 048_add_swarm_completes.sql
+-- 058_add_swarm_completes.sql
 --
 -- Req #2497: define a swarm-complete data type. Each /swarm-complete (and
 -- /primary-ai-swarm-complete) invocation creates one swarm_completes row
@@ -10,7 +10,7 @@
 -- no category_fk). The closeout side deviates from the launch side in
 -- exactly six fields (see CLAUDE.md / memory/swarm-completes.md):
 --   skill_name        which closeout skill ran (swarm-start has only one)
---   coordination_type planned|implemented|deployed (NULL for primary-ai)
+--   coordination_type discuss|planned|implemented|deployed (NULL for primary-ai)
 --   status            in_progress|ok|error (closeout can fail mid-flight)
 --   completed_at      finalize timestamp (launch is instantaneous)
 --   complete_summary  mirrors the swarm_sessions.complete_summary column
@@ -22,7 +22,6 @@
 --
 -- Captured at create time (when swarm-complete-record.sh fires):
 --   skill_name         swarm-complete | primary-ai-swarm-complete
---   arguments          raw $ARGUMENTS the user typed; "" stored as NULL
 --   coordination_type  from the worker manifest (planned|implemented|deployed);
 --                      NULL for /primary-ai-swarm-complete (primary has no manifest)
 --   status             defaults to 'in_progress'; finalize writes 'ok' or 'error'
@@ -42,7 +41,6 @@
 CREATE TABLE swarm_completes (
     id                  INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
     skill_name          VARCHAR(64)     NOT NULL,
-    arguments           VARCHAR(512)    NULL,
     coordination_type   VARCHAR(16)     NULL,
     status              VARCHAR(16)     NOT NULL DEFAULT 'in_progress',
     session_count       INT             NOT NULL DEFAULT 0,

--- a/schema.sql
+++ b/schema.sql
@@ -246,6 +246,51 @@ CREATE TABLE IF NOT EXISTS swarm_start_sessions (
         ON UPDATE CASCADE ON DELETE CASCADE
 );
 
+-- swarm_completes: one row per /swarm-complete or /primary-ai-swarm-complete
+-- invocation. Parallels swarm_starts (req #2422). Differences: skill_name
+-- discriminates which closeout ran, coordination_type captures the manifest
+-- value (NULL for primary), status tracks in_progress/ok/error, completed_at
+-- records the finalize time. complete_summary mirrors the swarm_sessions
+-- column name. Token / wall / turn / summary / telemetry columns are NULL
+-- until the skill's finalize step writes them via update_swarm_complete.
+-- Migration 048, req #2497.
+CREATE TABLE IF NOT EXISTS swarm_completes (
+    id                  INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    skill_name          VARCHAR(64)     NOT NULL,
+    arguments           VARCHAR(512)    NULL,
+    coordination_type   VARCHAR(16)     NULL,
+    status              VARCHAR(16)     NOT NULL DEFAULT 'in_progress',
+    session_count       INT             NOT NULL DEFAULT 0,
+    tokens_input        INT             NULL,
+    tokens_cache_write  INT             NULL,
+    tokens_cache_read   INT             NULL,
+    tokens_output       INT             NULL,
+    wall_seconds        INT             NULL,
+    turn_count          INT             NULL,
+    complete_summary    TEXT            NULL,
+    telemetry           TEXT            NULL,
+    started_at          TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at        TIMESTAMP       NULL,
+    creator_fk          VARCHAR(64)     NOT NULL,
+    create_ts           TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts           TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_swarm_completes_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS swarm_complete_sessions (
+    swarm_complete_fk   INT             NOT NULL,
+    session_fk          INT             NOT NULL,
+    PRIMARY KEY (swarm_complete_fk, session_fk),
+    CONSTRAINT fk_scs_swarm_complete
+        FOREIGN KEY (swarm_complete_fk) REFERENCES swarm_completes (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_scs_session
+        FOREIGN KEY (session_fk) REFERENCES swarm_sessions (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
 -- ============================================================================
 -- Dev server port coordination
 -- ============================================================================

--- a/schema.sql
+++ b/schema.sql
@@ -250,6 +250,51 @@ CREATE TABLE IF NOT EXISTS swarm_start_sessions (
         ON UPDATE CASCADE ON DELETE CASCADE
 );
 
+-- swarm_completes: one row per /swarm-complete or /primary-ai-swarm-complete
+-- invocation (req #2497). The close-out counterpart to swarm_starts (migration
+-- 046). Execution table — no closed flag, no sort_order (chronological by
+-- completed_at), no category_fk, no title. Deviates from the launch side in six
+-- fields: skill_name (which closeout ran), coordination_type (NULL for primary),
+-- status (in_progress|ok|error), completed_at (finalize timestamp), and
+-- complete_summary (mirrors swarm_sessions.complete_summary). Token / wall / turn
+-- / summary / telemetry columns are NULL until the skill's finalize step writes
+-- them via update_swarm_complete.
+CREATE TABLE IF NOT EXISTS swarm_completes (
+    id                  INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    skill_name          VARCHAR(64)     NOT NULL,
+    coordination_type   VARCHAR(16)     NULL,
+    status              VARCHAR(16)     NOT NULL DEFAULT 'in_progress',
+    session_count       INT             NOT NULL DEFAULT 0,
+    tokens_input        INT             NULL,
+    tokens_cache_write  INT             NULL,
+    tokens_cache_read   INT             NULL,
+    tokens_output       INT             NULL,
+    wall_seconds        INT             NULL,
+    turn_count          INT             NULL,
+    complete_summary    TEXT            NULL,
+    telemetry           TEXT            NULL,
+    started_at          TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at        TIMESTAMP       NULL,
+    creator_fk          VARCHAR(64)     NOT NULL,
+    create_ts           TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts           TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_swarm_completes_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS swarm_complete_sessions (
+    swarm_complete_fk   INT             NOT NULL,
+    session_fk          INT             NOT NULL,
+    PRIMARY KEY (swarm_complete_fk, session_fk),
+    CONSTRAINT fk_scs_swarm_complete
+        FOREIGN KEY (swarm_complete_fk) REFERENCES swarm_completes (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_scs_session
+        FOREIGN KEY (session_fk) REFERENCES swarm_sessions (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
 -- swarm_undos: one row per /swarm-undo invocation. Execution table — no
 -- closed flag, no sort_order (chronological by undone_at), no category_fk
 -- (inherits from the session/requirement being undone). Captures a mandatory

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -253,6 +253,42 @@ CREATE TABLE swarm_start_sessions (
         ON UPDATE CASCADE ON DELETE CASCADE
 );
 
+CREATE TABLE swarm_completes (
+    id                  INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    skill_name          VARCHAR(64)     NOT NULL,
+    coordination_type   VARCHAR(16)     NULL,
+    status              VARCHAR(16)     NOT NULL DEFAULT 'in_progress',
+    session_count       INT             NOT NULL DEFAULT 0,
+    tokens_input        INT             NULL,
+    tokens_cache_write  INT             NULL,
+    tokens_cache_read   INT             NULL,
+    tokens_output       INT             NULL,
+    wall_seconds        INT             NULL,
+    turn_count          INT             NULL,
+    complete_summary    TEXT            NULL,
+    telemetry           TEXT            NULL,
+    started_at          TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at        TIMESTAMP       NULL,
+    creator_fk          VARCHAR(64)     NOT NULL,
+    create_ts           TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts           TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_swarm_completes_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE swarm_complete_sessions (
+    swarm_complete_fk   INT             NOT NULL,
+    session_fk          INT             NOT NULL,
+    PRIMARY KEY (swarm_complete_fk, session_fk),
+    CONSTRAINT fk_scs_swarm_complete
+        FOREIGN KEY (swarm_complete_fk) REFERENCES swarm_completes (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_scs_session
+        FOREIGN KEY (session_fk) REFERENCES swarm_sessions (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
 CREATE TABLE swarm_undos (
     id                       INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
     session_fk               INT             NULL,

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -1,7 +1,7 @@
 -- Recreate darwin_dev test/dev tables from scratch
 -- Uses production-identical table names (same DDL as schema.sql)
 -- Idempotent: safe to run repeatedly to reset darwin_dev to canonical state
--- All 27 tables in FK-dependency order
+-- All 29 tables in FK-dependency order
 
 USE darwin_dev;
 
@@ -11,6 +11,7 @@ DROP TABLE IF EXISTS test_results, test_runs, test_plan_cases, test_plans,
     map_run_partners, map_partners,
     map_views, map_coordinates, map_runs, map_routes,
     priority_card_order, dev_servers,
+    swarm_complete_sessions, swarm_completes,
     swarm_start_sessions, swarm_starts,
     requirement_sessions,
     requirements, swarm_sessions, categories, projects,
@@ -236,6 +237,43 @@ CREATE TABLE swarm_start_sessions (
         FOREIGN KEY (swarm_start_fk) REFERENCES swarm_starts (id)
         ON UPDATE CASCADE ON DELETE CASCADE,
     CONSTRAINT fk_sss_session
+        FOREIGN KEY (session_fk) REFERENCES swarm_sessions (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE swarm_completes (
+    id                  INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    skill_name          VARCHAR(64)     NOT NULL,
+    arguments           VARCHAR(512)    NULL,
+    coordination_type   VARCHAR(16)     NULL,
+    status              VARCHAR(16)     NOT NULL DEFAULT 'in_progress',
+    session_count       INT             NOT NULL DEFAULT 0,
+    tokens_input        INT             NULL,
+    tokens_cache_write  INT             NULL,
+    tokens_cache_read   INT             NULL,
+    tokens_output       INT             NULL,
+    wall_seconds        INT             NULL,
+    turn_count          INT             NULL,
+    complete_summary    TEXT            NULL,
+    telemetry           TEXT            NULL,
+    started_at          TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at        TIMESTAMP       NULL,
+    creator_fk          VARCHAR(64)     NOT NULL,
+    create_ts           TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts           TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_swarm_completes_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE swarm_complete_sessions (
+    swarm_complete_fk   INT             NOT NULL,
+    session_fk          INT             NOT NULL,
+    PRIMARY KEY (swarm_complete_fk, session_fk),
+    CONSTRAINT fk_scs_swarm_complete
+        FOREIGN KEY (swarm_complete_fk) REFERENCES swarm_completes (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_scs_session
         FOREIGN KEY (session_fk) REFERENCES swarm_sessions (id)
         ON UPDATE CASCADE ON DELETE CASCADE
 );

--- a/tests/test_cascades.py
+++ b/tests/test_cascades.py
@@ -628,6 +628,97 @@ def test_delete_swarm_session_cascades_to_swarm_start_sessions(db_connection):
     db_connection.rollback()
 
 
+def test_delete_swarm_complete_cascades_to_swarm_complete_sessions(db_connection):
+    """DELETE swarm_complete → linked swarm_complete_sessions junction rows are
+    deleted via fk_scs_swarm_complete CASCADE (req #2497, migration 048).
+    The linked swarm_session itself survives."""
+    test_creator = 'cascade-test-swarm-complete-1'
+
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO profiles (id, name, email) "
+            "VALUES (%s, %s, %s)",
+            (test_creator, 'Cascade Test Profile', 'cascade@test.com')
+        )
+        cur.execute(
+            "INSERT INTO swarm_completes (skill_name, creator_fk) VALUES (%s, %s)",
+            ('swarm-complete', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        swarm_complete_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO swarm_sessions (swarm_status, creator_fk) VALUES (%s, %s)",
+            ('active', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        session_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO swarm_complete_sessions (swarm_complete_fk, session_fk) VALUES (%s, %s)",
+            (swarm_complete_id, session_id)
+        )
+
+        cur.execute("DELETE FROM swarm_completes WHERE id = %s", (swarm_complete_id,))
+
+        cur.execute(
+            "SELECT * FROM swarm_complete_sessions WHERE swarm_complete_fk = %s",
+            (swarm_complete_id,)
+        )
+        assert cur.fetchone() is None
+
+        # Linked swarm_session itself survives
+        cur.execute("SELECT id FROM swarm_sessions WHERE id = %s", (session_id,))
+        assert cur.fetchone() is not None
+
+    db_connection.rollback()
+
+
+def test_delete_swarm_session_cascades_to_swarm_complete_sessions(db_connection):
+    """DELETE swarm_session → linked swarm_complete_sessions junction rows are
+    deleted via fk_scs_session CASCADE (req #2497).
+    The parent swarm_complete row survives."""
+    test_creator = 'cascade-test-swarm-complete-2'
+
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO profiles (id, name, email) "
+            "VALUES (%s, %s, %s)",
+            (test_creator, 'Cascade Test Profile', 'cascade@test.com')
+        )
+        cur.execute(
+            "INSERT INTO swarm_completes (skill_name, creator_fk) VALUES (%s, %s)",
+            ('primary-ai-swarm-complete', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        swarm_complete_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO swarm_sessions (swarm_status, creator_fk) VALUES (%s, %s)",
+            ('active', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        session_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO swarm_complete_sessions (swarm_complete_fk, session_fk) VALUES (%s, %s)",
+            (swarm_complete_id, session_id)
+        )
+
+        cur.execute("DELETE FROM swarm_sessions WHERE id = %s", (session_id,))
+
+        cur.execute(
+            "SELECT * FROM swarm_complete_sessions WHERE session_fk = %s",
+            (session_id,)
+        )
+        assert cur.fetchone() is None
+
+        cur.execute("SELECT id FROM swarm_completes WHERE id = %s", (swarm_complete_id,))
+        assert cur.fetchone() is not None
+
+    db_connection.rollback()
+
+
 def test_delete_profile_cascades_to_roadmap_tables(db_connection, test_category_id):
     """DELETE profile → cascades through projects→categories, requirements, swarm_sessions.
 

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -728,7 +728,7 @@ def test_swarm_undos_columns(db_connection):
 
 
 def test_swarm_completes_columns(db_connection):
-    """Verify swarm_completes column definitions match migration 057 (req #2497).
+    """Verify swarm_completes column definitions match migration 058 (req #2497).
 
     Close-out counterpart to swarm_starts. Expected columns:
     - id: INT, PRI, AUTO_INCREMENT

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -727,6 +727,102 @@ def test_swarm_undos_columns(db_connection):
     assert columns['creator_fk']['Key'] == 'MUL'
 
 
+def test_swarm_completes_columns(db_connection):
+    """Verify swarm_completes column definitions match migration 057 (req #2497).
+
+    Close-out counterpart to swarm_starts. Expected columns:
+    - id: INT, PRI, AUTO_INCREMENT
+    - skill_name: VARCHAR(64), NOT NULL
+    - coordination_type: VARCHAR(16), NULL (NULL for primary-ai-swarm-complete)
+    - status: VARCHAR(16), NOT NULL, DEFAULT 'in_progress'
+    - session_count: INT, NOT NULL, DEFAULT 0
+    - tokens_input / tokens_cache_write / tokens_cache_read / tokens_output: INT, NULL
+    - wall_seconds: INT, NULL
+    - turn_count: INT, NULL
+    - complete_summary: TEXT, NULL
+    - telemetry: TEXT, NULL
+    - started_at: TIMESTAMP, NOT NULL, DEFAULT CURRENT_TIMESTAMP
+    - completed_at: TIMESTAMP, NULL (finalize timestamp)
+    - creator_fk: VARCHAR(64), NOT NULL, MUL
+    - create_ts / update_ts: TIMESTAMP, NULL
+    """
+    with db_connection.cursor() as cur:
+        cur.execute("DESCRIBE swarm_completes")
+        columns = {row['Field']: row for row in cur.fetchall()}
+
+    expected_fields = ['id', 'skill_name', 'coordination_type',
+                       'status', 'session_count',
+                       'tokens_input', 'tokens_cache_write', 'tokens_cache_read',
+                       'tokens_output', 'wall_seconds', 'turn_count',
+                       'complete_summary', 'telemetry',
+                       'started_at', 'completed_at',
+                       'creator_fk', 'create_ts', 'update_ts']
+    assert set(columns.keys()) == set(expected_fields)
+
+    assert columns['id']['Type'] == 'int'
+    assert columns['id']['Key'] == 'PRI'
+    assert columns['id']['Extra'] == 'auto_increment'
+
+    assert columns['skill_name']['Type'] == 'varchar(64)'
+    assert columns['skill_name']['Null'] == 'NO'
+
+    assert columns['coordination_type']['Type'] == 'varchar(16)'
+    assert columns['coordination_type']['Null'] == 'YES'
+
+    assert columns['status']['Type'] == 'varchar(16)'
+    assert columns['status']['Null'] == 'NO'
+    assert columns['status']['Default'] == 'in_progress'
+
+    assert columns['session_count']['Type'] == 'int'
+    assert columns['session_count']['Null'] == 'NO'
+    assert columns['session_count']['Default'] == '0'
+
+    # Token / timing / count columns are NULL until the skill's finalize populates them.
+    for col in ('tokens_input', 'tokens_cache_write', 'tokens_cache_read',
+                'tokens_output', 'wall_seconds', 'turn_count'):
+        assert columns[col]['Type'] == 'int', col
+        assert columns[col]['Null'] == 'YES', col
+
+    assert columns['complete_summary']['Type'] == 'text'
+    assert columns['complete_summary']['Null'] == 'YES'
+
+    assert columns['telemetry']['Type'] == 'text'
+    assert columns['telemetry']['Null'] == 'YES'
+
+    assert 'timestamp' in columns['started_at']['Type']
+    assert columns['started_at']['Null'] == 'NO'
+
+    assert 'timestamp' in columns['completed_at']['Type']
+    assert columns['completed_at']['Null'] == 'YES'
+
+    assert columns['creator_fk']['Type'] == 'varchar(64)'
+    assert columns['creator_fk']['Null'] == 'NO'
+    assert columns['creator_fk']['Key'] == 'MUL'
+
+
+def test_swarm_complete_sessions_columns(db_connection):
+    """Verify swarm_complete_sessions junction table column definitions (req #2497).
+
+    Expected columns:
+    - swarm_complete_fk: INT, PRI, NOT NULL
+    - session_fk: INT, PRI, NOT NULL
+    """
+    with db_connection.cursor() as cur:
+        cur.execute("DESCRIBE swarm_complete_sessions")
+        columns = {row['Field']: row for row in cur.fetchall()}
+
+    expected_fields = ['swarm_complete_fk', 'session_fk']
+    assert set(columns.keys()) == set(expected_fields)
+
+    assert columns['swarm_complete_fk']['Type'] == 'int'
+    assert columns['swarm_complete_fk']['Null'] == 'NO'
+    assert columns['swarm_complete_fk']['Key'] == 'PRI'
+
+    assert columns['session_fk']['Type'] == 'int'
+    assert columns['session_fk']['Null'] == 'NO'
+    assert columns['session_fk']['Key'] == 'PRI'
+
+
 def test_dev_servers_columns(db_connection):
     """Verify dev_servers column definitions match schema.sql.
 
@@ -1460,6 +1556,8 @@ def test_table_count(db_connection):
         'build_projects', 'branches', 'builds', 'customer_releases',
         # Req #2719 — swarm-undo data type
         'swarm_undos',
+        # Req #2497 — swarm-complete data type
+        'swarm_completes', 'swarm_complete_sessions',
     }
     assert expected_tables == tables, \
         f"Unexpected tables: {tables - expected_tables}, missing: {expected_tables - tables}"

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -645,6 +645,97 @@ def test_swarm_start_sessions_columns(db_connection):
     assert columns['session_fk']['Key'] == 'PRI'
 
 
+def test_swarm_completes_columns(db_connection):
+    """Verify swarm_completes column definitions match migration 048 (req #2497).
+
+    Parallel shape to swarm_starts with six differences:
+    - skill_name: VARCHAR(64), NOT NULL (discriminates closeout skill)
+    - coordination_type: VARCHAR(16), NULL (manifest value; NULL for primary)
+    - status: VARCHAR(16), NOT NULL, DEFAULT 'in_progress'
+    - completed_at: TIMESTAMP, NULL (finalize timestamp)
+    - complete_summary: TEXT, NULL (mirrors swarm_sessions.complete_summary)
+    - no auto_start, no autonomy_filter
+    """
+    with db_connection.cursor() as cur:
+        cur.execute("DESCRIBE swarm_completes")
+        columns = {row['Field']: row for row in cur.fetchall()}
+
+    expected_fields = ['id', 'skill_name', 'arguments', 'coordination_type',
+                       'status', 'session_count',
+                       'tokens_input', 'tokens_cache_write', 'tokens_cache_read',
+                       'tokens_output', 'wall_seconds', 'turn_count',
+                       'complete_summary', 'telemetry',
+                       'started_at', 'completed_at',
+                       'creator_fk', 'create_ts', 'update_ts']
+    assert set(columns.keys()) == set(expected_fields)
+
+    assert columns['id']['Type'] == 'int'
+    assert columns['id']['Key'] == 'PRI'
+    assert columns['id']['Extra'] == 'auto_increment'
+
+    assert columns['skill_name']['Type'] == 'varchar(64)'
+    assert columns['skill_name']['Null'] == 'NO'
+
+    assert columns['arguments']['Type'] == 'varchar(512)'
+    assert columns['arguments']['Null'] == 'YES'
+
+    assert columns['coordination_type']['Type'] == 'varchar(16)'
+    assert columns['coordination_type']['Null'] == 'YES'
+
+    assert columns['status']['Type'] == 'varchar(16)'
+    assert columns['status']['Null'] == 'NO'
+    assert columns['status']['Default'] == 'in_progress'
+
+    assert columns['session_count']['Type'] == 'int'
+    assert columns['session_count']['Null'] == 'NO'
+    assert columns['session_count']['Default'] == '0'
+
+    # Token / timing / count columns are NULL until skill-finalize populates them.
+    for col in ('tokens_input', 'tokens_cache_write', 'tokens_cache_read',
+                'tokens_output', 'wall_seconds', 'turn_count'):
+        assert columns[col]['Type'] == 'int', col
+        assert columns[col]['Null'] == 'YES', col
+
+    assert columns['complete_summary']['Type'] == 'text'
+    assert columns['complete_summary']['Null'] == 'YES'
+
+    assert columns['telemetry']['Type'] == 'text'
+    assert columns['telemetry']['Null'] == 'YES'
+
+    assert 'timestamp' in columns['started_at']['Type']
+    assert columns['started_at']['Null'] == 'NO'
+
+    assert 'timestamp' in columns['completed_at']['Type']
+    assert columns['completed_at']['Null'] == 'YES'
+
+    assert columns['creator_fk']['Type'] == 'varchar(64)'
+    assert columns['creator_fk']['Null'] == 'NO'
+    assert columns['creator_fk']['Key'] == 'MUL'
+
+
+def test_swarm_complete_sessions_columns(db_connection):
+    """Verify swarm_complete_sessions junction table column definitions (req #2497).
+
+    Expected columns:
+    - swarm_complete_fk: INT, PRI, NOT NULL
+    - session_fk: INT, PRI, NOT NULL
+    """
+    with db_connection.cursor() as cur:
+        cur.execute("DESCRIBE swarm_complete_sessions")
+        columns = {row['Field']: row for row in cur.fetchall()}
+
+    expected_fields = ['swarm_complete_fk', 'session_fk']
+    assert set(columns.keys()) == set(expected_fields)
+
+    assert columns['swarm_complete_fk']['Type'] == 'int'
+    assert columns['swarm_complete_fk']['Null'] == 'NO'
+    assert columns['swarm_complete_fk']['Key'] == 'PRI'
+
+    assert columns['session_fk']['Type'] == 'int'
+    assert columns['session_fk']['Null'] == 'NO'
+    assert columns['session_fk']['Key'] == 'PRI'
+
+
 def test_dev_servers_columns(db_connection):
     """Verify dev_servers column definitions match schema.sql.
 
@@ -1329,6 +1420,8 @@ def test_table_count(db_connection):
         'test_runs', 'test_results',
         # Req #2422 — swarm-start data type
         'swarm_starts', 'swarm_start_sessions',
+        # Req #2497 — swarm-complete data type (migration 048)
+        'swarm_completes', 'swarm_complete_sessions',
     }
     assert expected_tables == tables, \
         f"Unexpected tables: {tables - expected_tables}, missing: {expected_tables - tables}"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -161,7 +161,7 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         # Migration 053 — swarm_undos
         'fk_swarm_undos_swarm_start', 'fk_swarm_undos_session',
         'fk_swarm_undos_req', 'fk_swarm_undos_creator',
-        # Migration 057 — swarm_completes
+        # Migration 058 — swarm_completes
         'fk_swarm_completes_creator',
         'fk_scs_swarm_complete', 'fk_scs_session',
     ]
@@ -420,13 +420,14 @@ def test_migration_sequence_applies(db_connection, migration_test_prefix):
             'test_runs', 'test_results',
             # Req #2422 — swarm-start data type
             'swarm_starts', 'swarm_start_sessions',
-            # Req #2604 — Customer Release
-            'customers',
-            # Req #2606 — Build Visualizer data model (migrations 050-054)
-            'build_projects', 'branches', 'builds', 'customer_releases',
+            # Req #2604/#2606 — Customer Release + Build Visualizer (migrations
+            # 049-054) are CREATED, then DROPPED by migration 057 (req #2760 —
+            # build visualizer removed from production), so they do NOT appear in
+            # the final replay state. The 5 tables (customers, build_projects,
+            # branches, builds, customer_releases) are intentionally absent here.
             # Req #2719 — swarm-undo data type (migration 053)
             'swarm_undos',
-            # Req #2497 — swarm-complete data type (migration 057)
+            # Req #2497 — swarm-complete data type (migration 058)
             'swarm_completes', 'swarm_complete_sessions',
         ]
     }

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -71,6 +71,9 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         'test_runs',
         'features',
         'user_integrations',
+        # Req #2497 — swarm_complete_sessions before swarm_completes (longest-first).
+        'swarm_complete_sessions',
+        'swarm_completes',
         # Req #2422 — swarm_start_sessions before swarm_starts so the longer
         # match wins under the longest-first replace order.
         'swarm_start_sessions',
@@ -136,6 +139,9 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         # Migration 046
         'fk_swarm_starts_creator',
         'fk_sss_swarm_start', 'fk_sss_session',
+        # Migration 048 (req #2497)
+        'fk_swarm_completes_creator',
+        'fk_scs_swarm_complete', 'fk_scs_session',
     ]
     for cname in named_constraints:
         sql = sql.replace(cname, f'{table_prefix}_{cname}')
@@ -223,6 +229,8 @@ ALL_TABLE_SUFFIXES = [
     'user_integrations', 'map_run_partners', 'map_partners',
     'map_views', 'map_coordinates', 'map_runs', 'map_routes',
     'priority_card_order', 'dev_servers',
+    # Req #2497 — junction first, then parent (FK-safe drop order). Migration 048.
+    'swarm_complete_sessions', 'swarm_completes',
     # Req #2422 — junction first, then parent (FK-safe drop order).
     'swarm_start_sessions', 'swarm_starts',
     'requirement_sessions', 'priority_sessions',  # pre-038 name
@@ -378,6 +386,8 @@ def test_migration_sequence_applies(db_connection, migration_test_prefix):
             'test_runs', 'test_results',
             # Req #2422 — swarm-start data type
             'swarm_starts', 'swarm_start_sessions',
+            # Req #2497 — swarm-complete data type (migration 048)
+            'swarm_completes', 'swarm_complete_sessions',
         ]
     }
     assert tables == expected_tables, \

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -83,6 +83,9 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         # match wins under the longest-first replace order.
         'swarm_start_sessions',
         'swarm_starts',
+        # Req #2497 — swarm_complete_sessions before swarm_completes (longest-first).
+        'swarm_complete_sessions',
+        'swarm_completes',
         'requirement_sessions',
         'priority_sessions',     # pre-038 name (for RENAME TABLE in migration 038)
         'priority_card_order',
@@ -158,6 +161,9 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         # Migration 053 — swarm_undos
         'fk_swarm_undos_swarm_start', 'fk_swarm_undos_session',
         'fk_swarm_undos_req', 'fk_swarm_undos_creator',
+        # Migration 057 — swarm_completes
+        'fk_swarm_completes_creator',
+        'fk_scs_swarm_complete', 'fk_scs_session',
     ]
     for cname in named_constraints:
         sql = sql.replace(cname, f'{table_prefix}_{cname}')
@@ -251,6 +257,8 @@ ALL_TABLE_SUFFIXES = [
     'customer_releases', 'builds', 'branches', 'build_projects',
     # Req #2719 — swarm_undos (leaf log table; FKs to session/start/req SET NULL).
     'swarm_undos',
+    # Req #2497 — junction first, then parent (FK-safe drop order).
+    'swarm_complete_sessions', 'swarm_completes',
     # Req #2422 — junction first, then parent (FK-safe drop order).
     'swarm_start_sessions', 'swarm_starts',
     'requirement_sessions', 'priority_sessions',  # pre-038 name
@@ -418,6 +426,8 @@ def test_migration_sequence_applies(db_connection, migration_test_prefix):
             'build_projects', 'branches', 'builds', 'customer_releases',
             # Req #2719 — swarm-undo data type (migration 053)
             'swarm_undos',
+            # Req #2497 — swarm-complete data type (migration 057)
+            'swarm_completes', 'swarm_complete_sessions',
         ]
     }
     assert tables == expected_tables, \


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-06-07T23:10:35Z
- Merge branch 'main' of https://github.com/BillWilliams79/DarwinSQL into feature/2497-create-swarm-complete-object-1
- wip(DarwinSQL): 2026-06-07T23:04:19Z
- wip(DarwinSQL): 2026-06-07T19:06:02Z
- WIP: pause swarm session (req #2497)
- chore: init swarm session feature/2497-create-swarm-complete-object-1

## Files changed
```
 migrations/058_add_swarm_completes.sql | 77 ++++++++++++++++++++++++++
 schema.sql                             | 45 ++++++++++++++++
 scripts/recreate_darwin_dev.sql        | 36 +++++++++++++
 tests/test_cascades.py                 | 91 +++++++++++++++++++++++++++++++
 tests/test_data_types.py               | 98 ++++++++++++++++++++++++++++++++++
 tests/test_migrations.py               | 19 +++++--
 6 files changed, 362 insertions(+), 4 deletions(-)
```

## Testing
swarm_completes migration 058 (req #2497)

🤖 Generated with [Claude Code](https://claude.com/claude-code)