### PR TITLE
req #2604

### DIFF
--- a/migrations/049_add_customers.sql
+++ b/migrations/049_add_customers.sql
@@ -1,0 +1,24 @@
+-- 049_add_customers.sql
+--
+-- Req #2604: Customer Release — add `customers` table.
+--
+-- A customer is a recipient of a build release (HP, NVIDIA, Cisco, Google, ...).
+-- The Build Visualizer attaches `customer-release` branches to build dots to
+-- visualize which customer received which sprint or end-release build.
+--
+-- FK policy:
+--   creator_fk → profiles(id)  ON DELETE CASCADE
+
+CREATE TABLE customers (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    customer_name   VARCHAR(256)    NOT NULL,
+    description     TEXT            NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    closed          TINYINT(1)      NOT NULL DEFAULT 0,
+    sort_order      SMALLINT        NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_customers_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);

--- a/schema.sql
+++ b/schema.sql
@@ -513,3 +513,20 @@ CREATE TABLE IF NOT EXISTS test_results (
         ON UPDATE CASCADE ON DELETE CASCADE,
     CONSTRAINT uq_run_case UNIQUE KEY (test_run_fk, test_case_fk)
 );
+
+-- Req #2604: customers — recipients of build releases (HP, NVIDIA, Cisco, …).
+-- The Build Visualizer attaches `customer-release` branches to build dots to
+-- visualize which customer received which sprint/end-release build.
+CREATE TABLE IF NOT EXISTS customers (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    customer_name   VARCHAR(256)    NOT NULL,
+    description     TEXT            NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    closed          TINYINT(1)      NOT NULL DEFAULT 0,
+    sort_order      SMALLINT        NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_customers_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -1,12 +1,13 @@
 -- Recreate darwin_dev test/dev tables from scratch
 -- Uses production-identical table names (same DDL as schema.sql)
 -- Idempotent: safe to run repeatedly to reset darwin_dev to canonical state
--- All 27 tables in FK-dependency order
+-- All 28 tables in FK-dependency order
 
 USE darwin_dev;
 
 SET FOREIGN_KEY_CHECKS = 0;
-DROP TABLE IF EXISTS test_results, test_runs, test_plan_cases, test_plans,
+DROP TABLE IF EXISTS customers,
+    test_results, test_runs, test_plan_cases, test_plans,
     feature_test_cases, test_cases, features,
     map_run_partners, map_partners,
     map_views, map_coordinates, map_runs, map_routes,
@@ -492,4 +493,19 @@ CREATE TABLE test_results (
         FOREIGN KEY (creator_fk) REFERENCES profiles (id)
         ON UPDATE CASCADE ON DELETE CASCADE,
     CONSTRAINT uq_run_case UNIQUE KEY (test_run_fk, test_case_fk)
+);
+
+-- Req #2604: customers — recipients of build releases.
+CREATE TABLE customers (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    customer_name   VARCHAR(256)    NOT NULL,
+    description     TEXT            NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    closed          TINYINT(1)      NOT NULL DEFAULT 0,
+    sort_order      SMALLINT        NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_customers_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
 );

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1321,6 +1321,49 @@ def test_test_results_columns(db_connection):
         f"uq_run_case UNIQUE should cover (test_run_fk, test_case_fk), got {columns_in_unique}"
 
 
+def test_customers_columns(db_connection):
+    """Verify customers column definitions match migration 049 (req #2604).
+
+    Expected columns:
+    - id: INT, PRI, AUTO_INCREMENT
+    - customer_name: VARCHAR(256), NOT NULL
+    - description: TEXT, NULL
+    - creator_fk: VARCHAR(64), NOT NULL, MUL (FK to profiles)
+    - closed: TINYINT(1), NOT NULL, DEFAULT 0
+    - sort_order: SMALLINT, NULL
+    - create_ts / update_ts: TIMESTAMP, NULL
+    """
+    with db_connection.cursor() as cur:
+        cur.execute("DESCRIBE customers")
+        columns = {row['Field']: row for row in cur.fetchall()}
+
+    expected_fields = ['id', 'customer_name', 'description',
+                       'creator_fk', 'closed', 'sort_order',
+                       'create_ts', 'update_ts']
+    assert set(columns.keys()) == set(expected_fields)
+
+    assert columns['id']['Type'] == 'int'
+    assert columns['id']['Key'] == 'PRI'
+    assert columns['id']['Extra'] == 'auto_increment'
+
+    assert columns['customer_name']['Type'] == 'varchar(256)'
+    assert columns['customer_name']['Null'] == 'NO'
+
+    assert columns['description']['Type'] == 'text'
+    assert columns['description']['Null'] == 'YES'
+
+    assert columns['creator_fk']['Type'] == 'varchar(64)'
+    assert columns['creator_fk']['Null'] == 'NO'
+    assert columns['creator_fk']['Key'] == 'MUL'
+
+    assert columns['closed']['Type'] == 'tinyint(1)'
+    assert columns['closed']['Null'] == 'NO'
+    assert columns['closed']['Default'] == '0'
+
+    assert columns['sort_order']['Type'] == 'smallint'
+    assert columns['sort_order']['Null'] == 'YES'
+
+
 def test_table_count(db_connection):
     """Verify darwin_dev database contains the expected tables."""
     with db_connection.cursor() as cur:
@@ -1340,6 +1383,8 @@ def test_table_count(db_connection):
         'test_runs', 'test_results',
         # Req #2422 — swarm-start data type
         'swarm_starts', 'swarm_start_sessions',
+        # Req #2604 — Customer Release
+        'customers',
     }
     assert expected_tables == tables, \
         f"Unexpected tables: {tables - expected_tables}, missing: {expected_tables - tables}"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -87,6 +87,7 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         'requirements',
         'priorities',            # pre-038 name (for RENAME TABLE in migration 038)
         'categories',
+        'customers',
         'map_routes',
         'map_views',
         'map_runs',
@@ -136,6 +137,8 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         # Migration 046
         'fk_swarm_starts_creator',
         'fk_sss_swarm_start', 'fk_sss_session',
+        # Migration 049 — Customer Release
+        'fk_customers_creator',
     ]
     for cname in named_constraints:
         sql = sql.replace(cname, f'{table_prefix}_{cname}')
@@ -227,6 +230,8 @@ ALL_TABLE_SUFFIXES = [
     'swarm_start_sessions', 'swarm_starts',
     'requirement_sessions', 'priority_sessions',  # pre-038 name
     'requirements', 'priorities',                  # pre-038 name
+    # Req #2604 — customers (FK to profiles, no children) drops before profiles.
+    'customers',
     'swarm_sessions', 'categories', 'projects',
     'tasks', 'recurring_tasks', 'areas', 'domains', 'profiles',
 ]
@@ -378,6 +383,8 @@ def test_migration_sequence_applies(db_connection, migration_test_prefix):
             'test_runs', 'test_results',
             # Req #2422 — swarm-start data type
             'swarm_starts', 'swarm_start_sessions',
+            # Req #2604 — Customer Release
+            'customers',
         ]
     }
     assert tables == expected_tables, \


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-05-24T02:30:24Z
- chore: init swarm session feature/2604-customer-release-1

## Files changed
```
 migrations/049_add_customers.sql | 24 +++++++++++++++++++++
 schema.sql                       | 17 +++++++++++++++
 scripts/recreate_darwin_dev.sql  | 20 ++++++++++++++++--
 tests/test_data_types.py         | 45 ++++++++++++++++++++++++++++++++++++++++
 tests/test_migrations.py         |  7 +++++++
 5 files changed, 111 insertions(+), 2 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)