### PR TITLE
req #2723

### DIFF
--- a/migrations/054_decouple_build_projects_from_categories.sql
+++ b/migrations/054_decouple_build_projects_from_categories.sql
@@ -1,0 +1,30 @@
+-- 054_decouple_build_projects_from_categories.sql
+--
+-- Req #2723: build_projects is a top-level Build Visualizer entity and does
+-- not need a categorization dimension. The schema previously declared
+-- build_projects.category_fk NOT NULL FK -> categories(id) ON DELETE RESTRICT,
+-- which forced seed_build_projects.py to insert a 'Build Projects' row in the
+-- categories table just to host the 3 real build_projects rows. That row
+-- then leaked into the Requirements UI as a ghost category that could not be
+-- deleted (FK constraint -> 500).
+--
+-- Fix: drop the FK + column from build_projects, then delete the now-orphan
+-- 'Build Projects' categories rows. The 3 real build_projects rows
+-- ("Sample Project", "Default", "Sprint Cycle") are preserved untouched.
+--
+-- Verified on 2026-05-28:
+--   darwin     cat id=1202 (creator 37df7531-..., project_fk=1)   — only Build Projects row
+--   darwin_dev cat id=635  (creator 37df7531-..., project_fk=409) — only Build Projects row
+--
+-- The DELETE filters by name only — if a future user has reqs/features/
+-- test_cases/test_plans pointing at a 'Build Projects' category the
+-- ON DELETE RESTRICT on those FKs will abort the DELETE and the migration
+-- fails closed. Today no such rows exist.
+
+ALTER TABLE build_projects
+    DROP FOREIGN KEY fk_build_projects_category;
+
+ALTER TABLE build_projects
+    DROP COLUMN category_fk;
+
+DELETE FROM categories WHERE category_name = 'Build Projects';

