### PR TITLE
req #2606

### DIFF
--- a/migrations/050_add_build_data_model.sql
+++ b/migrations/050_add_build_data_model.sql
@@ -1,0 +1,167 @@
+-- 050_add_build_data_model.sql
+--
+-- Req #2606: SQL-backed Build Visualizer data model + Customer Release Events.
+--
+-- Canonical items: Project, Branch, Build, Customer, Release.
+--
+-- Trunk:
+--   Whichever branch the project's `trunk_branch_fk` points at. That branch has
+--   `branch_type='release'`, `parent_build_fk=NULL`. No boolean flag — the
+--   FK link from the project IS the trunk-identity declaration.
+--
+-- Versioning (compute-once-at-creation, no segments, no walk at render):
+--   * `branches.major` / `branches.minor` are STORED on the branch row at
+--     creation time. Inherited from origin-build's branch for sub-branches;
+--     set explicitly for trunk (project starter) and release branches (user
+--     picks at dialog).
+--   * `builds.build_number` (the B) is STORED on each build at creation time.
+--     Trunk builds increment monotonically; sub-branch builds inherit the
+--     FROZEN parent-trunk-build's B per design-guide §4.2.
+--   * `builds.branch_number` (the b) is STORED on each build at creation time
+--     using the reserved-range rules (0 for trunk, i+1 for release /
+--     sample-release, ord1*1000+i+1 for csr, 6000+ord0*100+i+1 for hotfix,
+--     7000+ord0*100+i+1 for development, 9000+ord0*100+i+1 for bootleg).
+--   * Renderer formats `M.m.B.b` purely from stored values — no engine walk.
+--   * The segment concept is DELETED. Each branch carries its own M.m
+--     directly; there is no trunk-segment table or column.
+--
+-- Branch parentage:
+--   A branch originates from a specific Build. `branches.parent_build_fk`
+--   points at that build. The parent BRANCH is derivable:
+--     SELECT branch_fk FROM builds WHERE id = branch.parent_build_fk
+--   So there is NO `parent_branch_fk` column — single source of truth.
+--   The trunk is the only branch with `parent_build_fk = NULL`.
+--
+-- No soft delete (`closed` removed from every new table per req #2606
+-- directive). Project / branch / build deletion is hard delete via the
+-- existing FK CASCADE chain.
+--
+-- FK policies:
+--   build_projects.category_fk -> categories     RESTRICT
+--   build_projects.trunk_branch_fk -> branches   SET NULL (deferred ALTER)
+--   build_projects.creator_fk -> profiles        CASCADE
+--   branches.project_fk -> build_projects        CASCADE
+--   branches.parent_build_fk -> builds           SET NULL (deferred ALTER)
+--   branches.creator_fk -> profiles              CASCADE
+--   builds.branch_fk -> branches                 CASCADE
+--   builds.creator_fk -> profiles                CASCADE
+--   customer_releases.customer_fk -> customers   RESTRICT
+--   customer_releases.build_fk -> builds         CASCADE
+--   customer_releases.creator_fk -> profiles     CASCADE
+--
+-- Two deferred ALTERs handle the circular FKs:
+--   branches.parent_build_fk        <-> builds.branch_fk
+--   build_projects.trunk_branch_fk  <-> branches.project_fk
+
+-- ----------------------------------------------------------------------------
+-- 1. build_projects (without trunk_branch_fk — added by deferred ALTER below)
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE build_projects (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title           VARCHAR(256)    NOT NULL,
+    description     TEXT            NULL,
+    project_status  VARCHAR(16)     NOT NULL DEFAULT 'draft', -- draft|active|archived
+    sort_order      SMALLINT        NULL,
+    category_fk     INT             NOT NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_build_projects_category
+        FOREIGN KEY (category_fk) REFERENCES categories (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_build_projects_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+-- ----------------------------------------------------------------------------
+-- 2. branches (without parent_build_fk — added by deferred ALTER below)
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE branches (
+    id                  INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    project_fk          INT             NOT NULL,
+    branch_type         VARCHAR(32)     NOT NULL, -- release|sample-release|hotfix|bootleg|csr|development
+    name                TEXT            NULL,     -- multi-line allowed (\n stacks vertically)
+    major               INT             NOT NULL, -- M.m stored on the branch (compute-once on create)
+    minor               INT             NOT NULL,
+    -- parent_build_fk INT NULL  added by deferred ALTER below
+    side                VARCHAR(16)     NULL,     -- override REGISTRY default (above|below|center)
+    row_order           INT             NULL,     -- override REGISTRY default
+    label_end           VARCHAR(128)    NULL,     -- trunk's right-endpoint annotation
+    sort_order          SMALLINT        NULL,
+    creator_fk          VARCHAR(64)     NOT NULL,
+    create_ts           TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts           TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_branches_project
+        FOREIGN KEY (project_fk) REFERENCES build_projects (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_branches_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+-- ----------------------------------------------------------------------------
+-- 3. builds (depends on branches)
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE builds (
+    id                      INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    branch_fk               INT             NOT NULL,
+    position                SMALLINT        NOT NULL,    -- 0-indexed order within branch
+    build_number            INT             NOT NULL,    -- B in M.m.B.b — computed at creation, stored
+    branch_number           INT             NOT NULL DEFAULT 0, -- b in M.m.B.b — 0 for trunk
+    dot_color               VARCHAR(32)     NULL,        -- green|red|yellow|gray (semantic overlay)
+    approved_for_release    TINYINT(1)      NOT NULL DEFAULT 0,
+    creator_fk              VARCHAR(64)     NOT NULL,
+    create_ts               TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts               TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_builds_branch
+        FOREIGN KEY (branch_fk) REFERENCES branches (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_builds_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT uq_builds_branch_position UNIQUE KEY (branch_fk, position)
+);
+
+-- ----------------------------------------------------------------------------
+-- 4. Deferred ALTERs for the two circular FKs
+-- ----------------------------------------------------------------------------
+
+ALTER TABLE branches
+    ADD COLUMN parent_build_fk INT NULL,
+    ADD CONSTRAINT fk_branches_parent_build
+        FOREIGN KEY (parent_build_fk) REFERENCES builds (id)
+        ON UPDATE CASCADE ON DELETE SET NULL;
+
+ALTER TABLE build_projects
+    ADD COLUMN trunk_branch_fk INT NULL,
+    ADD CONSTRAINT fk_build_projects_trunk_branch
+        FOREIGN KEY (trunk_branch_fk) REFERENCES branches (id)
+        ON UPDATE CASCADE ON DELETE SET NULL;
+
+-- ----------------------------------------------------------------------------
+-- 5. customer_releases (depends on customers + builds)
+-- ----------------------------------------------------------------------------
+
+CREATE TABLE customer_releases (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    customer_fk     INT             NOT NULL,
+    build_fk        INT             NOT NULL,
+    release_notes   TEXT            NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_customer_releases_customer
+        FOREIGN KEY (customer_fk) REFERENCES customers (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_customer_releases_build
+        FOREIGN KEY (build_fk) REFERENCES builds (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_customer_releases_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT uq_customer_releases_customer_build UNIQUE KEY (customer_fk, build_fk)
+);

--- a/schema.sql
+++ b/schema.sql
@@ -1,6 +1,6 @@
 -- Darwin Database Schema — Current State
 -- Database: darwin
--- This file reflects the final state of all 27 tables after all migrations.
+-- This file reflects the final state of all 32 tables after all migrations.
 -- It can be run against a fresh MySQL instance to create the complete schema.
 -- Table order respects FK dependencies.
 
@@ -530,3 +530,112 @@ CREATE TABLE IF NOT EXISTS customers (
         FOREIGN KEY (creator_fk) REFERENCES profiles (id)
         ON UPDATE CASCADE ON DELETE CASCADE
 );
+
+-- ============================================================================
+-- Req #2606: Build Visualizer data model — projects, branches, builds,
+-- customer-release events. Trunk = the branch a project's trunk_branch_fk
+-- points at (no boolean flag on branches). Branch carries M.m; build carries
+-- the COMPUTED-ONCE-AT-CREATION M.m.B.b values (no segments, no walk at
+-- render). A branch originates from a Build via parent_build_fk; the parent
+-- BRANCH is derivable via builds[parent_build_fk].branch_fk (no
+-- parent_branch_fk). No soft-delete `closed` on any of these tables.
+--
+-- Two circular FKs (build_projects.trunk_branch_fk <-> branches; and
+-- branches.parent_build_fk <-> builds) require deferred ALTERs to land. The
+-- migration file uses that pattern; for the schema dump we disable FK checks
+-- around the block so a fresh `mysql < schema.sql` install still succeeds.
+-- ============================================================================
+
+SET FOREIGN_KEY_CHECKS = 0;
+
+CREATE TABLE IF NOT EXISTS build_projects (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title           VARCHAR(256)    NOT NULL,
+    description     TEXT            NULL,
+    project_status  VARCHAR(16)     NOT NULL DEFAULT 'draft', -- draft|active|archived
+    trunk_branch_fk INT             NULL, -- FK declared at bottom (circular: -> branches)
+    sort_order      SMALLINT        NULL,
+    category_fk     INT             NOT NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_build_projects_category
+        FOREIGN KEY (category_fk) REFERENCES categories (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_build_projects_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_build_projects_trunk_branch
+        FOREIGN KEY (trunk_branch_fk) REFERENCES branches (id)
+        ON UPDATE CASCADE ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS branches (
+    id                  INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    project_fk          INT             NOT NULL,
+    branch_type         VARCHAR(32)     NOT NULL, -- release|sample-release|hotfix|bootleg|csr|development
+    name                TEXT            NULL,     -- multi-line allowed (\n stacks vertically)
+    major               INT             NOT NULL, -- M.m stored on the branch (compute-once on create)
+    minor               INT             NOT NULL,
+    parent_build_fk     INT             NULL,     -- FK -> builds(id) SET NULL; NULL on trunk only
+    side                VARCHAR(16)     NULL,
+    row_order           INT             NULL,
+    label_end           VARCHAR(128)    NULL,
+    sort_order          SMALLINT        NULL,
+    creator_fk          VARCHAR(64)     NOT NULL,
+    create_ts           TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts           TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_branches_project
+        FOREIGN KEY (project_fk) REFERENCES build_projects (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_branches_parent_build
+        FOREIGN KEY (parent_build_fk) REFERENCES builds (id)
+        ON UPDATE CASCADE ON DELETE SET NULL,
+    CONSTRAINT fk_branches_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS builds (
+    id                      INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    branch_fk               INT             NOT NULL,
+    position                SMALLINT        NOT NULL,    -- 0-indexed order within branch
+    build_number            INT             NOT NULL,    -- B in M.m.B.b — computed once at creation
+    branch_number           INT             NOT NULL DEFAULT 0, -- b in M.m.B.b — 0 for trunk
+    dot_color               VARCHAR(32)     NULL,        -- green|red|yellow|gray
+    approved_for_release    TINYINT(1)      NOT NULL DEFAULT 0,
+    creator_fk              VARCHAR(64)     NOT NULL,
+    create_ts               TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts               TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_builds_branch
+        FOREIGN KEY (branch_fk) REFERENCES branches (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_builds_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT uq_builds_branch_position UNIQUE KEY (branch_fk, position)
+);
+
+CREATE TABLE IF NOT EXISTS customer_releases (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    customer_fk     INT             NOT NULL,
+    build_fk        INT             NOT NULL,
+    release_notes   TEXT            NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_customer_releases_customer
+        FOREIGN KEY (customer_fk) REFERENCES customers (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_customer_releases_build
+        FOREIGN KEY (build_fk) REFERENCES builds (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_customer_releases_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT uq_customer_releases_customer_build UNIQUE KEY (customer_fk, build_fk)
+);
+-- (Req #2606 directive: `closed` soft-delete column removed from every new
+-- build-feature table. Hard delete via FK CASCADE chain only.)
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -1,12 +1,13 @@
 -- Recreate darwin_dev test/dev tables from scratch
 -- Uses production-identical table names (same DDL as schema.sql)
 -- Idempotent: safe to run repeatedly to reset darwin_dev to canonical state
--- All 28 tables in FK-dependency order
+-- All 32 tables in FK-dependency order
 
 USE darwin_dev;
 
 SET FOREIGN_KEY_CHECKS = 0;
-DROP TABLE IF EXISTS customers,
+DROP TABLE IF EXISTS customer_releases, builds, branches, build_projects,
+    customers,
     test_results, test_runs, test_plan_cases, test_plans,
     feature_test_cases, test_cases, features,
     map_run_partners, map_partners,
@@ -508,4 +509,104 @@ CREATE TABLE customers (
     CONSTRAINT fk_customers_creator
         FOREIGN KEY (creator_fk) REFERENCES profiles (id)
         ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+-- ============================================================================
+-- Req #2606: Build Visualizer data model. Trunk is identified by
+-- build_projects.trunk_branch_fk (a project links to its trunk branch).
+-- No parent_branch_fk on branches: a branch originates from a Build via
+-- parent_build_fk; the parent BRANCH is builds[parent_build_fk].branch_fk.
+-- No segment columns: branches carry M.m; builds carry the computed-once
+-- M.m.B.b values. No `closed` soft-delete columns. Two circular FKs
+-- (branches.parent_build_fk <-> builds.branch_fk;
+-- build_projects.trunk_branch_fk <-> branches.project_fk) safe under
+-- SET FOREIGN_KEY_CHECKS=0 above; in migration 050 they're deferred ALTERs.
+-- ============================================================================
+
+CREATE TABLE build_projects (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title           VARCHAR(256)    NOT NULL,
+    description     TEXT            NULL,
+    project_status  VARCHAR(16)     NOT NULL DEFAULT 'draft',
+    trunk_branch_fk INT             NULL,
+    sort_order      SMALLINT        NULL,
+    category_fk     INT             NOT NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_build_projects_category
+        FOREIGN KEY (category_fk) REFERENCES categories (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_build_projects_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_build_projects_trunk_branch
+        FOREIGN KEY (trunk_branch_fk) REFERENCES branches (id)
+        ON UPDATE CASCADE ON DELETE SET NULL
+);
+
+CREATE TABLE branches (
+    id                  INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    project_fk          INT             NOT NULL,
+    branch_type         VARCHAR(32)     NOT NULL,
+    name                TEXT            NULL,
+    major               INT             NOT NULL,
+    minor               INT             NOT NULL,
+    parent_build_fk     INT             NULL,
+    side                VARCHAR(16)     NULL,
+    row_order           INT             NULL,
+    label_end           VARCHAR(128)    NULL,
+    sort_order          SMALLINT        NULL,
+    creator_fk          VARCHAR(64)     NOT NULL,
+    create_ts           TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts           TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_branches_project
+        FOREIGN KEY (project_fk) REFERENCES build_projects (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_branches_parent_build
+        FOREIGN KEY (parent_build_fk) REFERENCES builds (id)
+        ON UPDATE CASCADE ON DELETE SET NULL,
+    CONSTRAINT fk_branches_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE builds (
+    id                      INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    branch_fk               INT             NOT NULL,
+    position                SMALLINT        NOT NULL,
+    build_number            INT             NOT NULL,
+    branch_number           INT             NOT NULL DEFAULT 0,
+    dot_color               VARCHAR(32)     NULL,
+    approved_for_release    TINYINT(1)      NOT NULL DEFAULT 0,
+    creator_fk              VARCHAR(64)     NOT NULL,
+    create_ts               TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts               TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_builds_branch
+        FOREIGN KEY (branch_fk) REFERENCES branches (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_builds_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT uq_builds_branch_position UNIQUE KEY (branch_fk, position)
+);
+
+CREATE TABLE customer_releases (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    customer_fk     INT             NOT NULL,
+    build_fk        INT             NOT NULL,
+    release_notes   TEXT            NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_customer_releases_customer
+        FOREIGN KEY (customer_fk) REFERENCES customers (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_customer_releases_build
+        FOREIGN KEY (build_fk) REFERENCES builds (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_customer_releases_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT uq_customer_releases_customer_build UNIQUE KEY (customer_fk, build_fk)
 );

--- a/scripts/seed_build_projects.py
+++ b/scripts/seed_build_projects.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""
+Seed darwin_dev with a Sample Project for the Build Visualizer (req #2606).
+
+Idempotent — uses natural-key UPSERTs so re-runs leave the same state.
+
+Creates:
+  1 build_projects row     "Sample Project"
+  1 trunk branch           (release type, project.trunk_branch_fk → here)
+  35 trunk builds          positions 0..34
+  3 above-side release branches  (release-1, release-2 — segment changes)
+  1 sample-release branch        (Sample/Sprint Release exemplar)
+  6 sub-branches                 (hotfix, bootleg, csr × 2, dev)
+  ~5 dev branches off m6        (dev-a, br20, br21, br22)
+  ~30 sub-branch builds          across all sub-branches
+  7 customer_releases events     HP→sr1, NVIDIA→sr2, Cisco→sr3,
+                                  HP+NVIDIA+Cisco+Google→r2c
+
+Fails fast if customers (HP/NVIDIA/Cisco/Google) are missing — they MUST be
+seeded by req #2604's own seed first (already done).
+
+Usage:
+    cd Lambda-Rest && . exports.sh && python3 ../DarwinSQL/scripts/seed_build_projects.py
+"""
+import os
+import sys
+
+import pymysql
+
+TARGET_DATABASE = 'darwin_dev'
+
+# Bill Williams primary user — owns the demo data
+DEFAULT_CREATOR_FK = '37df7531-000d-4470-8be4-1792d8261f69'
+BUILD_PROJECTS_CATEGORY_NAME = 'Build Projects'
+
+# Demo project shape — derived from Topology/build-visualizer/builds.json
+# Each tuple: (slug, branch_type, parent_branch_slug, parent_build_slug, build_count,
+#              segment_major, segment_minor, segment_initial_build_number, name)
+# slug is the in-script lookup key only (NOT stored in SQL).
+# The trunk has segment_* declared for segment 0.
+# Above-side release branches declare their NEXT trunk identity in segment_*.
+DEMO_BRANCHES = [
+    # slug,             branch_type,        parent_build_slug, builds_count, major, minor, name
+    # Trunk: major/minor are the project's starting identity. No segment bumps.
+    # Above-side releases: major/minor = the release's own identity (e.g. 5.1).
+    # Sub-branches inherit major/minor from their parent build's branch at
+    # creation time (the seed copies the value explicitly).
+    ('trunk',           'release',          None,           35,  5,  0,  'Main'),
+    ('release-1',       'release',          'm8',           3,   5,  1,  'Release 1'),
+    ('release-2',       'release',          'm18',          3,   5,  2,  'Release 2'),
+    ('sample-release',  'sample-release',   'm4',           4,   5,  0,  'Sample Release\nSprint Release'),
+    ('r1-hotfix',       'hotfix',           'r1-3',         3,   5,  1,  'R1 Hot Fix'),
+    ('r1-bootleg',      'bootleg',          'r1-3',         2,   5,  1,  'R1 Bootleg'),
+    ('r1-csr-1',        'csr',              'r1-3',         2,   5,  1,  'R1 CSR'),
+    ('r2-hotfix',       'hotfix',           'r2-3',         3,   5,  2,  'R2 Hot Fix'),
+    ('r2-csr',          'csr',              'r2-3',         3,   5,  2,  'R2 CSR'),
+    ('dev-a',           'development',      'm6',           3,   5,  0,  'Development Branches'),
+    ('br20',            'development',      'm6',           1,   5,  0,  'Branch 20'),
+    ('br21',            'development',      'm6',           1,   5,  0,  'Branch 21'),
+]
+
+# (branch_slug, position) -> stable build slug we use as a lookup key.
+# Position is 0-indexed. Slug pattern: trunk=m{n}, release-N=r{N}-{n}, sample-release=sr{n}, etc.
+def build_slug(branch_slug, position):
+    if branch_slug == 'trunk':
+        return f'm{position + 1}'
+    if branch_slug == 'release-1':
+        return f'r1-{position + 1}'
+    if branch_slug == 'release-2':
+        return f'r2-{position + 1}'
+    if branch_slug == 'sample-release':
+        return f'sr{position + 1}'
+    if branch_slug == 'r1-hotfix':
+        return f'h1-{position + 1}'
+    if branch_slug == 'r1-bootleg':
+        return f'bl1-{position + 1}'
+    if branch_slug == 'r1-csr-1':
+        return f'csr1-{position + 1}'
+    if branch_slug == 'r2-hotfix':
+        return f'h2-{position + 1}'
+    if branch_slug == 'r2-csr':
+        return f'csr2-{position + 1}'
+    if branch_slug == 'dev-a':
+        return f'da{position + 1}'
+    if branch_slug == 'br20':
+        return f'b20-{position + 1}'
+    if branch_slug == 'br21':
+        return f'b21-{position + 1}'
+    return f'{branch_slug}-{position + 1}'
+
+
+# Maps shipping-customer name to the build slug it received.
+# Each row = one customer_releases row.
+RELEASE_EVENTS = [
+    ('HP',     'sr1'),
+    ('NVIDIA', 'sr2'),
+    ('Cisco',  'sr3'),
+    ('HP',     'r2-3'),  # r2c in builds.json = r2-3 here (3rd build of release-2)
+    ('NVIDIA', 'r2-3'),
+    ('Cisco',  'r2-3'),
+    ('Google', 'r2-3'),
+]
+
+
+def get_admin_connection():
+    return pymysql.connect(
+        host=os.environ['endpoint'],
+        user=os.environ['username'],
+        password=os.environ['db_password'],
+        database=TARGET_DATABASE,
+        cursorclass=pymysql.cursors.DictCursor,
+        autocommit=True,
+    )
+
+
+def upsert_category(cur):
+    """UPSERT 'Build Projects' category for the demo creator. Returns id."""
+    cur.execute(
+        "SELECT id FROM categories WHERE category_name=%s AND creator_fk=%s",
+        (BUILD_PROJECTS_CATEGORY_NAME, DEFAULT_CREATOR_FK),
+    )
+    row = cur.fetchone()
+    if row:
+        return row['id']
+    # Categories require project_fk NOT NULL — reuse any existing project for this creator
+    cur.execute(
+        "SELECT id FROM projects WHERE creator_fk=%s ORDER BY id LIMIT 1",
+        (DEFAULT_CREATOR_FK,),
+    )
+    proj_row = cur.fetchone()
+    if not proj_row:
+        sys.exit(f"ABORT: no projects row for creator {DEFAULT_CREATOR_FK}; cannot create category")
+    cur.execute(
+        "INSERT INTO categories (category_name, project_fk, creator_fk) VALUES (%s, %s, %s)",
+        (BUILD_PROJECTS_CATEGORY_NAME, proj_row['id'], DEFAULT_CREATOR_FK),
+    )
+    return cur.lastrowid
+
+
+def upsert_project(cur, category_id):
+    """UPSERT 'Sample Project' build_projects row. Returns id."""
+    cur.execute(
+        "SELECT id FROM build_projects WHERE title=%s AND creator_fk=%s",
+        ('Sample Project', DEFAULT_CREATOR_FK),
+    )
+    row = cur.fetchone()
+    if row:
+        return row['id']
+    cur.execute(
+        """INSERT INTO build_projects
+           (title, description, project_status, category_fk, creator_fk)
+           VALUES (%s, %s, %s, %s, %s)""",
+        ('Sample Project',
+         'Demo project for the Build Visualizer. Trunk = a release-type Branch the project links to via trunk_branch_fk.',
+         'active', category_id, DEFAULT_CREATOR_FK),
+    )
+    return cur.lastrowid
+
+
+def upsert_branch(cur, project_id, branch_type, name, parent_build_id, major, minor):
+    """UPSERT one branch. Lookup key: (project_id, branch_type, name).
+
+    parent_build_fk is INTENTIONALLY excluded from the lookup — branches are
+    inserted in two passes (parent_build_fk patched after builds exist).
+    Re-running with the same (project, branch_type, name) updates major/minor
+    rather than inserting a duplicate.
+    """
+    cur.execute(
+        "SELECT id FROM branches WHERE project_fk=%s AND branch_type=%s AND name<=>%s",
+        (project_id, branch_type, name),
+    )
+    row = cur.fetchone()
+    if row:
+        cur.execute(
+            "UPDATE branches SET major=%s, minor=%s WHERE id=%s",
+            (major, minor, row['id']),
+        )
+        return row['id']
+    cur.execute(
+        """INSERT INTO branches
+           (project_fk, branch_type, name, major, minor, parent_build_fk, creator_fk)
+           VALUES (%s, %s, %s, %s, %s, %s, %s)""",
+        (project_id, branch_type, name, major, minor, parent_build_id, DEFAULT_CREATOR_FK),
+    )
+    return cur.lastrowid
+
+
+def upsert_build(cur, branch_id, position, build_number, branch_number,
+                 dot_color=None, approved_for_release=0):
+    """UPSERT one build. Lookup key: (branch_id, position). UNIQUE constraint.
+
+    build_number (B) and branch_number (b) are computed by the caller at seed
+    time using the version-scheme rules — matching what the UI would compute
+    once at build creation.
+    """
+    cur.execute(
+        "SELECT id FROM builds WHERE branch_fk=%s AND position=%s",
+        (branch_id, position),
+    )
+    row = cur.fetchone()
+    if row:
+        cur.execute(
+            """UPDATE builds SET build_number=%s, branch_number=%s,
+                     dot_color=%s, approved_for_release=%s WHERE id=%s""",
+            (build_number, branch_number, dot_color, approved_for_release, row['id']),
+        )
+        return row['id']
+    cur.execute(
+        """INSERT INTO builds (branch_fk, position, build_number, branch_number,
+                               dot_color, approved_for_release, creator_fk)
+           VALUES (%s, %s, %s, %s, %s, %s, %s)""",
+        (branch_id, position, build_number, branch_number,
+         dot_color, approved_for_release, DEFAULT_CREATOR_FK),
+    )
+    return cur.lastrowid
+
+
+# Compute the build_number (B) and branch_number (b) for a build at
+# (branch_type, position_within_branch, parent_trunk_build_number,
+#  ord0_among_same_type_siblings_off_same_parent_build,
+#  ord1_among_same_type_siblings_off_same_parent_build,
+#  trunk_starting_build_number).
+# Mirrors the design-guide §4.2 rules.
+def compute_build_numbers(branch_type, position, parent_trunk_build_number,
+                          ord0, ord1, trunk_starting_build_number):
+    if branch_type == 'release_trunk_marker':  # internal marker; trunk handled separately
+        return None
+    if parent_trunk_build_number is None:
+        # Trunk: monotonic from starting_build_number
+        return trunk_starting_build_number + position, 0
+    # Sub-branches: build_number FROZEN at parent's value; branch_number per type
+    B = parent_trunk_build_number
+    if branch_type in ('release', 'sample-release'):
+        b = position + 1
+    elif branch_type == 'csr':
+        b = ord1 * 1000 + position + 1
+    elif branch_type == 'hotfix':
+        b = 6000 + ord0 * 100 + position + 1
+    elif branch_type == 'development':
+        b = 7000 + ord0 * 100 + position + 1
+    elif branch_type == 'bootleg':
+        b = 9000 + ord0 * 100 + position + 1
+    else:
+        b = position + 1
+    return B, b
+
+
+def upsert_release_event(cur, customer_id, build_id, notes=None):
+    """UPSERT one customer_releases row. UNIQUE(customer_fk, build_fk)."""
+    cur.execute(
+        "SELECT id FROM customer_releases WHERE customer_fk=%s AND build_fk=%s",
+        (customer_id, build_id),
+    )
+    row = cur.fetchone()
+    if row:
+        return row['id']
+    cur.execute(
+        """INSERT INTO customer_releases (customer_fk, build_fk, release_notes, creator_fk)
+           VALUES (%s, %s, %s, %s)""",
+        (customer_id, build_id, notes, DEFAULT_CREATOR_FK),
+    )
+    return cur.lastrowid
+
+
+def lookup_customer_id(cur, customer_name):
+    cur.execute(
+        "SELECT id FROM customers WHERE customer_name=%s AND creator_fk=%s",
+        (customer_name, DEFAULT_CREATOR_FK),
+    )
+    row = cur.fetchone()
+    if not row:
+        sys.exit(f"ABORT: customer '{customer_name}' not seeded — run req #2604 customers seed first")
+    return row['id']
+
+
+def main():
+    conn = get_admin_connection()
+    with conn.cursor() as cur:
+        cur.execute("SELECT DATABASE() AS db")
+        actual = cur.fetchone()['db']
+        if actual != TARGET_DATABASE:
+            sys.exit(f"ABORT: expected '{TARGET_DATABASE}', got '{actual}'")
+
+        category_id = upsert_category(cur)
+        print(f"category '{BUILD_PROJECTS_CATEGORY_NAME}' id={category_id}")
+
+        project_id = upsert_project(cur, category_id)
+        print(f"project 'Sample Project' id={project_id}")
+
+        # Pass 1: create every branch row (parent_build_fk left NULL — patched
+        # later once builds exist). Trunk is created first since it has no
+        # parent_build dependency.
+        branch_id_by_slug = {}
+        for (slug, btype, parent_build_slug, count, major, minor, name) in DEMO_BRANCHES:
+            bid = upsert_branch(cur, project_id, btype, name, None, major, minor)
+            branch_id_by_slug[slug] = bid
+
+        trunk_id = branch_id_by_slug['trunk']
+        cur.execute(
+            "UPDATE build_projects SET trunk_branch_fk=%s WHERE id=%s",
+            (trunk_id, project_id),
+        )
+        print(f"trunk branch id={trunk_id}; project.trunk_branch_fk linked")
+
+        # Pass 2: insert builds. Trunk builds get monotonic B; sub-branch builds
+        # need their parent-trunk-build's B (FROZEN) — computed lazily as we
+        # walk DEMO_BRANCHES (trunk is first, so its B values are known by the
+        # time sub-branches are processed).
+        TRUNK_STARTING_BUILD_NUMBER = 1
+        build_id_by_slug = {}
+        # parent_build_slug -> trunk B at that build (for FROZEN inheritance)
+        # Populated as trunk builds are inserted.
+        trunk_build_number_by_slug = {}
+
+        # Count siblings for ord0/ord1 — group sub-branches by (branch_type, parent_build_slug).
+        from collections import defaultdict
+        sibling_ord = defaultdict(int)
+        ord0_by_slug = {}
+        for (slug, btype, parent_build_slug, count, major, minor, name) in DEMO_BRANCHES:
+            if parent_build_slug is None:
+                continue  # trunk
+            key = (btype, parent_build_slug)
+            ord0_by_slug[slug] = sibling_ord[key]
+            sibling_ord[key] += 1
+
+        for (slug, btype, parent_build_slug, count, major, minor, name) in DEMO_BRANCHES:
+            branch_id = branch_id_by_slug[slug]
+            for pos in range(count):
+                if parent_build_slug is None:
+                    # Trunk
+                    B = TRUNK_STARTING_BUILD_NUMBER + pos
+                    b = 0
+                else:
+                    parent_B = trunk_build_number_by_slug.get(parent_build_slug)
+                    # If parent isn't on trunk (e.g., r1-hotfix off r1-3), walk
+                    # up one level — r1-3 itself inherits from trunk's m8.
+                    if parent_B is None:
+                        # Find which trunk build the parent branch's parent_build is
+                        # (one level up). For seed simplicity, trace via metadata.
+                        for (s2, bt2, pb2, c2, mj2, mn2, n2) in DEMO_BRANCHES:
+                            if s2 == None:
+                                continue
+                            # find a sub-branch whose any build matches parent_build_slug
+                            for p2 in range(c2):
+                                if build_slug(s2, p2) == parent_build_slug:
+                                    # s2's parent_build_slug (one up) should be on trunk
+                                    parent_B = trunk_build_number_by_slug.get(pb2)
+                                    break
+                            if parent_B is not None:
+                                break
+                    ord0 = ord0_by_slug.get(slug, 0)
+                    ord1 = ord0 + 1
+                    B, b = compute_build_numbers(btype, pos, parent_B, ord0, ord1, TRUNK_STARTING_BUILD_NUMBER)
+                build = upsert_build(cur, branch_id, pos, B, b)
+                build_id_by_slug[build_slug(slug, pos)] = build
+                if parent_build_slug is None:
+                    trunk_build_number_by_slug[build_slug(slug, pos)] = B
+        print(f"builds inserted: {len(build_id_by_slug)} total")
+
+        # Pass 3: patch parent_build_fk on each non-trunk branch
+        for (slug, btype, parent_build_slug, count, major, minor, name) in DEMO_BRANCHES:
+            if not parent_build_slug:
+                continue
+            branch_id = branch_id_by_slug[slug]
+            parent_build_id = build_id_by_slug.get(parent_build_slug)
+            if not parent_build_id:
+                sys.exit(f"ABORT: parent build '{parent_build_slug}' not found for branch '{slug}'")
+            cur.execute(
+                "UPDATE branches SET parent_build_fk=%s WHERE id=%s",
+                (parent_build_id, branch_id),
+            )
+
+        # Customer releases — fail-fast on missing customer
+        for (customer_name, target_build_slug) in RELEASE_EVENTS:
+            customer_id = lookup_customer_id(cur, customer_name)
+            build_id = build_id_by_slug.get(target_build_slug)
+            if not build_id:
+                sys.exit(f"ABORT: build '{target_build_slug}' not found for release to {customer_name}")
+            upsert_release_event(cur, customer_id, build_id)
+            # Mark build approved_for_release=1 + clear dot_color
+            cur.execute(
+                "UPDATE builds SET approved_for_release=1, dot_color=NULL WHERE id=%s",
+                (build_id,),
+            )
+        print(f"customer_releases events inserted: {len(RELEASE_EVENTS)}")
+
+        # Final summary
+        cur.execute("SELECT COUNT(*) AS n FROM build_projects WHERE creator_fk=%s", (DEFAULT_CREATOR_FK,))
+        print(f"  build_projects: {cur.fetchone()['n']}")
+        cur.execute("SELECT COUNT(*) AS n FROM branches WHERE project_fk=%s", (project_id,))
+        print(f"  branches:       {cur.fetchone()['n']}")
+        cur.execute(
+            "SELECT COUNT(*) AS n FROM builds WHERE branch_fk IN (SELECT id FROM branches WHERE project_fk=%s)",
+            (project_id,),
+        )
+        print(f"  builds:         {cur.fetchone()['n']}")
+        cur.execute("SELECT COUNT(*) AS n FROM customer_releases WHERE creator_fk=%s", (DEFAULT_CREATOR_FK,))
+        print(f"  customer_releases: {cur.fetchone()['n']}")
+
+    conn.close()
+    print("done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1385,6 +1385,78 @@ def test_table_count(db_connection):
         'swarm_starts', 'swarm_start_sessions',
         # Req #2604 — Customer Release
         'customers',
+        # Req #2606 — Build Visualizer data model
+        'build_projects', 'branches', 'builds', 'customer_releases',
     }
     assert expected_tables == tables, \
         f"Unexpected tables: {tables - expected_tables}, missing: {expected_tables - tables}"
+
+
+# ============================================================================
+# Req #2606 — Build Visualizer data model column tests
+# ============================================================================
+
+def _columns(cur, table):
+    cur.execute(f"DESCRIBE {table}")
+    return {row['Field']: row for row in cur.fetchall()}
+
+
+def test_build_projects_columns(db_connection):
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'build_projects')
+    assert cols['title']['Null'] == 'NO'
+    assert cols['title']['Type'] == 'varchar(256)'
+    assert cols['description']['Null'] == 'YES'
+    assert cols['project_status']['Null'] == 'NO'
+    assert cols['project_status']['Default'] == 'draft'
+    assert cols['trunk_branch_fk']['Null'] == 'YES'
+    assert cols['category_fk']['Null'] == 'NO'
+    assert cols['creator_fk']['Null'] == 'NO'
+    # Req #2606: no `closed` column on any new build-feature table.
+    assert 'closed' not in cols
+
+
+def test_branches_columns(db_connection):
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'branches')
+    assert cols['project_fk']['Null'] == 'NO'
+    assert cols['branch_type']['Null'] == 'NO'
+    assert cols['name']['Null'] == 'YES'
+    assert cols['major']['Null'] == 'NO'
+    assert cols['minor']['Null'] == 'NO'
+    assert cols['parent_build_fk']['Null'] == 'YES'
+    assert cols['creator_fk']['Null'] == 'NO'
+    # Req #2606: parent_branch_fk REMOVED (derived via builds[parent_build_fk]).
+    assert 'parent_branch_fk' not in cols
+    # Req #2606: segment_* columns REMOVED (each branch carries M.m directly).
+    assert 'segment_major' not in cols
+    assert 'segment_minor' not in cols
+    assert 'segment_initial_build_number' not in cols
+    assert 'closed' not in cols
+
+
+def test_builds_columns(db_connection):
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'builds')
+    assert cols['branch_fk']['Null'] == 'NO'
+    assert cols['position']['Null'] == 'NO'
+    assert cols['build_number']['Null'] == 'NO'        # B — stored, computed once
+    assert cols['branch_number']['Null'] == 'NO'        # b — stored, 0 for trunk
+    assert cols['branch_number']['Default'] == '0'
+    assert cols['approved_for_release']['Null'] == 'NO'
+    assert cols['approved_for_release']['Default'] == '0'
+    assert cols['dot_color']['Null'] == 'YES'
+    assert cols['creator_fk']['Null'] == 'NO'
+    # Req #2606: no `closed` column; auto-numbered (no `title`).
+    assert 'closed' not in cols
+    assert 'title' not in cols
+
+
+def test_customer_releases_columns(db_connection):
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'customer_releases')
+    assert cols['customer_fk']['Null'] == 'NO'
+    assert cols['build_fk']['Null'] == 'NO'
+    assert cols['release_notes']['Null'] == 'YES'
+    assert cols['creator_fk']['Null'] == 'NO'
+    assert 'closed' not in cols


### PR DESCRIPTION
## Summary
- Merge branch 'main' of https://github.com/BillWilliams79/DarwinSQL into feature/2606-customer-release-events-sql-backed-1
- wip(DarwinSQL): 2026-05-24T22:42:01Z
- chore: init swarm session feature/2606-customer-release-events-sql-backed-1

## Files changed
```
 migrations/050_add_build_data_model.sql | 167 +++++++++++++
 schema.sql                              | 111 ++++++++-
 scripts/recreate_darwin_dev.sql         | 105 ++++++++-
 scripts/seed_build_projects.py          | 405 ++++++++++++++++++++++++++++++++
 tests/test_data_types.py                |  72 ++++++
 5 files changed, 857 insertions(+), 3 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)