### PR TITLE
req #2745

### DIFF
--- a/migrations/056_coordination_type_not_null.sql
+++ b/migrations/056_coordination_type_not_null.sql
@@ -1,0 +1,30 @@
+-- 056_coordination_type_not_null.sql
+--
+-- Req #2745: autonomy (coordination_type) is now MANDATORY on requirements.
+-- The new 'discuss' coordination type replaces the old "no setting" (NULL)
+-- behavior with an explicit, intentional waiting state, so an empty autonomy
+-- is no longer a meaningful state — every requirement must carry one of
+-- discuss | planned | implemented | deployed.
+--
+-- This migration enforces that at the database level so neither the UI, the
+-- MCP layer, nor raw SQL can reintroduce a NULL.
+--
+-- Step 1 backfills any remaining NULLs to 'discuss' (the value chosen for
+-- previously-unset requirements during the req #2745 backfill — anything left
+-- unset was intentionally left for discussion). In production the backfill was
+-- already applied via MCP; this UPDATE is a no-op there and a safety net for
+-- darwin_dev / any clone with stragglers.
+--
+-- Step 2 makes the column NOT NULL while preserving the existing
+-- DEFAULT 'implemented' so omitted-column INSERTs continue to get a valid value.
+--
+-- Affects the `requirements` table only. swarm_undos.coordination_type and
+-- swarm_completes.coordination_type remain NULLABLE — they are snapshot/log
+-- columns that legitimately record the absence of a prior coordination value.
+
+-- Step 1: backfill stragglers
+UPDATE requirements SET coordination_type = 'discuss' WHERE coordination_type IS NULL;
+
+-- Step 2: enforce NOT NULL (default unchanged)
+ALTER TABLE requirements
+    MODIFY coordination_type VARCHAR(16) NOT NULL DEFAULT 'implemented';

--- a/schema.sql
+++ b/schema.sql
@@ -152,8 +152,8 @@ CREATE TABLE IF NOT EXISTS requirements (
     creator_fk      VARCHAR(64)     NOT NULL,
     create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
     update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
-    coordination_type VARCHAR(16)   NULL DEFAULT 'implemented',
-                                            -- planned | implemented | deployed (default: implemented)
+    coordination_type VARCHAR(16)   NOT NULL DEFAULT 'implemented',
+                                            -- discuss | planned | implemented | deployed (mandatory, req #2745; default: implemented)
     sort_order      SMALLINT        NULL DEFAULT NULL,
                                             -- in-card hand-sort position (req #2417); NULL = unranked, falls to id-order
     affected_repos  VARCHAR(255)    NULL DEFAULT NULL,

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -158,6 +158,7 @@ CREATE TABLE requirements (
     creator_fk      VARCHAR(64)     NOT NULL,
     create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
     update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    coordination_type VARCHAR(16)   NOT NULL DEFAULT 'implemented',  -- mandatory autonomy (req #2745)
     FOREIGN KEY (project_fk)
         REFERENCES projects (id)
         ON UPDATE CASCADE ON DELETE SET NULL,

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -402,7 +402,7 @@ def test_requirements_columns(db_connection):
     - creator_fk: VARCHAR(64), NOT NULL, MUL
     - create_ts: TIMESTAMP, NULL
     - update_ts: TIMESTAMP, NULL
-    - coordination_type: VARCHAR(16), NULL, DEFAULT 'implemented'
+    - coordination_type: VARCHAR(16), NOT NULL, DEFAULT 'implemented' (mandatory, req #2745)
     - sort_order: SMALLINT, NULL, DEFAULT NULL  (req #2417 — in-card hand sort)
     - affected_repos: VARCHAR(255), NULL, DEFAULT NULL  (req #2583 — per-requirement repo override)
     """
@@ -461,7 +461,7 @@ def test_requirements_columns(db_connection):
     assert columns['creator_fk']['Key'] == 'MUL'
 
     assert columns['coordination_type']['Type'] == 'varchar(16)'
-    assert columns['coordination_type']['Null'] == 'YES'
+    assert columns['coordination_type']['Null'] == 'NO'   # mandatory autonomy (req #2745)
     assert columns['coordination_type']['Default'] == 'implemented'
 
     assert columns['sort_order']['Type'] == 'smallint'


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-06-01T08:06:51Z
- chore: init swarm session feature/2745-new-coordination-type-discuss-req-1

## Files changed
```
 migrations/056_coordination_type_not_null.sql | 30 +++++++++++++++++++++++++++
 schema.sql                                    |  4 ++--
 scripts/recreate_darwin_dev.sql               |  1 +
 tests/test_data_types.py                      |  4 ++--
 4 files changed, 35 insertions(+), 4 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)