### PR TITLE
New Data Types: Acceptance Test

### DIFF
--- a/migrations/061_add_acceptance_tests.sql
+++ b/migrations/061_add_acceptance_tests.sql
@@ -1,0 +1,65 @@
+-- 061_add_acceptance_tests.sql
+--
+-- Req #2633: New data type — Acceptance Test (AT).
+--
+-- An Acceptance Test is a named test gate a software release must pass before
+-- the release event is approved. ATs are a reusable CATALOG (Build AT, Daily
+-- AT, Sprint AT, Functional AT, OEM AT, RC AT, Cert AT); each branch is
+-- assigned a set of required ATs (the branch-type -> AT matrix lives in the
+-- frontend config map). A single pass/fail status is recorded PER BRANCH.
+--
+-- DARWIN_DEV ONLY. The Build Visualizer data model lives only in `darwin_dev`
+-- after req #2760 (the 5 build-viz tables were dropped from production
+-- `darwin` by migration 057). These two tables + the branches column follow
+-- the same rule: apply to `darwin_dev`, never to production `darwin`. They are
+-- carried in the dev-superset (schema.sql + scripts/recreate_darwin_dev.sql).
+--
+-- acceptance_tests          catalog table. Follows the build-viz CATALOG shape
+--                           (mirrors `customers`): closed + sort_order, NO
+--                           category_fk. Adds:
+--                             acceptance_test_status  pass|fail (default pass)
+--                             expected_wall_mins      user-set expected wall
+--                                                     clock, in minutes.
+-- branch_acceptance_tests   junction: which branch-level ATs apply to a branch.
+--                           Composite PK, CASCADE both sides, sort_order for
+--                           per-branch label stacking. (Build AT is render-only
+--                           per build and is NOT stored here.)
+-- branches.acceptance_test_status  single pass/fail covering the branch's
+--                           branch-level ATs (drives the green/red AT glyph;
+--                           build dot color + approved_for_release untouched).
+--
+-- No circular FKs here (acceptance_tests -> profiles; junction -> branches +
+-- acceptance_tests; all referenced tables pre-exist), so no deferred ALTER /
+-- FK-checks-off block is needed.
+
+CREATE TABLE IF NOT EXISTS acceptance_tests (
+    id                      INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title                   VARCHAR(256)    NOT NULL,                 -- AT name, e.g. "Sprint AT"
+    description             TEXT            NULL,
+    acceptance_test_status  VARCHAR(16)     NOT NULL DEFAULT 'pass',  -- pass|fail (default pass)
+    expected_wall_mins      INT             NULL,                     -- user-set expected wall clock, minutes
+    closed                  TINYINT(1)      NOT NULL DEFAULT 0,
+    sort_order              SMALLINT        NULL,
+    creator_fk              VARCHAR(64)     NOT NULL,
+    create_ts               TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts               TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_acceptance_tests_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS branch_acceptance_tests (
+    branch_fk           INT         NOT NULL,
+    acceptance_test_fk  INT         NOT NULL,
+    sort_order          SMALLINT    NULL,   -- per-branch AT label stacking order
+    PRIMARY KEY (branch_fk, acceptance_test_fk),
+    CONSTRAINT fk_bat_branch
+        FOREIGN KEY (branch_fk) REFERENCES branches (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_bat_acceptance_test
+        FOREIGN KEY (acceptance_test_fk) REFERENCES acceptance_tests (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+ALTER TABLE branches
+    ADD COLUMN acceptance_test_status VARCHAR(16) NULL DEFAULT 'pass' AFTER external_id;

--- a/schema.sql
+++ b/schema.sql
@@ -702,6 +702,7 @@ CREATE TABLE IF NOT EXISTS branches (
     label_end           VARCHAR(128)    NULL,
     sort_order          SMALLINT        NULL,
     external_id         VARCHAR(64)     NULL,     -- iframe slug ('main', 'release-1', 'dev-a') — req #2648 / migration 051
+    acceptance_test_status VARCHAR(16)  NULL DEFAULT 'pass', -- single per-branch AT pass|fail — req #2633 / migration 061
     creator_fk          VARCHAR(64)     NOT NULL,
     create_ts           TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
     update_ts           TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
@@ -762,5 +763,38 @@ CREATE TABLE IF NOT EXISTS customer_releases (
 );
 -- (Req #2606 directive: `closed` soft-delete column removed from every new
 -- build-feature table. Hard delete via FK CASCADE chain only.)
+
+-- Req #2633: Acceptance Tests (AT). Catalog + branch junction. Follows the
+-- build-viz CATALOG shape (mirrors `customers`: closed + sort_order, no
+-- category_fk). branches.acceptance_test_status (added above) is the single
+-- per-branch pass|fail. Migration 061. darwin_dev only.
+CREATE TABLE IF NOT EXISTS acceptance_tests (
+    id                      INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title                   VARCHAR(256)    NOT NULL,                 -- AT name, e.g. "Sprint AT"
+    description             TEXT            NULL,
+    acceptance_test_status  VARCHAR(16)     NOT NULL DEFAULT 'pass',  -- pass|fail (default pass)
+    expected_wall_mins      INT             NULL,                     -- user-set expected wall clock, minutes
+    closed                  TINYINT(1)      NOT NULL DEFAULT 0,
+    sort_order              SMALLINT        NULL,
+    creator_fk              VARCHAR(64)     NOT NULL,
+    create_ts               TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts               TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_acceptance_tests_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS branch_acceptance_tests (
+    branch_fk           INT         NOT NULL,
+    acceptance_test_fk  INT         NOT NULL,
+    sort_order          SMALLINT    NULL,   -- per-branch AT label stacking order
+    PRIMARY KEY (branch_fk, acceptance_test_fk),
+    CONSTRAINT fk_bat_branch
+        FOREIGN KEY (branch_fk) REFERENCES branches (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_bat_acceptance_test
+        FOREIGN KEY (acceptance_test_fk) REFERENCES acceptance_tests (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
 
 SET FOREIGN_KEY_CHECKS = 1;

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -668,6 +668,7 @@ CREATE TABLE branches (
     label_end           VARCHAR(128)    NULL,
     sort_order          SMALLINT        NULL,
     external_id         VARCHAR(64)     NULL,
+    acceptance_test_status VARCHAR(16)  NULL DEFAULT 'pass', -- single per-branch AT pass|fail — req #2633 / migration 061
     creator_fk          VARCHAR(64)     NOT NULL,
     create_ts           TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
     update_ts           TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
@@ -725,6 +726,36 @@ CREATE TABLE customer_releases (
         FOREIGN KEY (creator_fk) REFERENCES profiles (id)
         ON UPDATE CASCADE ON DELETE CASCADE,
     CONSTRAINT uq_customer_releases_customer_build UNIQUE KEY (customer_fk, build_fk)
+);
+
+-- Req #2633: Acceptance Tests (AT). Catalog + branch junction (migration 061).
+CREATE TABLE acceptance_tests (
+    id                      INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title                   VARCHAR(256)    NOT NULL,
+    description             TEXT            NULL,
+    acceptance_test_status  VARCHAR(16)     NOT NULL DEFAULT 'pass',  -- pass|fail
+    expected_wall_mins      INT             NULL,                     -- user-set expected wall clock, minutes
+    closed                  TINYINT(1)      NOT NULL DEFAULT 0,
+    sort_order              SMALLINT        NULL,
+    creator_fk              VARCHAR(64)     NOT NULL,
+    create_ts               TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts               TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_acceptance_tests_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE branch_acceptance_tests (
+    branch_fk           INT         NOT NULL,
+    acceptance_test_fk  INT         NOT NULL,
+    sort_order          SMALLINT    NULL,
+    PRIMARY KEY (branch_fk, acceptance_test_fk),
+    CONSTRAINT fk_bat_branch
+        FOREIGN KEY (branch_fk) REFERENCES branches (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_bat_acceptance_test
+        FOREIGN KEY (acceptance_test_fk) REFERENCES acceptance_tests (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
 );
 
 SET FOREIGN_KEY_CHECKS = 1;

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1568,6 +1568,8 @@ def test_table_count(db_connection):
         'customers',
         # Req #2606 — Build Visualizer data model
         'build_projects', 'branches', 'builds', 'customer_releases',
+        # Req #2633 — Acceptance Test data type (build-viz; darwin_dev only)
+        'acceptance_tests', 'branch_acceptance_tests',
         # Req #2719 — swarm-undo data type
         'swarm_undos',
         # Req #2497 — swarm-complete data type
@@ -1623,6 +1625,50 @@ def test_branches_columns(db_connection):
     assert 'segment_minor' not in cols
     assert 'segment_initial_build_number' not in cols
     assert 'closed' not in cols
+    # Req #2633: single per-branch Acceptance Test status (pass|fail, default pass).
+    assert cols['acceptance_test_status']['Null'] == 'YES'
+    assert 'varchar(16)' in cols['acceptance_test_status']['Type'].lower()
+    assert cols['acceptance_test_status']['Default'] == 'pass'
+
+
+def test_acceptance_tests_columns(db_connection):
+    """Req #2633: acceptance_tests catalog (build-viz CATALOG shape, mirrors
+    customers: closed + sort_order, NO category_fk). Adds acceptance_test_status
+    (pass|fail default pass) + expected_wall_mins."""
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'acceptance_tests')
+    expected = {'id', 'title', 'description', 'acceptance_test_status',
+                'expected_wall_mins', 'closed', 'sort_order', 'creator_fk',
+                'create_ts', 'update_ts'}
+    assert set(cols.keys()) == expected
+    assert cols['id']['Extra'] == 'auto_increment'
+    assert cols['title']['Type'] == 'varchar(256)'
+    assert cols['title']['Null'] == 'NO'
+    assert cols['description']['Null'] == 'YES'
+    assert 'varchar(16)' in cols['acceptance_test_status']['Type'].lower()
+    assert cols['acceptance_test_status']['Null'] == 'NO'
+    assert cols['acceptance_test_status']['Default'] == 'pass'
+    assert cols['expected_wall_mins']['Type'] == 'int'
+    assert cols['expected_wall_mins']['Null'] == 'YES'
+    assert cols['closed']['Type'] == 'tinyint(1)'
+    assert cols['closed']['Default'] == '0'
+    assert cols['sort_order']['Type'] == 'smallint'
+    assert cols['creator_fk']['Null'] == 'NO'
+    # Build-viz catalog convention: no category_fk.
+    assert 'category_fk' not in cols
+
+
+def test_branch_acceptance_tests_columns(db_connection):
+    """Req #2633: branch_acceptance_tests junction — composite PK, sort_order for
+    per-branch label stacking, no surrogate id / creator / timestamps."""
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'branch_acceptance_tests')
+    assert set(cols.keys()) == {'branch_fk', 'acceptance_test_fk', 'sort_order'}
+    assert cols['branch_fk']['Key'] == 'PRI'
+    assert cols['acceptance_test_fk']['Key'] == 'PRI'
+    assert cols['sort_order']['Type'] == 'smallint'
+    assert 'id' not in cols
+    assert 'creator_fk' not in cols
 
 
 def test_builds_columns(db_connection):


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-06-16T03:05:40Z
- chore: init swarm session feature/2633-new-data-types-acceptance-test-1

## Files changed
```
 migrations/061_add_acceptance_tests.sql | 65 +++++++++++++++++++++++++++++++++
 schema.sql                              | 34 +++++++++++++++++
 scripts/recreate_darwin_dev.sql         | 31 ++++++++++++++++
 tests/test_data_types.py                | 46 +++++++++++++++++++++++
 4 files changed, 176 insertions(+)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)