### PR TITLE
Promote ai_model/effort to dedicated columns on swarm_starts and swarm_completes for cost-by-model analytics

### DIFF
--- a/migrations/065_add_ai_model_effort_to_starts_completes.sql
+++ b/migrations/065_add_ai_model_effort_to_starts_completes.sql
@@ -1,0 +1,112 @@
+-- 065_add_ai_model_effort_to_starts_completes.sql
+--
+-- Req #2949: promote ai_model/effort to dedicated, queryable columns on
+-- swarm_starts and swarm_completes, mirroring the columns swarm_sessions
+-- already has (req #2909 migration 062, req #2916 migration 063). Today the
+-- same fact is buried in the `telemetry` TEXT blob (the TOKEN_TELEMETRY JSON
+-- written by scripts/swarm/telemetry-capture.sh, keys "model" / "effort"),
+-- which requires JSON-parsing free text for a cost-by-model rollup and
+-- carries a "[1m]" context-window suffix on primary-session rows
+-- (e.g. sonnet[1m]) that needs normalizing.
+--
+-- Value domains match swarm_sessions:
+--   ai_model  VARCHAR(16) NOT NULL DEFAULT 'opus'  -- haiku|sonnet|opus|fable
+--   effort    VARCHAR(16) NOT NULL DEFAULT 'high'  -- low|medium|high|xhigh|ultracode
+-- Unlike swarm_sessions.effort (whose column DEFAULT was later bumped to
+-- 'xhigh' for new rows, req #2916), swarm_starts/swarm_completes keep 'high'
+-- as the default for BOTH the backfill and future inserts — these are
+-- terminal log rows written once at finalize time with a real telemetry-
+-- derived value, not user-editable settings that need a "current" default.
+--
+-- NOT NULL mirrors requirements.coordination_type (req #2745) and the
+-- ai_model/effort precedent above: an unset model/effort is not a
+-- meaningful state for a cost-recording row.
+--
+-- Backfill: ADD COLUMN ... DEFAULT already backfills every historical row to
+-- 'opus'/'high'. The UPDATE below then overwrites ONLY rows whose telemetry
+-- blob contains a well-formed TOKEN_TELEMETRY JSON payload with a valid,
+-- normalizable model/effort — everything else (NULL telemetry, no marker,
+-- malformed JSON, or a value outside the enum after normalization, e.g.
+-- "unknown") is left at the column DEFAULT rather than fabricating a
+-- precise-looking guess.
+--
+-- Parsing approach: the telemetry text always ends with the JSON payload as
+-- the LAST thing appended (see skill-finalize.sh / primary-complete-
+-- finalize.sh / swarm-complete.md), immediately after a 'TOKEN_TELEMETRY:'
+-- marker line (worker swarm_completes rows use a 'COMPLETE_TOKEN_TELEMETRY:'
+-- marker, which still ends in the substring 'TOKEN_TELEMETRY:'). MySQL's
+-- SUBSTRING_INDEX(str, delim, -1) returns everything after the LAST
+-- occurrence of delim, so it recovers the JSON payload regardless of which
+-- marker variant was used. JSON_VALID() guards against malformed/absent
+-- payloads before JSON_EXTRACT runs (JSON_EXTRACT errors on invalid JSON).
+--
+-- Normalization mirrors scripts/swarm/normalize_model_effort.py (the live-
+-- write helper) — keep both in sync if the enum domains change:
+--   model:  REGEXP_REPLACE(raw, '\\[[^]]*\\]$', '') strips a trailing
+--           bracketed suffix ('sonnet[1m]' -> 'sonnet'), then validated
+--           against the enum.
+--   effort: 'max' -> 'ultracode', then validated against the enum.
+
+ALTER TABLE swarm_starts
+    ADD COLUMN ai_model VARCHAR(16) NOT NULL DEFAULT 'opus' AFTER session_count,
+    ADD COLUMN effort   VARCHAR(16) NOT NULL DEFAULT 'high' AFTER ai_model;
+
+ALTER TABLE swarm_completes
+    ADD COLUMN ai_model VARCHAR(16) NOT NULL DEFAULT 'opus' AFTER session_count,
+    ADD COLUMN effort   VARCHAR(16) NOT NULL DEFAULT 'high' AFTER ai_model;
+
+-- --- Backfill swarm_starts ---
+UPDATE swarm_starts s
+JOIN (
+    SELECT
+        id,
+        TRIM(SUBSTRING_INDEX(telemetry, 'TOKEN_TELEMETRY:', -1)) AS json_text
+    FROM swarm_starts
+    WHERE telemetry IS NOT NULL
+      AND telemetry LIKE '%TOKEN_TELEMETRY:%'
+) t ON t.id = s.id AND JSON_VALID(t.json_text)
+SET
+    s.ai_model = CASE REGEXP_REPLACE(
+                        JSON_UNQUOTE(JSON_EXTRACT(t.json_text, '$.model')),
+                        '\\[[^]]*\\]$', '')
+                     WHEN 'haiku'  THEN 'haiku'
+                     WHEN 'sonnet' THEN 'sonnet'
+                     WHEN 'opus'   THEN 'opus'
+                     WHEN 'fable'  THEN 'fable'
+                     ELSE 'opus'
+                 END,
+    s.effort = CASE
+                   WHEN JSON_UNQUOTE(JSON_EXTRACT(t.json_text, '$.effort')) = 'max' THEN 'ultracode'
+                   WHEN JSON_UNQUOTE(JSON_EXTRACT(t.json_text, '$.effort'))
+                        IN ('low', 'medium', 'high', 'xhigh', 'ultracode')
+                       THEN JSON_UNQUOTE(JSON_EXTRACT(t.json_text, '$.effort'))
+                   ELSE 'high'
+               END;
+
+-- --- Backfill swarm_completes ---
+UPDATE swarm_completes c
+JOIN (
+    SELECT
+        id,
+        TRIM(SUBSTRING_INDEX(telemetry, 'TOKEN_TELEMETRY:', -1)) AS json_text
+    FROM swarm_completes
+    WHERE telemetry IS NOT NULL
+      AND telemetry LIKE '%TOKEN_TELEMETRY:%'
+) t ON t.id = c.id AND JSON_VALID(t.json_text)
+SET
+    c.ai_model = CASE REGEXP_REPLACE(
+                        JSON_UNQUOTE(JSON_EXTRACT(t.json_text, '$.model')),
+                        '\\[[^]]*\\]$', '')
+                     WHEN 'haiku'  THEN 'haiku'
+                     WHEN 'sonnet' THEN 'sonnet'
+                     WHEN 'opus'   THEN 'opus'
+                     WHEN 'fable'  THEN 'fable'
+                     ELSE 'opus'
+                 END,
+    c.effort = CASE
+                   WHEN JSON_UNQUOTE(JSON_EXTRACT(t.json_text, '$.effort')) = 'max' THEN 'ultracode'
+                   WHEN JSON_UNQUOTE(JSON_EXTRACT(t.json_text, '$.effort'))
+                        IN ('low', 'medium', 'high', 'xhigh', 'ultracode')
+                       THEN JSON_UNQUOTE(JSON_EXTRACT(t.json_text, '$.effort'))
+                   ELSE 'high'
+               END;

--- a/schema.sql
+++ b/schema.sql
@@ -279,12 +279,16 @@ CREATE TABLE IF NOT EXISTS requirement_sessions (
 -- (a launch can span categories), no title (arguments string is the label).
 -- Token / wall / turn / summary / telemetry columns are NULL until skill-finalize
 -- captures them at end-of-run; populated via update_swarm_start.
+-- ai_model/effort (req #2949, migration 065): normalized, queryable copy of
+-- the same fact buried in the telemetry JSON blob — mirrors swarm_sessions.
 CREATE TABLE IF NOT EXISTS swarm_starts (
     id                  INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
     arguments           VARCHAR(512)    NULL,
     autonomy_filter     VARCHAR(16)     NULL,
     auto_start          TINYINT(1)      NOT NULL DEFAULT 0,
     session_count       INT             NOT NULL DEFAULT 0,
+    ai_model            VARCHAR(16)     NOT NULL DEFAULT 'opus',
+    effort              VARCHAR(16)     NOT NULL DEFAULT 'high',
     machine_fk          INT             NULL,          -- req #2943; which machine ran this start
     tokens_input        INT             NULL,
     tokens_cache_write  INT             NULL,
@@ -327,12 +331,16 @@ CREATE TABLE IF NOT EXISTS swarm_start_sessions (
 -- complete_summary (mirrors swarm_sessions.complete_summary). Token / wall / turn
 -- / summary / telemetry columns are NULL until the skill's finalize step writes
 -- them via update_swarm_complete.
+-- ai_model/effort (req #2949, migration 065): normalized, queryable copy of
+-- the same fact buried in the telemetry JSON blob — mirrors swarm_starts.
 CREATE TABLE IF NOT EXISTS swarm_completes (
     id                  INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
     skill_name          VARCHAR(64)     NOT NULL,
     coordination_type   VARCHAR(16)     NULL,
     status              VARCHAR(16)     NOT NULL DEFAULT 'in_progress',
     session_count       INT             NOT NULL DEFAULT 0,
+    ai_model            VARCHAR(16)     NOT NULL DEFAULT 'opus',
+    effort              VARCHAR(16)     NOT NULL DEFAULT 'high',
     tokens_input        INT             NULL,
     tokens_cache_write  INT             NULL,
     tokens_cache_read   INT             NULL,

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -277,6 +277,8 @@ CREATE TABLE swarm_starts (
     autonomy_filter     VARCHAR(16)     NULL,
     auto_start          TINYINT(1)      NOT NULL DEFAULT 0,
     session_count       INT             NOT NULL DEFAULT 0,
+    ai_model            VARCHAR(16)     NOT NULL DEFAULT 'opus',  -- req #2949
+    effort              VARCHAR(16)     NOT NULL DEFAULT 'high',  -- req #2949
     machine_fk          INT             NULL,          -- req #2943
     tokens_input        INT             NULL,
     tokens_cache_write  INT             NULL,
@@ -316,6 +318,8 @@ CREATE TABLE swarm_completes (
     coordination_type   VARCHAR(16)     NULL,
     status              VARCHAR(16)     NOT NULL DEFAULT 'in_progress',
     session_count       INT             NOT NULL DEFAULT 0,
+    ai_model            VARCHAR(16)     NOT NULL DEFAULT 'opus',  -- req #2949
+    effort              VARCHAR(16)     NOT NULL DEFAULT 'high',  -- req #2949
     tokens_input        INT             NULL,
     tokens_cache_write  INT             NULL,
     tokens_cache_read   INT             NULL,

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -652,6 +652,8 @@ def test_swarm_starts_columns(db_connection):
     - autonomy_filter: VARCHAR(16), NULL
     - auto_start: TINYINT(1), NOT NULL, DEFAULT 0
     - session_count: INT, NOT NULL, DEFAULT 0
+    - ai_model: VARCHAR(16), NOT NULL, DEFAULT 'opus' (req #2949)
+    - effort: VARCHAR(16), NOT NULL, DEFAULT 'high' (req #2949)
     - tokens_input / tokens_cache_write / tokens_cache_read / tokens_output: INT, NULL
     - wall_seconds: INT, NULL
     - turn_count: INT, NULL
@@ -666,7 +668,7 @@ def test_swarm_starts_columns(db_connection):
         columns = {row['Field']: row for row in cur.fetchall()}
 
     expected_fields = ['id', 'arguments', 'autonomy_filter',
-                       'auto_start', 'session_count',
+                       'auto_start', 'session_count', 'ai_model', 'effort',
                        'tokens_input', 'tokens_cache_write', 'tokens_cache_read',
                        'tokens_output', 'wall_seconds', 'turn_count',
                        'start_summary', 'telemetry',
@@ -699,6 +701,15 @@ def test_swarm_starts_columns(db_connection):
     assert columns['session_count']['Type'] == 'int'
     assert columns['session_count']['Null'] == 'NO'
     assert columns['session_count']['Default'] == '0'
+
+    # req #2949 — normalized, queryable copy of the telemetry blob's model/effort.
+    assert columns['ai_model']['Type'] == 'varchar(16)'
+    assert columns['ai_model']['Null'] == 'NO'
+    assert columns['ai_model']['Default'] == 'opus'
+
+    assert columns['effort']['Type'] == 'varchar(16)'
+    assert columns['effort']['Null'] == 'NO'
+    assert columns['effort']['Default'] == 'high'
 
     # Token / timing / count columns are NULL until skill-finalize populates them.
     for col in ('tokens_input', 'tokens_cache_write', 'tokens_cache_read',
@@ -811,6 +822,8 @@ def test_swarm_completes_columns(db_connection):
     - coordination_type: VARCHAR(16), NULL (NULL for primary-ai-swarm-complete)
     - status: VARCHAR(16), NOT NULL, DEFAULT 'in_progress'
     - session_count: INT, NOT NULL, DEFAULT 0
+    - ai_model: VARCHAR(16), NOT NULL, DEFAULT 'opus' (req #2949)
+    - effort: VARCHAR(16), NOT NULL, DEFAULT 'high' (req #2949)
     - tokens_input / tokens_cache_write / tokens_cache_read / tokens_output: INT, NULL
     - wall_seconds: INT, NULL
     - turn_count: INT, NULL
@@ -826,7 +839,7 @@ def test_swarm_completes_columns(db_connection):
         columns = {row['Field']: row for row in cur.fetchall()}
 
     expected_fields = ['id', 'skill_name', 'coordination_type',
-                       'status', 'session_count',
+                       'status', 'session_count', 'ai_model', 'effort',
                        'tokens_input', 'tokens_cache_write', 'tokens_cache_read',
                        'tokens_output', 'wall_seconds', 'turn_count',
                        'complete_summary', 'telemetry',
@@ -851,6 +864,15 @@ def test_swarm_completes_columns(db_connection):
     assert columns['session_count']['Type'] == 'int'
     assert columns['session_count']['Null'] == 'NO'
     assert columns['session_count']['Default'] == '0'
+
+    # req #2949 — normalized, queryable copy of the telemetry blob's model/effort.
+    assert columns['ai_model']['Type'] == 'varchar(16)'
+    assert columns['ai_model']['Null'] == 'NO'
+    assert columns['ai_model']['Default'] == 'opus'
+
+    assert columns['effort']['Type'] == 'varchar(16)'
+    assert columns['effort']['Null'] == 'NO'
+    assert columns['effort']['Default'] == 'high'
 
     # Token / timing / count columns are NULL until the skill's finalize populates them.
     for col in ('tokens_input', 'tokens_cache_write', 'tokens_cache_read',


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-07-11T21:45:10Z
- chore: init swarm session feature/2949-promote-ai-modeleffort-to-dedicated-1

## Files changed
```
 ...065_add_ai_model_effort_to_starts_completes.sql | 112 +++++++++++++++++++++
 schema.sql                                         |   8 ++
 scripts/recreate_darwin_dev.sql                    |   4 +
 tests/test_data_types.py                           |  26 ++++-
 4 files changed, 148 insertions(+), 2 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)