### PR TITLE
Add Machine setting to requirements + machine-aware swarm skills

### DIFF
--- a/migrations/066_add_requirement_machine.sql
+++ b/migrations/066_add_requirement_machine.sql
@@ -1,0 +1,33 @@
+-- 066_add_requirement_machine.sql
+--
+-- Req #2978: pin a requirement to a specific machine.
+--
+-- Req #2943 (migration 064) introduced the `machines` entity and stamped
+-- swarm_sessions / swarm_starts / dev_servers with a nullable `machine_fk`
+-- recording WHERE each execution ran. It deliberately scoped `requirements`
+-- out. This migration is that follow-up: `requirements.machine_fk` records
+-- where a requirement is ALLOWED to run.
+--
+-- Semantics — NULL = "Any":
+--   NULL          → the requirement may be launched on any machine (the default)
+--   <machines.id> → the requirement is pinned; /swarm-start will only launch it
+--                   on that machine, and refuses an explicit launch elsewhere.
+--
+-- No backfill. `NULL DEFAULT NULL` means every pre-existing requirement is "Any"
+-- the moment this runs, which is the correct default — the handful that need a
+-- pin are set by hand on the requirement detail page afterward. This is
+-- deliberately unlike 064's commented-out execution-history backfill: that one
+-- attributed the PAST (where work actually ran), this one constrains the FUTURE
+-- (where work is allowed to run), and nothing in the existing data implies a
+-- constraint the user never expressed.
+--
+-- FK matches the 064 convention exactly: ON UPDATE CASCADE ON DELETE RESTRICT.
+-- A machine referenced by a requirement therefore cannot be hard-deleted —
+-- retire it via `closed = 1` instead. (The MCP `delete_machine` guard message
+-- names `requirements` alongside the three execution tables as of this req.)
+
+ALTER TABLE requirements
+    ADD COLUMN machine_fk INT NULL DEFAULT NULL AFTER effort,
+    ADD CONSTRAINT fk_requirements_machine
+        FOREIGN KEY (machine_fk) REFERENCES machines (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT;

--- a/schema.sql
+++ b/schema.sql
@@ -138,42 +138,6 @@ CREATE TABLE IF NOT EXISTS categories (
         ON UPDATE CASCADE ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS requirements (
-    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    title           VARCHAR(256)    NOT NULL,
-    description     TEXT            NULL,
-    requirement_status VARCHAR(16)  NOT NULL DEFAULT 'authoring',
-                                            -- authoring | approved | swarm_ready | development | met | deferred | wontfix
-    started_at      TIMESTAMP       NULL,
-    completed_at    TIMESTAMP       NULL,
-    deferred_at     TIMESTAMP       NULL,
-    project_fk      INT             NULL,
-    category_fk     INT             NOT NULL,
-    creator_fk      VARCHAR(64)     NOT NULL,
-    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
-    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
-    coordination_type VARCHAR(16)   NOT NULL DEFAULT 'implemented',
-                                            -- discuss | planned | implemented | deployed (mandatory, req #2745; default: implemented)
-    ai_model        VARCHAR(16)     NOT NULL DEFAULT 'opus',
-                                            -- haiku | sonnet | opus | fable (req #2909; default: opus, pre-#2909 rows assumed opus)
-    effort          VARCHAR(16)     NOT NULL DEFAULT 'xhigh',
-                                            -- low | medium | high | xhigh | ultracode (req #2916; default: xhigh, pre-#2916 rows assumed high)
-    sort_order      SMALLINT        NULL DEFAULT NULL,
-                                            -- in-card hand-sort position (req #2417); NULL = unranked, falls to id-order
-    affected_repos  VARCHAR(255)    NULL DEFAULT NULL,
-                                            -- comma-separated sub-repo override (req #2583); NULL = use category default
-    FOREIGN KEY (project_fk)
-        REFERENCES projects (id)
-        ON UPDATE CASCADE ON DELETE SET NULL,
-    CONSTRAINT fk_requirements_category
-        FOREIGN KEY (category_fk)
-        REFERENCES categories (id)
-        ON UPDATE CASCADE ON DELETE RESTRICT,
-    FOREIGN KEY (creator_fk)
-        REFERENCES profiles (id)
-        ON UPDATE CASCADE ON DELETE CASCADE
-);
-
 -- ============================================================================
 -- Machine registry (req #2943)
 -- ============================================================================
@@ -200,6 +164,48 @@ CREATE TABLE IF NOT EXISTS machines (
     UNIQUE KEY uq_machines_hostname (hostname),
     CONSTRAINT fk_machines_creator
         FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS requirements (
+    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title           VARCHAR(256)    NOT NULL,
+    description     TEXT            NULL,
+    requirement_status VARCHAR(16)  NOT NULL DEFAULT 'authoring',
+                                            -- authoring | approved | swarm_ready | development | met | deferred | wontfix
+    started_at      TIMESTAMP       NULL,
+    completed_at    TIMESTAMP       NULL,
+    deferred_at     TIMESTAMP       NULL,
+    project_fk      INT             NULL,
+    category_fk     INT             NOT NULL,
+    creator_fk      VARCHAR(64)     NOT NULL,
+    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
+    coordination_type VARCHAR(16)   NOT NULL DEFAULT 'implemented',
+                                            -- discuss | planned | implemented | deployed (mandatory, req #2745; default: implemented)
+    ai_model        VARCHAR(16)     NOT NULL DEFAULT 'opus',
+                                            -- haiku | sonnet | opus | fable (req #2909; default: opus, pre-#2909 rows assumed opus)
+    effort          VARCHAR(16)     NOT NULL DEFAULT 'xhigh',
+                                            -- low | medium | high | xhigh | ultracode (req #2916; default: xhigh, pre-#2916 rows assumed high)
+    sort_order      SMALLINT        NULL DEFAULT NULL,
+                                            -- in-card hand-sort position (req #2417); NULL = unranked, falls to id-order
+    affected_repos  VARCHAR(255)    NULL DEFAULT NULL,
+                                            -- comma-separated sub-repo override (req #2583); NULL = use category default
+    machine_fk      INT             NULL DEFAULT NULL,
+                                            -- machine pin (req #2978, migration 066); NULL = "Any" machine may run it
+    FOREIGN KEY (project_fk)
+        REFERENCES projects (id)
+        ON UPDATE CASCADE ON DELETE SET NULL,
+    CONSTRAINT fk_requirements_category
+        FOREIGN KEY (category_fk)
+        REFERENCES categories (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_requirements_machine
+        FOREIGN KEY (machine_fk)
+        REFERENCES machines (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    FOREIGN KEY (creator_fk)
+        REFERENCES profiles (id)
         ON UPDATE CASCADE ON DELETE CASCADE
 );
 

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -148,6 +148,29 @@ CREATE TABLE categories (
         ON UPDATE CASCADE ON DELETE CASCADE
 );
 
+-- Machine registry (req #2943) — created before the execution tables that
+-- reference it via machine_fk.
+CREATE TABLE machines (
+    id           INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title        VARCHAR(256) NOT NULL,
+    description  TEXT         NULL,
+    hostname     VARCHAR(128) NOT NULL,
+    platform     VARCHAR(16)  NOT NULL,           -- darwin | wsl | linux
+    arch         VARCHAR(16)  NOT NULL,           -- arm64 | x86_64
+    os_version   VARCHAR(64)  NULL,
+    hw_model     VARCHAR(64)  NULL,
+    last_seen_at TIMESTAMP    NULL,
+    closed       TINYINT(1)   NOT NULL DEFAULT 0,
+    sort_order   SMALLINT     NULL,
+    creator_fk   VARCHAR(64)  NOT NULL,
+    create_ts    TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts    TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_machines_hostname (hostname),
+    CONSTRAINT fk_machines_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
 CREATE TABLE requirements (
     id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
     title           VARCHAR(256)    NOT NULL,
@@ -172,6 +195,8 @@ CREATE TABLE requirements (
                                             -- in-card hand-sort position (req #2417); NULL = unranked, falls to id-order
     affected_repos  VARCHAR(255)    NULL DEFAULT NULL,
                                             -- comma-separated sub-repo override (req #2583); NULL = use category default
+    machine_fk      INT             NULL DEFAULT NULL,
+                                            -- machine pin (req #2978, migration 066); NULL = "Any" machine may run it
     FOREIGN KEY (project_fk)
         REFERENCES projects (id)
         ON UPDATE CASCADE ON DELETE SET NULL,
@@ -179,31 +204,12 @@ CREATE TABLE requirements (
         FOREIGN KEY (category_fk)
         REFERENCES categories (id)
         ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_requirements_machine
+        FOREIGN KEY (machine_fk)
+        REFERENCES machines (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
     FOREIGN KEY (creator_fk)
         REFERENCES profiles (id)
-        ON UPDATE CASCADE ON DELETE CASCADE
-);
-
--- Machine registry (req #2943) — created before the execution tables that
--- reference it via machine_fk.
-CREATE TABLE machines (
-    id           INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    title        VARCHAR(256) NOT NULL,
-    description  TEXT         NULL,
-    hostname     VARCHAR(128) NOT NULL,
-    platform     VARCHAR(16)  NOT NULL,           -- darwin | wsl | linux
-    arch         VARCHAR(16)  NOT NULL,           -- arm64 | x86_64
-    os_version   VARCHAR(64)  NULL,
-    hw_model     VARCHAR(64)  NULL,
-    last_seen_at TIMESTAMP    NULL,
-    closed       TINYINT(1)   NOT NULL DEFAULT 0,
-    sort_order   SMALLINT     NULL,
-    creator_fk   VARCHAR(64)  NOT NULL,
-    create_ts    TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
-    update_ts    TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
-    UNIQUE KEY uq_machines_hostname (hostname),
-    CONSTRAINT fk_machines_creator
-        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
         ON UPDATE CASCADE ON DELETE CASCADE
 );
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1118,6 +1118,54 @@ def test_machine_fk_restrict_dev_servers(db_connection, test_creator_fk):
     db_connection.rollback()
 
 
+def test_machine_fk_restrict_requirements(db_connection, test_creator_fk, test_category_id):
+    """requirements.machine_fk is ON DELETE RESTRICT (req #2978, migration 066).
+
+    A machine PINNED BY a requirement cannot be hard-deleted — retire it via
+    closed=1 instead. This is the fourth referencing table alongside the three
+    execution tables from req #2943, and the MCP delete_machine guard message
+    names it.
+    """
+    with db_connection.cursor() as cur:
+        mid = _insert_machine(cur, test_creator_fk, 'restrict-req.local')
+        cur.execute(
+            "INSERT INTO requirements (title, machine_fk, creator_fk, category_fk) "
+            "VALUES (%s, %s, %s, %s)",
+            ('m-restrict-req', mid, test_creator_fk, test_category_id),
+        )
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute("DELETE FROM machines WHERE id = %s", (mid,))
+    db_connection.rollback()
+
+
+def test_requirement_machine_fk_defaults_null(db_connection, test_creator_fk, test_category_id):
+    """A requirement created without machine_fk is NULL = "Any machine" (req #2978).
+
+    This is what makes migration 066 backfill-free: every pre-existing and every
+    newly-created requirement is "Any" unless explicitly pinned.
+    """
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO requirements (title, creator_fk, category_fk) VALUES (%s, %s, %s)",
+            ('m-default-any', test_creator_fk, test_category_id),
+        )
+        cur.execute("SELECT machine_fk FROM requirements WHERE id = LAST_INSERT_ID()")
+        assert cur.fetchone()['machine_fk'] is None
+    db_connection.rollback()
+
+
+def test_requirement_machine_fk_invalid_reference(db_connection, test_creator_fk, test_category_id):
+    """A requirement referencing a non-existent machine_fk → IntegrityError."""
+    with db_connection.cursor() as cur:
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO requirements (title, machine_fk, creator_fk, category_fk) "
+                "VALUES (%s, %s, %s, %s)",
+                ('m-req-bad-fk', 999999999, test_creator_fk, test_category_id),
+            )
+    db_connection.rollback()
+
+
 def test_machine_fk_invalid_reference(db_connection, test_creator_fk):
     """A swarm_session referencing a non-existent machine_fk → IntegrityError."""
     with db_connection.cursor() as cur:

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -430,6 +430,9 @@ def test_requirements_columns(db_connection):
     # Tolerate both pre- and post-migration-063 state (req #2916 added effort).
     if 'effort' in columns:
         expected_fields.append('effort')
+    # Tolerate both pre- and post-migration-066 state (req #2978 added machine_fk).
+    if 'machine_fk' in columns:
+        expected_fields.append('machine_fk')
     assert set(columns.keys()) == set(expected_fields)
 
     assert columns['id']['Type'] == 'int'
@@ -489,6 +492,15 @@ def test_requirements_columns(db_connection):
         assert columns['effort']['Type'] == 'varchar(16)'
         assert columns['effort']['Null'] == 'NO'   # mandatory effort (req #2916)
         assert columns['effort']['Default'] == 'xhigh'
+
+    # req #2978 machine_fk (migration 066) — nullable FK, no default. Unlike
+    # coordination_type / ai_model / effort this one is deliberately NULLable:
+    # NULL is the meaningful "Any machine" value, not a missing setting.
+    if 'machine_fk' in columns:
+        assert columns['machine_fk']['Type'] == 'int'
+        assert columns['machine_fk']['Null'] == 'YES'
+        assert columns['machine_fk']['Key'] == 'MUL'
+        assert columns['machine_fk']['Default'] is None
 
 
 def test_swarm_sessions_columns(db_connection):


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-07-19T11:40:27Z
- chore: init swarm session feature/2978-add-machine-setting-to-requirements-1

## Files changed
```
 migrations/066_add_requirement_machine.sql | 33 +++++++++++++++
 schema.sql                                 | 64 ++++++++++++++++--------------
 scripts/recreate_darwin_dev.sql            | 52 +++++++++++++-----------
 tests/test_constraints.py                  | 48 ++++++++++++++++++++++
 tests/test_data_types.py                   | 12 ++++++
 5 files changed, 157 insertions(+), 52 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)