### PR TITLE
Per-requirement repos override (fix category-default mismatch)

### DIFF
--- a/migrations/048_requirements_affected_repos.sql
+++ b/migrations/048_requirements_affected_repos.sql
@@ -1,0 +1,29 @@
+-- Migration 048: Add affected_repos column to requirements (req #2583)
+--
+-- Per-requirement override for the worktree composition that /swarm-start
+-- creates. When NULL (default), /swarm-start uses the category-default
+-- sub-repos table (Swarm → [], Topology → [Darwin, Topology], everything
+-- else → [Darwin]). When set, the comma-separated list overrides that
+-- default. DarwinAI-Config is unconditionally first regardless (req #2232).
+--
+-- Motivating incident: the 2026-05-22 mega launch shipped three deployed
+-- sessions (req #2425, #2566, #2568) with empty PRs. Reqs 2425 and 2566
+-- were filed in the Swarm category (category default: [] = config only)
+-- but described Darwin UI work — the worker spun up a worktree containing
+-- only DarwinAI-Config, found no Darwin to edit, and /swarm-complete
+-- closed the empty PR. Silent failure. Per-requirement override is the
+-- surgical fix at the right granularity: a single category routinely
+-- mixes work across sub-repos and the category-default-only model
+-- doesn't reflect that.
+--
+-- Format: comma-separated sub-repo names (no whitespace required but
+-- tolerated; the skill trims tokens). Examples: "Darwin", "Darwin,Topology",
+-- "Lambda-Rest,DarwinSQL". NULL = use category default.
+--
+-- VARCHAR(255) is generous — the longest possible legitimate value
+-- ("Darwin,DarwinSQL,Lambda-Rest,Lambda-Cognito,Lambda-JWT,Topology" ≈ 60
+-- chars) fits comfortably with room for future sub-repos.
+
+ALTER TABLE requirements
+    ADD COLUMN affected_repos VARCHAR(255) NULL
+    COMMENT 'Comma-separated sub-repo names override (req #2583); NULL falls back to category default.';

--- a/schema.sql
+++ b/schema.sql
@@ -154,6 +154,8 @@ CREATE TABLE IF NOT EXISTS requirements (
                                             -- planned | implemented | deployed (default: implemented)
     sort_order      SMALLINT        NULL DEFAULT NULL,
                                             -- in-card hand-sort position (req #2417); NULL = unranked, falls to id-order
+    affected_repos  VARCHAR(255)    NULL DEFAULT NULL,
+                                            -- comma-separated sub-repo override (req #2583); NULL = use category default
     FOREIGN KEY (project_fk)
         REFERENCES projects (id)
         ON UPDATE CASCADE ON DELETE SET NULL,

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -376,7 +376,8 @@ def test_categories_columns(db_connection):
 def test_requirements_columns(db_connection):
     """Verify requirements column definitions match schema.sql.
 
-    Expected columns (migration 046 re-adds sort_order; req #2417):
+    Expected columns (migration 046 re-adds sort_order; req #2417;
+    migration 048 adds affected_repos; req #2583):
     - id: INT, PRI, AUTO_INCREMENT
     - title: VARCHAR(256), NOT NULL
     - description: TEXT, NULL
@@ -391,6 +392,7 @@ def test_requirements_columns(db_connection):
     - update_ts: TIMESTAMP, NULL
     - coordination_type: VARCHAR(16), NULL, DEFAULT 'implemented'
     - sort_order: SMALLINT, NULL, DEFAULT NULL  (req #2417 — in-card hand sort)
+    - affected_repos: VARCHAR(255), NULL, DEFAULT NULL  (req #2583 — per-requirement repo override)
     """
     with db_connection.cursor() as cur:
         cur.execute("DESCRIBE requirements")
@@ -405,6 +407,10 @@ def test_requirements_columns(db_connection):
     # everywhere, this branch can be removed.
     if 'sort_order' in columns:
         expected_fields.append('sort_order')
+    # Tolerate both pre- and post-migration-048 state (req #2583 added
+    # affected_repos; the migration may not have landed in this DB yet).
+    if 'affected_repos' in columns:
+        expected_fields.append('affected_repos')
     assert set(columns.keys()) == set(expected_fields)
 
     assert columns['id']['Type'] == 'int'
@@ -449,6 +455,11 @@ def test_requirements_columns(db_connection):
     assert columns['sort_order']['Type'] == 'smallint'
     assert columns['sort_order']['Null'] == 'YES'
     assert columns['sort_order']['Default'] is None
+
+    if 'affected_repos' in columns:
+        assert columns['affected_repos']['Type'] == 'varchar(255)'
+        assert columns['affected_repos']['Null'] == 'YES'
+        assert columns['affected_repos']['Default'] is None
 
 
 def test_swarm_sessions_columns(db_connection):


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-05-23T06:03:52Z
- chore: init swarm session feature/2583-per-requirement-repos-override-fix-1

## Files changed
```
 migrations/048_requirements_affected_repos.sql | 29 ++++++++++++++++++++++++++
 schema.sql                                     |  2 ++
 tests/test_data_types.py                       | 13 +++++++++++-
 3 files changed, 43 insertions(+), 1 deletion(-)
```

## Testing
0 tests run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Related PRs: BillWilliams79/DarwinAI-Config#253 (MCP + skill + tests)