--- a/schema.sql
+++ b/schema.sql
@@ -591,13 +591,9 @@ CREATE TABLE IF NOT EXISTS build_projects (
     project_status  VARCHAR(16)     NOT NULL DEFAULT 'draft', -- draft|active|archived
     trunk_branch_fk INT             NULL, -- FK declared at bottom (circular: -> branches)
     sort_order      SMALLINT        NULL,
-    category_fk     INT             NOT NULL,
     creator_fk      VARCHAR(64)     NOT NULL,
     create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
     update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
-    CONSTRAINT fk_build_projects_category
-        FOREIGN KEY (category_fk) REFERENCES categories (id)
-        ON UPDATE CASCADE ON DELETE RESTRICT,
     CONSTRAINT fk_build_projects_creator
         FOREIGN KEY (creator_fk) REFERENCES profiles (id)
         ON UPDATE CASCADE ON DELETE CASCADE,

--- a/scripts/import_builds_json.py
+++ b/scripts/import_builds_json.py
@@ -49,7 +49,6 @@ from _production_snapshot_guard import assert_recent_production_snapshot
 
 # Bill Williams primary user — owns the imported demo data
 DEFAULT_CREATOR_FK = '37df7531-000d-4470-8be4-1792d8261f69'
-BUILD_PROJECTS_CATEGORY_NAME = 'Build Projects'
 DEFAULT_IMPORT_TITLE = 'Default'
 
 ALLOWED_DATABASES = ('darwin_dev', 'darwin')
@@ -82,23 +81,7 @@ def assert_target_db(cur, target_database):
         sys.exit(f"ABORT: expected '{target_database}', got '{actual}'")
 
 
-def lookup_category_id(cur):
-    cur.execute(
-        "SELECT id FROM categories WHERE category_name=%s AND creator_fk=%s",
-        (BUILD_PROJECTS_CATEGORY_NAME, DEFAULT_CREATOR_FK),
-    )
-    row = cur.fetchone()
-    if row:
-        return row['id']
-    # Category must exist (seeded by seed_build_projects.py). Fail fast — this
-    # script's job is import, not seeding the surrounding scaffolding.
-    sys.exit(
-        f"ABORT: category '{BUILD_PROJECTS_CATEGORY_NAME}' not found for creator "
-        f"{DEFAULT_CREATOR_FK}; run seed_build_projects.py first."
-    )
-
-
-def upsert_project(cur, category_id, title, description):
+def upsert_project(cur, title, description):
     cur.execute(
         "SELECT id FROM build_projects WHERE title=%s AND creator_fk=%s",
         (title, DEFAULT_CREATOR_FK),
@@ -108,9 +91,9 @@ def upsert_project(cur, category_id, title, description):
         return row['id']
     cur.execute(
         """INSERT INTO build_projects
-           (title, description, project_status, category_fk, creator_fk)
-           VALUES (%s, %s, %s, %s, %s)""",
-        (title, description, 'active', category_id, DEFAULT_CREATOR_FK),
+           (title, description, project_status, creator_fk)
+           VALUES (%s, %s, %s, %s)""",
+        (title, description, 'active', DEFAULT_CREATOR_FK),
     )
     return cur.lastrowid
 
@@ -308,8 +291,7 @@ def main():
     with conn.cursor() as cur:
         assert_target_db(cur, target_database)
 
-        category_id = lookup_category_id(cur)
-        project_id = upsert_project(cur, category_id, args.title, description)
+        project_id = upsert_project(cur, args.title, description)
         print(f"project '{args.title}' id={project_id}")
 
         # Pass 1: insert every non-cr branch (parent_build_fk NULL — patched later).

--- a/scripts/seed_build_projects.py
+++ b/scripts/seed_build_projects.py
@@ -39,7 +39,6 @@ from _production_snapshot_guard import assert_recent_production_snapshot
 
 # Bill Williams primary user — owns the demo data
 DEFAULT_CREATOR_FK = '37df7531-000d-4470-8be4-1792d8261f69'
-BUILD_PROJECTS_CATEGORY_NAME = 'Build Projects'
 
 ALLOWED_DATABASES = ('darwin_dev', 'darwin')
 PRODUCTION_DATABASE = 'darwin'
@@ -124,31 +123,7 @@ def get_admin_connection(database):
     )
 
 
-def upsert_category(cur):
-    """UPSERT 'Build Projects' category for the demo creator. Returns id."""
-    cur.execute(
-        "SELECT id FROM categories WHERE category_name=%s AND creator_fk=%s",
-        (BUILD_PROJECTS_CATEGORY_NAME, DEFAULT_CREATOR_FK),
-    )
-    row = cur.fetchone()
-    if row:
-        return row['id']
-    # Categories require project_fk NOT NULL — reuse any existing project for this creator
-    cur.execute(
-        "SELECT id FROM projects WHERE creator_fk=%s ORDER BY id LIMIT 1",
-        (DEFAULT_CREATOR_FK,),
-    )
-    proj_row = cur.fetchone()
-    if not proj_row:
-        sys.exit(f"ABORT: no projects row for creator {DEFAULT_CREATOR_FK}; cannot create category")
-    cur.execute(
-        "INSERT INTO categories (category_name, project_fk, creator_fk) VALUES (%s, %s, %s)",
-        (BUILD_PROJECTS_CATEGORY_NAME, proj_row['id'], DEFAULT_CREATOR_FK),
-    )
-    return cur.lastrowid
-
-
-def upsert_project(cur, category_id):
+def upsert_project(cur):
     """UPSERT 'Sample Project' build_projects row. Returns id."""
     cur.execute(
         "SELECT id FROM build_projects WHERE title=%s AND creator_fk=%s",
@@ -159,11 +134,11 @@ def upsert_project(cur, category_id):
         return row['id']
     cur.execute(
         """INSERT INTO build_projects
-           (title, description, project_status, category_fk, creator_fk)
-           VALUES (%s, %s, %s, %s, %s)""",
+           (title, description, project_status, creator_fk)
+           VALUES (%s, %s, %s, %s)""",
         ('Sample Project',
          'Demo project for the Build Visualizer. Trunk = a release-type Branch the project links to via trunk_branch_fk.',
-         'active', category_id, DEFAULT_CREATOR_FK),
+         'active', DEFAULT_CREATOR_FK),
     )
     return cur.lastrowid
 
@@ -317,10 +292,7 @@ def main():
         if actual != target_database:
             sys.exit(f"ABORT: expected '{target_database}', got '{actual}'")
 
-        category_id = upsert_category(cur)
-        print(f"category '{BUILD_PROJECTS_CATEGORY_NAME}' id={category_id}")
-
-        project_id = upsert_project(cur, category_id)
+        project_id = upsert_project(cur)
         print(f"project 'Sample Project' id={project_id}")
 
         # Pass 1: create every branch row (parent_build_fk left NULL — patched

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1483,10 +1483,11 @@ def test_build_projects_columns(db_connection):
     assert cols['project_status']['Null'] == 'NO'
     assert cols['project_status']['Default'] == 'draft'
     assert cols['trunk_branch_fk']['Null'] == 'YES'
-    assert cols['category_fk']['Null'] == 'NO'
     assert cols['creator_fk']['Null'] == 'NO'
     # Req #2606: no `closed` column on any new build-feature table.
     assert 'closed' not in cols
+    # Req #2723: build_projects no longer carries a category_fk.
+    assert 'category_fk' not in cols
 
 
 def test_branches_columns(db_connection):


### PR DESCRIPTION
## Summary
- Decouple build_projects from categories (delete orphan Build Projects category) (req #2723)
- chore: init swarm session feature/2723-decouple-build-projects-from-1

## Files changed
```
 ...054_decouple_build_projects_from_categories.sql | 30 +++++++++++++++++
 schema.sql                                         |  4 ---
 scripts/import_builds_json.py                      | 28 +++-------------
 scripts/seed_build_projects.py                     | 38 +++-------------------
 tests/test_data_types.py                           |  3 +-
 5 files changed, 42 insertions(+), 61 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)