### PR TITLE
Machines entity - track which machine runs each session and start

### DIFF
--- a/migrations/064_add_machines.sql
+++ b/migrations/064_add_machines.sql
@@ -1,0 +1,102 @@
+-- 064_add_machines.sql
+--
+-- Req #2943: `machines` entity — track WHICH machine ran each swarm_session,
+-- swarm_start, and dev_server claim.
+--
+-- Two machines now run Darwin swarm work (Mac mini / iTerm launch path and the
+-- WSL box / tmux launch path) with more possible. Nothing recorded which
+-- machine a session/start/dev-server ran on. This migration introduces the
+-- `machines` content table (auto-registered on first swarm activity) and stamps
+-- the three execution tables with a nullable `machine_fk`.
+--
+-- Design bias — critical limited items only: a machine is a friendly name plus a
+-- handful of shell-detectable facts (hostname/platform/arch/os_version/hw_model).
+-- No browser/user-agent capture (sessions are CLI-side), no extended hardware
+-- inventory (RAM/cores/GPU).
+--
+-- machines is a content-table baseline (memory/new-data-type-pattern.md): id,
+-- title, description, closed, sort_order, creator_fk, create_ts/update_ts — PLUS
+-- the auto-detected identity columns. NO category_fk (infrastructure entity, not
+-- categorized). `hostname` is the auto-match key and is UNIQUE.
+--
+-- Nullable machine_fk by design: pre-feature rows stay NULL (no fabricated
+-- attribution — same principle as swarm_sessions.legacy_secs). An OPTIONAL
+-- one-time backfill (all pre-WSL history ran on the Mac mini) is shipped as a
+-- commented-out statement at the bottom, applied by hand once the Mac's row
+-- exists — never auto-applied.
+--
+-- dev_servers additionally SWAPS its port uniqueness: DROP the global uq_port,
+-- ADD uq_machine_port(machine_fk, port). Ports are machine-local; the global
+-- key made the two machines falsely contend for the 3000-3007 registry slots
+-- even though the real ports don't conflict. Per-machine uniqueness gives each
+-- machine the full pool. (MySQL treats NULLs as distinct in a UNIQUE key, so
+-- legacy NULL-machine rows never contend with each other — acceptable since
+-- dev_servers rows are transient.)
+--
+-- swarm_sessions/swarm_starts/dev_servers machine_fk FK: ON UPDATE CASCADE
+-- ON DELETE RESTRICT (a machine with execution history cannot be hard-deleted;
+-- retire it via the `closed` flag instead).
+--
+-- requirements table is OUT OF SCOPE — no requirements.machine_fk (can be added
+-- later with the identical pattern if ever wanted).
+
+-- ---------------------------------------------------------------------------
+-- New table: machines
+-- ---------------------------------------------------------------------------
+CREATE TABLE machines (
+    id           INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title        VARCHAR(256) NOT NULL,           -- user-supplied friendly name; auto-registration seeds it with hostname
+    description  TEXT         NULL,
+    hostname     VARCHAR(128) NOT NULL,           -- auto-detected; the auto-match key; UNIQUE
+    platform     VARCHAR(16)  NOT NULL,           -- darwin | wsl | linux (auto-detected)
+    arch         VARCHAR(16)  NOT NULL,           -- arm64 | x86_64 (auto-detected)
+    os_version   VARCHAR(64)  NULL,               -- auto: sw_vers on macOS; /etc/os-release PRETTY_NAME on Linux/WSL
+    hw_model     VARCHAR(64)  NULL,               -- auto best-effort: `sysctl -n hw.model` on macOS (e.g. "Mac16,11");
+                                                  -- hostnamectl "Hardware Model" or /proc/cpuinfo fallback on WSL; NULL when unavailable
+    last_seen_at TIMESTAMP    NULL,               -- auto-updated on each identity resolution
+    closed       TINYINT(1)   NOT NULL DEFAULT 0, -- retire a machine
+    sort_order   SMALLINT     NULL,
+    creator_fk   VARCHAR(64)  NOT NULL,
+    create_ts    TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts    TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_machines_hostname (hostname),
+    CONSTRAINT fk_machines_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+-- ---------------------------------------------------------------------------
+-- machine_fk on the three execution tables (nullable; FK RESTRICT)
+-- ---------------------------------------------------------------------------
+ALTER TABLE swarm_sessions
+    ADD COLUMN machine_fk INT NULL AFTER worktree_path,
+    ADD CONSTRAINT fk_swarm_sessions_machine
+        FOREIGN KEY (machine_fk) REFERENCES machines (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT;
+
+ALTER TABLE swarm_starts
+    ADD COLUMN machine_fk INT NULL AFTER session_count,
+    ADD CONSTRAINT fk_swarm_starts_machine
+        FOREIGN KEY (machine_fk) REFERENCES machines (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT;
+
+-- dev_servers: add machine_fk AND swap the port uniqueness to per-machine.
+ALTER TABLE dev_servers
+    ADD COLUMN machine_fk INT NULL AFTER session_fk,
+    ADD CONSTRAINT fk_dev_servers_machine
+        FOREIGN KEY (machine_fk) REFERENCES machines (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    DROP KEY uq_port,
+    ADD UNIQUE KEY uq_machine_port (machine_fk, port);
+
+-- ---------------------------------------------------------------------------
+-- OPTIONAL one-time backfill (NOT auto-applied — user decision at review time)
+-- ---------------------------------------------------------------------------
+-- All pre-WSL swarm history ran on the Mac mini. Once the Mac's machines row
+-- exists (auto-registered on the first post-deploy swarm launch, or inserted by
+-- hand), a one-time UPDATE can attribute every NULL-machine execution row to it.
+-- Replace <MAC_ID> with the Mac's machines.id and run by hand if desired:
+--
+--   UPDATE swarm_sessions SET machine_fk = <MAC_ID> WHERE machine_fk IS NULL;
+--   UPDATE swarm_starts    SET machine_fk = <MAC_ID> WHERE machine_fk IS NULL;
+--   -- dev_servers rows are transient; backfill is pointless there.

--- a/schema.sql
+++ b/schema.sql
@@ -175,6 +175,35 @@ CREATE TABLE IF NOT EXISTS requirements (
 );
 
 -- ============================================================================
+-- Machine registry (req #2943)
+-- ============================================================================
+-- Content table: which machine (Mac mini / WSL box / …) ran a swarm_session,
+-- swarm_start, or dev_server claim. Auto-registered on first swarm activity by
+-- scripts/swarm/machine-identity.sh (matched by UNIQUE hostname). Defined BEFORE
+-- the execution tables so their machine_fk FKs resolve on a fresh schema run.
+-- No category_fk — infrastructure entity, not categorized.
+CREATE TABLE IF NOT EXISTS machines (
+    id           INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title        VARCHAR(256) NOT NULL,           -- friendly name; auto-registration seeds it with hostname
+    description  TEXT         NULL,
+    hostname     VARCHAR(128) NOT NULL,           -- auto-detected; the auto-match key; UNIQUE
+    platform     VARCHAR(16)  NOT NULL,           -- darwin | wsl | linux
+    arch         VARCHAR(16)  NOT NULL,           -- arm64 | x86_64
+    os_version   VARCHAR(64)  NULL,               -- sw_vers (macOS) / os-release PRETTY_NAME (Linux/WSL)
+    hw_model     VARCHAR(64)  NULL,               -- sysctl hw.model (macOS) / best-effort WSL; NULL when unavailable
+    last_seen_at TIMESTAMP    NULL,               -- auto-updated on each identity resolution
+    closed       TINYINT(1)   NOT NULL DEFAULT 0, -- retire a machine
+    sort_order   SMALLINT     NULL,
+    creator_fk   VARCHAR(64)  NOT NULL,
+    create_ts    TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts    TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_machines_hostname (hostname),
+    CONSTRAINT fk_machines_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+-- ============================================================================
 -- Swarm session management
 -- ============================================================================
 
@@ -192,6 +221,7 @@ CREATE TABLE IF NOT EXISTS swarm_sessions (
     effort          VARCHAR(16)     NOT NULL DEFAULT 'xhigh',
                                             -- low | medium | high | xhigh | ultracode (req #2916; captured at launch, default: xhigh)
     worktree_path   VARCHAR(512)    NULL,
+    machine_fk      INT             NULL,          -- req #2943; which machine ran this session
     started_at      TIMESTAMP       NULL,
     completed_at    TIMESTAMP       NULL,
     -- Phase accumulators (req #2332). On each swarm_status change db.py adds
@@ -226,7 +256,10 @@ CREATE TABLE IF NOT EXISTS swarm_sessions (
     update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (creator_fk)
         REFERENCES profiles (id)
-        ON UPDATE CASCADE ON DELETE CASCADE
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_swarm_sessions_machine
+        FOREIGN KEY (machine_fk) REFERENCES machines (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT
 );
 
 CREATE TABLE IF NOT EXISTS requirement_sessions (
@@ -252,6 +285,7 @@ CREATE TABLE IF NOT EXISTS swarm_starts (
     autonomy_filter     VARCHAR(16)     NULL,
     auto_start          TINYINT(1)      NOT NULL DEFAULT 0,
     session_count       INT             NOT NULL DEFAULT 0,
+    machine_fk          INT             NULL,          -- req #2943; which machine ran this start
     tokens_input        INT             NULL,
     tokens_cache_write  INT             NULL,
     tokens_cache_read   INT             NULL,
@@ -266,7 +300,10 @@ CREATE TABLE IF NOT EXISTS swarm_starts (
     update_ts           TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
     CONSTRAINT fk_swarm_starts_creator
         FOREIGN KEY (creator_fk) REFERENCES profiles (id)
-        ON UPDATE CASCADE ON DELETE CASCADE
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_swarm_starts_machine
+        FOREIGN KEY (machine_fk) REFERENCES machines (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT
 );
 
 CREATE TABLE IF NOT EXISTS swarm_start_sessions (
@@ -371,17 +408,23 @@ CREATE TABLE IF NOT EXISTS dev_servers (
     terminal_number SMALLINT        NULL,
     workspace_path  VARCHAR(512)    NOT NULL,
     session_fk      INT             NULL,
+    machine_fk      INT             NULL,          -- req #2943; which machine hosts this dev server
     creator_fk      VARCHAR(64)     NOT NULL,
     started_at      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
     update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
-    UNIQUE KEY uq_port (port),
+    -- req #2943: ports are machine-local; per-machine uniqueness replaces the
+    -- old global uq_port so two machines don't falsely contend for 3000-3007.
+    UNIQUE KEY uq_machine_port (machine_fk, port),
     FOREIGN KEY (creator_fk)
         REFERENCES profiles (id)
         ON UPDATE CASCADE ON DELETE CASCADE,
     FOREIGN KEY (session_fk)
         REFERENCES swarm_sessions (id)
-        ON UPDATE CASCADE ON DELETE SET NULL
+        ON UPDATE CASCADE ON DELETE SET NULL,
+    CONSTRAINT fk_dev_servers_machine
+        FOREIGN KEY (machine_fk) REFERENCES machines (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT
 );
 
 -- ============================================================================

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -17,7 +17,7 @@ DROP TABLE IF EXISTS customer_releases, builds, branches, build_projects,
     swarm_undos,
     swarm_start_sessions, swarm_starts,
     requirement_sessions,
-    requirements, swarm_sessions, categories, projects,
+    requirements, swarm_sessions, machines, categories, projects,
     tasks, recurring_tasks, areas, domains, profiles;
 SET FOREIGN_KEY_CHECKS = 1;
 
@@ -184,6 +184,29 @@ CREATE TABLE requirements (
         ON UPDATE CASCADE ON DELETE CASCADE
 );
 
+-- Machine registry (req #2943) — created before the execution tables that
+-- reference it via machine_fk.
+CREATE TABLE machines (
+    id           INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title        VARCHAR(256) NOT NULL,
+    description  TEXT         NULL,
+    hostname     VARCHAR(128) NOT NULL,
+    platform     VARCHAR(16)  NOT NULL,           -- darwin | wsl | linux
+    arch         VARCHAR(16)  NOT NULL,           -- arm64 | x86_64
+    os_version   VARCHAR(64)  NULL,
+    hw_model     VARCHAR(64)  NULL,
+    last_seen_at TIMESTAMP    NULL,
+    closed       TINYINT(1)   NOT NULL DEFAULT 0,
+    sort_order   SMALLINT     NULL,
+    creator_fk   VARCHAR(64)  NOT NULL,
+    create_ts    TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts    TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_machines_hostname (hostname),
+    CONSTRAINT fk_machines_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
 -- Swarm session management
 
 CREATE TABLE swarm_sessions (
@@ -200,6 +223,7 @@ CREATE TABLE swarm_sessions (
     effort          VARCHAR(16)     NOT NULL DEFAULT 'xhigh',
                                             -- low | medium | high | xhigh | ultracode (req #2916; captured at launch, default: xhigh)
     worktree_path   VARCHAR(512)    NULL,
+    machine_fk      INT             NULL,          -- req #2943
     started_at      TIMESTAMP       NULL,
     completed_at    TIMESTAMP       NULL,
     -- Phase accumulators (req #2332, migration 059)
@@ -229,7 +253,10 @@ CREATE TABLE swarm_sessions (
     update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
     FOREIGN KEY (creator_fk)
         REFERENCES profiles (id)
-        ON UPDATE CASCADE ON DELETE CASCADE
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_swarm_sessions_machine
+        FOREIGN KEY (machine_fk) REFERENCES machines (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT
 );
 
 CREATE TABLE requirement_sessions (
@@ -250,6 +277,7 @@ CREATE TABLE swarm_starts (
     autonomy_filter     VARCHAR(16)     NULL,
     auto_start          TINYINT(1)      NOT NULL DEFAULT 0,
     session_count       INT             NOT NULL DEFAULT 0,
+    machine_fk          INT             NULL,          -- req #2943
     tokens_input        INT             NULL,
     tokens_cache_write  INT             NULL,
     tokens_cache_read   INT             NULL,
@@ -264,7 +292,10 @@ CREATE TABLE swarm_starts (
     update_ts           TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
     CONSTRAINT fk_swarm_starts_creator
         FOREIGN KEY (creator_fk) REFERENCES profiles (id)
-        ON UPDATE CASCADE ON DELETE CASCADE
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_swarm_starts_machine
+        FOREIGN KEY (machine_fk) REFERENCES machines (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT
 );
 
 CREATE TABLE swarm_start_sessions (
@@ -353,17 +384,22 @@ CREATE TABLE dev_servers (
     terminal_number SMALLINT        NULL,
     workspace_path  VARCHAR(512)    NOT NULL,
     session_fk      INT             NULL,
+    machine_fk      INT             NULL,          -- req #2943
     creator_fk      VARCHAR(64)     NOT NULL,
     started_at      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
     update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
-    UNIQUE KEY uq_port (port),
+    -- req #2943: per-machine port uniqueness (ports are machine-local)
+    UNIQUE KEY uq_machine_port (machine_fk, port),
     FOREIGN KEY (creator_fk)
         REFERENCES profiles (id)
         ON UPDATE CASCADE ON DELETE CASCADE,
     FOREIGN KEY (session_fk)
         REFERENCES swarm_sessions (id)
-        ON UPDATE CASCADE ON DELETE SET NULL
+        ON UPDATE CASCADE ON DELETE SET NULL,
+    CONSTRAINT fk_dev_servers_machine
+        FOREIGN KEY (machine_fk) REFERENCES machines (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT
 );
 
 -- Priority card hand-sort order

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,11 @@ def seed_test_profile(db_connection, test_creator_fk):
         cur.execute("DELETE FROM dev_servers WHERE creator_fk = %s", (test_creator_fk,))
         cur.execute("DELETE FROM requirements WHERE creator_fk = %s", (test_creator_fk,))
         cur.execute("DELETE FROM swarm_sessions WHERE creator_fk = %s", (test_creator_fk,))
+        # Req #2943: swarm_starts + machines. machine_fk is ON DELETE RESTRICT on
+        # dev_servers/swarm_sessions/swarm_starts, so machines must be deleted
+        # AFTER those three (all cleared just above) to satisfy the constraint.
+        cur.execute("DELETE FROM swarm_starts WHERE creator_fk = %s", (test_creator_fk,))
+        cur.execute("DELETE FROM machines WHERE creator_fk = %s", (test_creator_fk,))
         # Req #2380: features/test_cases/test_plans RESTRICT on categories,
         # so delete these BEFORE categories. test_results and test_runs also
         # clean up explicitly to handle tests that commit mid-run.

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -4,6 +4,8 @@ Test FK constraints, NOT NULL constraints, unique constraints, and defaults.
 Tests verify that database constraints prevent invalid data entry.
 Each test uses transactions with rollback to keep darwin_dev test DB clean.
 """
+import uuid
+
 import pymysql
 import pytest
 
@@ -1041,4 +1043,131 @@ def test_feature_test_cases_composite_pk(db_connection, test_creator_fk, test_ca
                 "INSERT INTO feature_test_cases (feature_fk, test_case_fk) VALUES (%s, %s)",
                 (f_id, tc_id)
             )
+    db_connection.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Req #2943 — machines registry constraints
+# ---------------------------------------------------------------------------
+
+def _insert_machine(cur, creator_fk, hostname, title=None, platform='darwin',
+                    arch='arm64'):
+    """Insert a machines row and return its id. All-NOT-NULL fields supplied."""
+    cur.execute(
+        "INSERT INTO machines (title, hostname, platform, arch, creator_fk) "
+        "VALUES (%s, %s, %s, %s, %s)",
+        (title or hostname, hostname, platform, arch, creator_fk),
+    )
+    cur.execute("SELECT LAST_INSERT_ID() AS id")
+    return cur.fetchone()['id']
+
+
+def test_machines_hostname_unique(db_connection, test_creator_fk):
+    """uq_machines_hostname: a second machine with the same hostname → IntegrityError.
+
+    hostname is the auto-registration match key; duplicates must be rejected so
+    machine-identity.sh can rely on it to repair a wiped cache without creating a
+    duplicate row."""
+    with db_connection.cursor() as cur:
+        _insert_machine(cur, test_creator_fk, 'dup-host.local')
+        with pytest.raises(pymysql.IntegrityError):
+            _insert_machine(cur, test_creator_fk, 'dup-host.local', title='other')
+    db_connection.rollback()
+
+
+def test_machine_fk_restrict_swarm_sessions(db_connection, test_creator_fk):
+    """swarm_sessions.machine_fk is ON DELETE RESTRICT: deleting a machine that a
+    session references must fail (retire via `closed`, don't hard-delete)."""
+    with db_connection.cursor() as cur:
+        mid = _insert_machine(cur, test_creator_fk, 'restrict-sess.local')
+        cur.execute(
+            "INSERT INTO swarm_sessions (task_name, swarm_status, machine_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s)",
+            ('m-restrict-sess', 'active', mid, test_creator_fk),
+        )
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute("DELETE FROM machines WHERE id = %s", (mid,))
+    db_connection.rollback()
+
+
+def test_machine_fk_restrict_swarm_starts(db_connection, test_creator_fk):
+    """swarm_starts.machine_fk is ON DELETE RESTRICT."""
+    with db_connection.cursor() as cur:
+        mid = _insert_machine(cur, test_creator_fk, 'restrict-start.local')
+        cur.execute(
+            "INSERT INTO swarm_starts (arguments, machine_fk, creator_fk) "
+            "VALUES (%s, %s, %s)",
+            ('m-restrict-start', mid, test_creator_fk),
+        )
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute("DELETE FROM machines WHERE id = %s", (mid,))
+    db_connection.rollback()
+
+
+def test_machine_fk_restrict_dev_servers(db_connection, test_creator_fk):
+    """dev_servers.machine_fk is ON DELETE RESTRICT."""
+    with db_connection.cursor() as cur:
+        mid = _insert_machine(cur, test_creator_fk, 'restrict-dev.local')
+        cur.execute(
+            "INSERT INTO dev_servers (port, pid, workspace_path, machine_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            (3000, 111, '/tmp/ws', mid, test_creator_fk),
+        )
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute("DELETE FROM machines WHERE id = %s", (mid,))
+    db_connection.rollback()
+
+
+def test_machine_fk_invalid_reference(db_connection, test_creator_fk):
+    """A swarm_session referencing a non-existent machine_fk → IntegrityError."""
+    with db_connection.cursor() as cur:
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO swarm_sessions (task_name, swarm_status, machine_fk, creator_fk) "
+                "VALUES (%s, %s, %s, %s)",
+                ('m-bad-fk', 'active', 999999999, test_creator_fk),
+            )
+    db_connection.rollback()
+
+
+def test_dev_servers_uq_machine_port(db_connection, test_creator_fk):
+    """uq_machine_port(machine_fk, port): the SAME port is allowed on two DIFFERENT
+    machines (ports are machine-local — the whole point of req #2943), but a
+    DUPLICATE port on the SAME machine is rejected."""
+    with db_connection.cursor() as cur:
+        m1 = _insert_machine(cur, test_creator_fk, 'port-a.local')
+        m2 = _insert_machine(cur, test_creator_fk, 'port-b.local')
+        # Port 3005 on machine 1.
+        cur.execute(
+            "INSERT INTO dev_servers (port, pid, workspace_path, machine_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            (3005, 201, '/tmp/a', m1, test_creator_fk),
+        )
+        # SAME port 3005 on machine 2 → allowed (no false cross-machine contention).
+        cur.execute(
+            "INSERT INTO dev_servers (port, pid, workspace_path, machine_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            (3005, 202, '/tmp/b', m2, test_creator_fk),
+        )
+        # DUPLICATE port 3005 on machine 1 → rejected.
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO dev_servers (port, pid, workspace_path, machine_fk, creator_fk) "
+                "VALUES (%s, %s, %s, %s, %s)",
+                (3005, 203, '/tmp/c', m1, test_creator_fk),
+            )
+    db_connection.rollback()
+
+
+def test_machines_creator_fk_cascade(db_connection):
+    """machines.creator_fk is ON DELETE CASCADE — deleting the owning profile
+    removes the machine (profile removal takes all owned data)."""
+    cfk = f"schema-test-mach-{uuid.uuid4().hex[:8]}"
+    with db_connection.cursor() as cur:
+        cur.execute("INSERT INTO profiles (id, name, email) VALUES (%s, %s, %s)",
+                    (cfk, 'Mach Cascade', 'mc@test.com'))
+        _insert_machine(cur, cfk, 'cascade-host.local')
+        cur.execute("DELETE FROM profiles WHERE id = %s", (cfk,))
+        cur.execute("SELECT COUNT(*) AS c FROM machines WHERE creator_fk = %s", (cfk,))
+        assert cur.fetchone()['c'] == 0
     db_connection.rollback()

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -540,7 +540,16 @@ def test_swarm_sessions_columns(db_connection):
     # Tolerate both pre- and post-migration-063 state (req #2916 added effort).
     if 'effort' in columns:
         expected_fields.append('effort')
+    # Tolerate both pre- and post-migration-064 state (req #2943 added machine_fk).
+    if 'machine_fk' in columns:
+        expected_fields.append('machine_fk')
     assert set(columns.keys()) == set(expected_fields)
+
+    # req #2943 machine_fk (migration 064) — nullable FK, no default.
+    if 'machine_fk' in columns:
+        assert columns['machine_fk']['Type'] == 'int'
+        assert columns['machine_fk']['Null'] == 'YES'
+        assert columns['machine_fk']['Key'] == 'MUL'
 
     # req #2839 token columns (migration 060)
     assert columns['phase_tokens']['Type'] == 'json'
@@ -662,11 +671,20 @@ def test_swarm_starts_columns(db_connection):
                        'tokens_output', 'wall_seconds', 'turn_count',
                        'start_summary', 'telemetry',
                        'started_at', 'creator_fk', 'create_ts', 'update_ts']
+    # Tolerate both pre- and post-migration-064 state (req #2943 added machine_fk).
+    if 'machine_fk' in columns:
+        expected_fields.append('machine_fk')
     assert set(columns.keys()) == set(expected_fields)
 
     assert columns['id']['Type'] == 'int'
     assert columns['id']['Key'] == 'PRI'
     assert columns['id']['Extra'] == 'auto_increment'
+
+    # req #2943 machine_fk (migration 064) — nullable FK, no default.
+    if 'machine_fk' in columns:
+        assert columns['machine_fk']['Type'] == 'int'
+        assert columns['machine_fk']['Null'] == 'YES'
+        assert columns['machine_fk']['Key'] == 'MUL'
 
     assert columns['arguments']['Type'] == 'varchar(512)'
     assert columns['arguments']['Null'] == 'YES'
@@ -890,6 +908,7 @@ def test_dev_servers_columns(db_connection):
     - terminal_number: SMALLINT, NULL (req #2419)
     - workspace_path: VARCHAR(512), NOT NULL
     - session_fk: INT, NULL, MUL
+    - machine_fk: INT, NULL, MUL (req #2943 — first column of uq_machine_port)
     - creator_fk: VARCHAR(64), NOT NULL, MUL
     - started_at: TIMESTAMP, NOT NULL
     - create_ts: TIMESTAMP, NULL
@@ -900,7 +919,8 @@ def test_dev_servers_columns(db_connection):
         columns = {row['Field']: row for row in cur.fetchall()}
 
     expected_fields = ['id', 'port', 'pid', 'terminal_number', 'workspace_path',
-                       'session_fk', 'creator_fk', 'started_at', 'create_ts', 'update_ts']
+                       'session_fk', 'machine_fk', 'creator_fk', 'started_at',
+                       'create_ts', 'update_ts']
     assert set(columns.keys()) == set(expected_fields)
 
     assert columns['id']['Type'] == 'int'
@@ -909,7 +929,10 @@ def test_dev_servers_columns(db_connection):
 
     assert columns['port']['Type'] == 'smallint'
     assert columns['port']['Null'] == 'NO'
-    assert columns['port']['Key'] == 'UNI'
+    # Req #2943: port is no longer globally UNIQUE — it is the SECOND column of
+    # the composite uq_machine_port(machine_fk, port), so it reports no Key here
+    # (only the leading column of an index shows in DESCRIBE).
+    assert columns['port']['Key'] == ''
 
     assert columns['terminal_number']['Type'] == 'smallint'
     assert columns['terminal_number']['Null'] == 'YES'
@@ -923,6 +946,11 @@ def test_dev_servers_columns(db_connection):
     assert columns['session_fk']['Type'] == 'int'
     assert columns['session_fk']['Null'] == 'YES'
     assert columns['session_fk']['Key'] == 'MUL'
+
+    # Req #2943 — machine_fk: nullable FK, leading column of uq_machine_port.
+    assert columns['machine_fk']['Type'] == 'int'
+    assert columns['machine_fk']['Null'] == 'YES'
+    assert columns['machine_fk']['Key'] == 'MUL'
 
     assert columns['creator_fk']['Type'] == 'varchar(64)'
     assert columns['creator_fk']['Null'] == 'NO'
@@ -1617,6 +1645,8 @@ def test_table_count(db_connection):
         'swarm_undos',
         # Req #2497 — swarm-complete data type
         'swarm_completes', 'swarm_complete_sessions',
+        # Req #2943 — machine registry
+        'machines',
     }
     assert expected_tables == tables, \
         f"Unexpected tables: {tables - expected_tables}, missing: {expected_tables - tables}"
@@ -1712,6 +1742,61 @@ def test_branch_acceptance_tests_columns(db_connection):
     assert cols['sort_order']['Type'] == 'smallint'
     assert 'id' not in cols
     assert 'creator_fk' not in cols
+
+
+def test_machines_columns(db_connection):
+    """Req #2943: machines registry — content-table baseline (id/title/description/
+    closed/sort_order/creator_fk/timestamps) PLUS the auto-detected identity
+    columns. No category_fk (infrastructure entity). hostname is UNIQUE (the
+    auto-match key). platform/arch NOT NULL; os_version/hw_model/last_seen_at NULL."""
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'machines')
+    expected = {'id', 'title', 'description', 'hostname', 'platform', 'arch',
+                'os_version', 'hw_model', 'last_seen_at', 'closed', 'sort_order',
+                'creator_fk', 'create_ts', 'update_ts'}
+    assert set(cols.keys()) == expected
+
+    assert cols['id']['Type'] == 'int'
+    assert cols['id']['Key'] == 'PRI'
+    assert cols['id']['Extra'] == 'auto_increment'
+
+    assert cols['title']['Type'] == 'varchar(256)'
+    assert cols['title']['Null'] == 'NO'
+
+    assert cols['description']['Type'] == 'text'
+    assert cols['description']['Null'] == 'YES'
+
+    # hostname is the auto-match key — NOT NULL + UNIQUE.
+    assert cols['hostname']['Type'] == 'varchar(128)'
+    assert cols['hostname']['Null'] == 'NO'
+    assert cols['hostname']['Key'] == 'UNI'
+
+    assert cols['platform']['Type'] == 'varchar(16)'
+    assert cols['platform']['Null'] == 'NO'
+    assert cols['arch']['Type'] == 'varchar(16)'
+    assert cols['arch']['Null'] == 'NO'
+
+    # Auto best-effort identity facts — nullable.
+    assert cols['os_version']['Type'] == 'varchar(64)'
+    assert cols['os_version']['Null'] == 'YES'
+    assert cols['hw_model']['Type'] == 'varchar(64)'
+    assert cols['hw_model']['Null'] == 'YES'
+    assert 'timestamp' in cols['last_seen_at']['Type']
+    assert cols['last_seen_at']['Null'] == 'YES'
+
+    # Content-table baseline soft-delete + hand-sort.
+    assert cols['closed']['Type'] == 'tinyint(1)'
+    assert cols['closed']['Null'] == 'NO'
+    assert cols['closed']['Default'] == '0'
+    assert cols['sort_order']['Type'] == 'smallint'
+    assert cols['sort_order']['Null'] == 'YES'
+
+    assert cols['creator_fk']['Type'] == 'varchar(64)'
+    assert cols['creator_fk']['Null'] == 'NO'
+    assert cols['creator_fk']['Key'] == 'MUL'
+
+    # Infrastructure entity — deliberately no category_fk.
+    assert 'category_fk' not in cols
 
 
 def test_builds_columns(db_connection):

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -95,6 +95,11 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         'recurring_tasks',
         'map_partners',
         'dev_servers',
+        # Req #2943 — machine registry (migration 064). No partial-match conflict
+        # with the machine_fk column or uq_machine_port key (the \b lookahead
+        # stops the regex at `machines` only when followed by _ibfk or a word
+        # boundary, not the `_fk`/`_port`/`_hostname` suffixes).
+        'machines',
         'requirements',
         'priorities',            # pre-038 name (for RENAME TABLE in migration 038)
         'categories',
@@ -164,6 +169,11 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         # Migration 058 — swarm_completes
         'fk_swarm_completes_creator',
         'fk_scs_swarm_complete', 'fk_scs_session',
+        # Migration 064 — machines registry (req #2943)
+        'fk_machines_creator',
+        'fk_swarm_sessions_machine', 'fk_swarm_starts_machine',
+        'fk_dev_servers_machine',
+        'uq_machines_hostname', 'uq_machine_port',
     ]
     for cname in named_constraints:
         sql = sql.replace(cname, f'{table_prefix}_{cname}')
@@ -251,6 +261,9 @@ ALL_TABLE_SUFFIXES = [
     'user_integrations', 'map_run_partners', 'map_partners',
     'map_views', 'map_coordinates', 'map_runs', 'map_routes',
     'priority_card_order', 'dev_servers',
+    # Req #2943 — machines (dropped with FK_CHECKS=0, so order is not critical;
+    # placed among the leaves for readability).
+    'machines',
     # Req #2606 — Build Visualizer (migrations 050-054). FK-safe order: leaves
     # first — customer_releases → builds → branches → build_projects (the
     # build_projects<->branches circular FK is handled by FK_CHECKS=0 in cleanup).
@@ -429,6 +442,8 @@ def test_migration_sequence_applies(db_connection, migration_test_prefix):
             'swarm_undos',
             # Req #2497 — swarm-complete data type (migration 058)
             'swarm_completes', 'swarm_complete_sessions',
+            # Req #2943 — machine registry (migration 064)
+            'machines',
         ]
     }
     assert tables == expected_tables, \


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-07-11T20:59:09Z
- chore: init swarm session feature/2943-machines-entity-track-which-machine-1

## Files changed
```
 migrations/064_add_machines.sql | 102 +++++++++++++++++++++++++++++++
 schema.sql                      |  51 ++++++++++++++--
 scripts/recreate_darwin_dev.sql |  46 ++++++++++++--
 tests/conftest.py               |   5 ++
 tests/test_constraints.py       | 129 ++++++++++++++++++++++++++++++++++++++++
 tests/test_data_types.py        |  89 ++++++++++++++++++++++++++-
 tests/test_migrations.py        |  15 +++++
 7 files changed, 426 insertions(+), 11 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)