### PR TITLE
req #2719

### DIFF
--- a/migrations/053_add_swarm_undos.sql
+++ b/migrations/053_add_swarm_undos.sql
@@ -1,0 +1,59 @@
+-- 053_add_swarm_undos.sql
+--
+-- Req #2719: define a swarm-undo data type so every /swarm-undo invocation
+-- emits a durable record of what was undone and why. Parallels swarm_starts
+-- (migration 046) — one row per /swarm-undo invocation, capturing a free-form
+-- reason from the user plus enough snapshot metadata to survive the cascade
+-- delete of the underlying swarm_sessions row.
+--
+-- session_fk is NULLABLE and ON DELETE SET NULL because /swarm-undo deletes the
+-- session row immediately after recording the undo. The snapshot columns
+-- (req_id_at_undo, task_name, branch, coordination_type, swarm_start_fk_at_undo)
+-- preserve the linkage history once the session row is gone.
+--
+-- Captured columns:
+--   session_fk             - live FK while the session exists; NULL after delete.
+--   swarm_start_fk_at_undo - snapshot of the swarm_start that launched this
+--                            session; enables visualizer matching (circle ->
+--                            tombstone) even after session_fk goes to NULL.
+--   req_id_at_undo         - snapshot of the requirement the session worked on.
+--   task_name              - snapshot kebab-case session label.
+--   branch                 - snapshot feature/<reqId>-<taskName> branch.
+--   coordination_type      - snapshot of planned|implemented|deployed.
+--   reason                 - mandatory free-text "why" supplied by the user
+--                            at undo time. Future hardening may convert this
+--                            to an enum/choice; today the column is the
+--                            authoritative record.
+
+CREATE TABLE swarm_undos (
+    id                       INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    session_fk               INT             NULL,
+    swarm_start_fk_at_undo   INT             NULL,
+    req_id_at_undo           INT             NULL,
+    task_name                VARCHAR(255)    NULL,
+    branch                   VARCHAR(255)    NULL,
+    coordination_type        VARCHAR(16)     NULL,
+    reason                   TEXT            NOT NULL,
+    undone_at                TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    creator_fk               VARCHAR(64)     NOT NULL,
+    create_ts                TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts                TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_swarm_undos_session
+        FOREIGN KEY (session_fk) REFERENCES swarm_sessions (id)
+        ON UPDATE CASCADE ON DELETE SET NULL,
+    CONSTRAINT fk_swarm_undos_swarm_start
+        FOREIGN KEY (swarm_start_fk_at_undo) REFERENCES swarm_starts (id)
+        ON UPDATE CASCADE ON DELETE SET NULL,
+    CONSTRAINT fk_swarm_undos_req
+        FOREIGN KEY (req_id_at_undo) REFERENCES requirements (id)
+        ON UPDATE CASCADE ON DELETE SET NULL,
+    CONSTRAINT fk_swarm_undos_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE INDEX ix_swarm_undos_swarm_start_fk_at_undo
+    ON swarm_undos (swarm_start_fk_at_undo);
+
+CREATE INDEX ix_swarm_undos_undone_at
+    ON swarm_undos (undone_at);

--- a/schema.sql
+++ b/schema.sql
@@ -1,6 +1,6 @@
 -- Darwin Database Schema — Current State
 -- Database: darwin
--- This file reflects the final state of all 32 tables after all migrations.
+-- This file reflects the final state of all 33 tables after all migrations.
 -- It can be run against a fresh MySQL instance to create the complete schema.
 -- Table order respects FK dependencies.
 
@@ -248,6 +248,40 @@ CREATE TABLE IF NOT EXISTS swarm_start_sessions (
     CONSTRAINT fk_sss_session
         FOREIGN KEY (session_fk) REFERENCES swarm_sessions (id)
         ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+-- swarm_undos: one row per /swarm-undo invocation. Execution table — no
+-- closed flag, no sort_order (chronological by undone_at), no category_fk
+-- (inherits from the session/requirement being undone). Captures a mandatory
+-- free-text reason from the user plus snapshot metadata so the record survives
+-- the session-row deletion that /swarm-undo performs immediately afterwards.
+CREATE TABLE IF NOT EXISTS swarm_undos (
+    id                       INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    session_fk               INT             NULL,
+    swarm_start_fk_at_undo   INT             NULL,
+    req_id_at_undo           INT             NULL,
+    task_name                VARCHAR(255)    NULL,
+    branch                   VARCHAR(255)    NULL,
+    coordination_type        VARCHAR(16)     NULL,
+    reason                   TEXT            NOT NULL,
+    undone_at                TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    creator_fk               VARCHAR(64)     NOT NULL,
+    create_ts                TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts                TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_swarm_undos_session
+        FOREIGN KEY (session_fk) REFERENCES swarm_sessions (id)
+        ON UPDATE CASCADE ON DELETE SET NULL,
+    CONSTRAINT fk_swarm_undos_swarm_start
+        FOREIGN KEY (swarm_start_fk_at_undo) REFERENCES swarm_starts (id)
+        ON UPDATE CASCADE ON DELETE SET NULL,
+    CONSTRAINT fk_swarm_undos_req
+        FOREIGN KEY (req_id_at_undo) REFERENCES requirements (id)
+        ON UPDATE CASCADE ON DELETE SET NULL,
+    CONSTRAINT fk_swarm_undos_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    KEY ix_swarm_undos_swarm_start_fk_at_undo (swarm_start_fk_at_undo),
+    KEY ix_swarm_undos_undone_at (undone_at)
 );
 
 -- ============================================================================

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -1,7 +1,7 @@
 -- Recreate darwin_dev test/dev tables from scratch
 -- Uses production-identical table names (same DDL as schema.sql)
 -- Idempotent: safe to run repeatedly to reset darwin_dev to canonical state
--- All 32 tables in FK-dependency order
+-- All 33 tables in FK-dependency order
 
 USE darwin_dev;
 
@@ -13,6 +13,7 @@ DROP TABLE IF EXISTS customer_releases, builds, branches, build_projects,
     map_run_partners, map_partners,
     map_views, map_coordinates, map_runs, map_routes,
     priority_card_order, dev_servers,
+    swarm_undos,
     swarm_start_sessions, swarm_starts,
     requirement_sessions,
     requirements, swarm_sessions, categories, projects,
@@ -240,6 +241,35 @@ CREATE TABLE swarm_start_sessions (
     CONSTRAINT fk_sss_session
         FOREIGN KEY (session_fk) REFERENCES swarm_sessions (id)
         ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE swarm_undos (
+    id                       INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    session_fk               INT             NULL,
+    swarm_start_fk_at_undo   INT             NULL,
+    req_id_at_undo           INT             NULL,
+    task_name                VARCHAR(255)    NULL,
+    branch                   VARCHAR(255)    NULL,
+    coordination_type        VARCHAR(16)     NULL,
+    reason                   TEXT            NOT NULL,
+    undone_at                TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    creator_fk               VARCHAR(64)     NOT NULL,
+    create_ts                TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts                TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_swarm_undos_session
+        FOREIGN KEY (session_fk) REFERENCES swarm_sessions (id)
+        ON UPDATE CASCADE ON DELETE SET NULL,
+    CONSTRAINT fk_swarm_undos_swarm_start
+        FOREIGN KEY (swarm_start_fk_at_undo) REFERENCES swarm_starts (id)
+        ON UPDATE CASCADE ON DELETE SET NULL,
+    CONSTRAINT fk_swarm_undos_req
+        FOREIGN KEY (req_id_at_undo) REFERENCES requirements (id)
+        ON UPDATE CASCADE ON DELETE SET NULL,
+    CONSTRAINT fk_swarm_undos_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    KEY ix_swarm_undos_swarm_start_fk_at_undo (swarm_start_fk_at_undo),
+    KEY ix_swarm_undos_undone_at (undone_at)
 );
 
 -- Dev server port coordination

--- a/tests/test_cascades.py
+++ b/tests/test_cascades.py
@@ -1029,3 +1029,163 @@ def test_delete_test_plan_cascades_to_plan_cases(db_connection):
         cur.execute("SELECT id FROM test_cases WHERE id = %s", (case_id,))
         assert cur.fetchone() is not None
     db_connection.rollback()
+
+
+# ============================================================================
+# swarm_undos (req #2719) — the core design invariant of this table is that
+# the row survives every parent-row deletion via ON DELETE SET NULL, so the
+# audit-trail of "this launch was undone, here's the reason" persists even
+# after /swarm-undo removes the session row and the requirement is flipped
+# back to approved. These four tests pin that invariant down per FK.
+# ============================================================================
+
+def test_delete_session_sets_swarm_undo_session_fk_null(db_connection, test_category_id):
+    """DELETE swarm_session → swarm_undos.session_fk = NULL, undo row survives.
+
+    This is the load-bearing invariant: `/swarm-undo` writes the undo row
+    BEFORE deleting the session (Step 2.6 before Step 6 of the skill); the
+    cascade then nulls the back-reference while the snapshot columns
+    (swarm_start_fk_at_undo, req_id_at_undo, task_name, branch, ...) keep
+    full record of what was undone.
+    """
+    test_creator = 'cascade-test-undo-session-1'
+
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO profiles (id, name, email) VALUES (%s, %s, %s)",
+            (test_creator, 'Cascade Test Profile', 'cascade-undo-1@test.com')
+        )
+        cur.execute(
+            "INSERT INTO swarm_sessions (swarm_status, creator_fk) VALUES (%s, %s)",
+            ('active', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        session_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO swarm_undos (session_fk, reason, creator_fk) "
+            "VALUES (%s, %s, %s)",
+            (session_id, 'cascade-test-undo-reason', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        undo_id = cur.fetchone()['id']
+
+        cur.execute("DELETE FROM swarm_sessions WHERE id = %s", (session_id,))
+
+        cur.execute("SELECT session_fk, reason FROM swarm_undos WHERE id = %s",
+                    (undo_id,))
+        row = cur.fetchone()
+        assert row is not None, "swarm_undo row was deleted; should have survived"
+        assert row['session_fk'] is None, \
+            "session_fk should be NULLed by ON DELETE SET NULL"
+        assert row['reason'] == 'cascade-test-undo-reason', \
+            "snapshot columns must survive the cascade unchanged"
+
+    db_connection.rollback()
+
+
+def test_delete_swarm_start_sets_swarm_undo_start_fk_null(db_connection):
+    """DELETE swarm_start → swarm_undos.swarm_start_fk_at_undo = NULL,
+    undo row survives. swarm_starts are not deleted by /swarm-undo today,
+    but this FK behavior is the safety net for future cleanup paths.
+    """
+    test_creator = 'cascade-test-undo-start-1'
+
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO profiles (id, name, email) VALUES (%s, %s, %s)",
+            (test_creator, 'Cascade Test Profile', 'cascade-undo-2@test.com')
+        )
+        cur.execute(
+            "INSERT INTO swarm_starts (creator_fk) VALUES (%s)",
+            (test_creator,)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        start_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO swarm_undos (swarm_start_fk_at_undo, reason, creator_fk) "
+            "VALUES (%s, %s, %s)",
+            (start_id, 'cascade-test-start-fk', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        undo_id = cur.fetchone()['id']
+
+        cur.execute("DELETE FROM swarm_starts WHERE id = %s", (start_id,))
+
+        cur.execute(
+            "SELECT swarm_start_fk_at_undo, reason FROM swarm_undos WHERE id = %s",
+            (undo_id,)
+        )
+        row = cur.fetchone()
+        assert row is not None
+        assert row['swarm_start_fk_at_undo'] is None
+        assert row['reason'] == 'cascade-test-start-fk'
+
+    db_connection.rollback()
+
+
+def test_delete_requirement_sets_swarm_undo_req_fk_null(db_connection, test_category_id):
+    """DELETE requirement → swarm_undos.req_id_at_undo = NULL, undo row
+    survives."""
+    test_creator = 'cascade-test-undo-req-1'
+
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO profiles (id, name, email) VALUES (%s, %s, %s)",
+            (test_creator, 'Cascade Test Profile', 'cascade-undo-3@test.com')
+        )
+        cur.execute(
+            "INSERT INTO requirements (title, creator_fk, category_fk) "
+            "VALUES (%s, %s, %s)",
+            ('Cascade Undo Req', test_creator, test_category_id)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        req_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO swarm_undos (req_id_at_undo, reason, creator_fk) "
+            "VALUES (%s, %s, %s)",
+            (req_id, 'cascade-test-req-fk', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        undo_id = cur.fetchone()['id']
+
+        cur.execute("DELETE FROM requirements WHERE id = %s", (req_id,))
+
+        cur.execute(
+            "SELECT req_id_at_undo, reason FROM swarm_undos WHERE id = %s",
+            (undo_id,)
+        )
+        row = cur.fetchone()
+        assert row is not None
+        assert row['req_id_at_undo'] is None
+        assert row['reason'] == 'cascade-test-req-fk'
+
+    db_connection.rollback()
+
+
+def test_delete_profile_cascades_to_swarm_undos(db_connection):
+    """DELETE profile → swarm_undos rows owned by the profile are deleted
+    (ON DELETE CASCADE on creator_fk)."""
+    test_creator = 'cascade-test-undo-creator-1'
+
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO profiles (id, name, email) VALUES (%s, %s, %s)",
+            (test_creator, 'Cascade Test Profile', 'cascade-undo-4@test.com')
+        )
+        cur.execute(
+            "INSERT INTO swarm_undos (reason, creator_fk) VALUES (%s, %s)",
+            ('cascade-test-creator', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        undo_id = cur.fetchone()['id']
+
+        cur.execute("DELETE FROM profiles WHERE id = %s", (test_creator,))
+
+        cur.execute("SELECT id FROM swarm_undos WHERE id = %s", (undo_id,))
+        assert cur.fetchone() is None, \
+            "swarm_undo row should be cascade-deleted when its creator profile is deleted"
+
+    db_connection.rollback()

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -668,6 +668,65 @@ def test_swarm_start_sessions_columns(db_connection):
     assert columns['session_fk']['Key'] == 'PRI'
 
 
+def test_swarm_undos_columns(db_connection):
+    """Verify swarm_undos column definitions match migration 053 (req #2719).
+
+    Expected columns:
+    - id: INT, PRI, AUTO_INCREMENT
+    - session_fk: INT, NULL, MUL (ON DELETE SET NULL)
+    - swarm_start_fk_at_undo: INT, NULL, MUL (snapshot)
+    - req_id_at_undo: INT, NULL, MUL (snapshot)
+    - task_name: VARCHAR(255), NULL
+    - branch: VARCHAR(255), NULL
+    - coordination_type: VARCHAR(16), NULL
+    - reason: TEXT, NOT NULL
+    - undone_at: TIMESTAMP, NOT NULL, DEFAULT CURRENT_TIMESTAMP
+    - creator_fk: VARCHAR(64), NOT NULL, MUL
+    - create_ts / update_ts: TIMESTAMP, NULL
+    """
+    with db_connection.cursor() as cur:
+        cur.execute("DESCRIBE swarm_undos")
+        columns = {row['Field']: row for row in cur.fetchall()}
+
+    expected_fields = ['id', 'session_fk', 'swarm_start_fk_at_undo',
+                       'req_id_at_undo', 'task_name', 'branch',
+                       'coordination_type', 'reason',
+                       'undone_at', 'creator_fk', 'create_ts', 'update_ts']
+    assert set(columns.keys()) == set(expected_fields)
+
+    assert columns['id']['Type'] == 'int'
+    assert columns['id']['Key'] == 'PRI'
+    assert columns['id']['Extra'] == 'auto_increment'
+
+    assert columns['session_fk']['Type'] == 'int'
+    assert columns['session_fk']['Null'] == 'YES'
+
+    assert columns['swarm_start_fk_at_undo']['Type'] == 'int'
+    assert columns['swarm_start_fk_at_undo']['Null'] == 'YES'
+
+    assert columns['req_id_at_undo']['Type'] == 'int'
+    assert columns['req_id_at_undo']['Null'] == 'YES'
+
+    assert columns['task_name']['Type'] == 'varchar(255)'
+    assert columns['task_name']['Null'] == 'YES'
+
+    assert columns['branch']['Type'] == 'varchar(255)'
+    assert columns['branch']['Null'] == 'YES'
+
+    assert columns['coordination_type']['Type'] == 'varchar(16)'
+    assert columns['coordination_type']['Null'] == 'YES'
+
+    assert columns['reason']['Type'] == 'text'
+    assert columns['reason']['Null'] == 'NO'
+
+    assert 'timestamp' in columns['undone_at']['Type']
+    assert columns['undone_at']['Null'] == 'NO'
+
+    assert columns['creator_fk']['Type'] == 'varchar(64)'
+    assert columns['creator_fk']['Null'] == 'NO'
+    assert columns['creator_fk']['Key'] == 'MUL'
+
+
 def test_dev_servers_columns(db_connection):
     """Verify dev_servers column definitions match schema.sql.
 
@@ -1399,6 +1458,8 @@ def test_table_count(db_connection):
         'customers',
         # Req #2606 — Build Visualizer data model
         'build_projects', 'branches', 'builds', 'customer_releases',
+        # Req #2719 — swarm-undo data type
+        'swarm_undos',
     }
     assert expected_tables == tables, \
         f"Unexpected tables: {tables - expected_tables}, missing: {expected_tables - tables}"


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-05-28T08:37:52Z
- chore: init swarm session feature/2719-swarm-undo-data-and-tombstone-1

## Files changed
```
 migrations/053_add_swarm_undos.sql |  59 ++++++++++++++
 schema.sql                         |  36 ++++++++-
 scripts/recreate_darwin_dev.sql    |  32 +++++++-
 tests/test_cascades.py             | 160 +++++++++++++++++++++++++++++++++++++
 tests/test_data_types.py           |  61 ++++++++++++++
 5 files changed, 346 insertions(+), 2 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)