### PR TITLE
Architect + Architecture Document data type (ownership registry)

### DIFF
--- a/migrations/067_add_agents_registry.sql
+++ b/migrations/067_add_agents_registry.sql
@@ -1,0 +1,188 @@
+-- 067_add_agents_registry.sql
+--
+-- Req #2997: Architect + Architecture Document data type (ownership registry).
+--
+-- PROBLEM. The 11 architect agents under `.claude/agents/` each carry their
+-- entire brain as prose inside a single .md file. Nothing records WHO owns WHICH
+-- document: an ownership survey (req #2982) found 6 of 11 agents with explicit
+-- "Owned files" sections, 5 with ownership implied only, 2 stale entries
+-- (cognito-config.md, tasks-architecture.md), and the req #2982 HTML docs
+-- unowned entirely. Ownership that lives only in prose drifts silently.
+--
+-- SHAPE. Agent .md files become thin human-readable CHARTER STUBS; the durable
+-- knowledge moves into these five tables and is read at agent boot through a
+-- single MCP call (darwin://agents/<Agent Name>). The DB is canon; stub
+-- frontmatter is a mirror reconciled at session boundaries by
+-- scripts/swarm/reconcile-agent-stubs.sh (the harness cannot query MCP at spawn
+-- time, so model/effort/description must physically exist in the file).
+--
+-- Every table here is a shape Darwin already has — flat content tables plus
+-- plain junctions (memory/new-data-type-pattern.md). Deliberately NOT a generic
+-- section/attribute store: an earlier `agent_sections` design was considered and
+-- REJECTED during design (see req #2997 history). Long or complex content
+-- belongs in an architecture document — a groomable md/html file — not in DB
+-- prose. Fields edited in Darwin's UI are short by nature.
+--
+-- PRODUCTION table (not darwin_dev-only). Unlike the build-visualizer tables
+-- (migration 057), the agent registry is a first-class production concern: the
+-- MCP daemon runs with DB_NAME=darwin and every agent boot reads through it.
+--
+-- NO category_fk on any table. These are infrastructure entities describing the
+-- tooling itself, not user-categorized content — same call as `machines`
+-- (migration 064).
+--
+-- Phase 1 seeds ONE agent end-to-end (aws-architect) to prove the loading path.
+-- The remaining 10 agents are req #2998.
+
+-- ---------------------------------------------------------------------------
+-- agents — one row per architect agent.
+--
+-- `name` is the MCP lookup key and matches the H1 in the charter stub
+-- ("AWS Architect"); `file_name` is the stub's basename ("aws-architect.md").
+-- Both are UNIQUE so either can resolve an agent, and neither can silently
+-- duplicate.
+--
+-- ai_model/effort are the STANDARD HEADER PIN: every architect defaults to
+-- opus[1m] / high, replacing the stale per-agent `claude-opus-4-6` pins. These
+-- are the values a reconcile writes into stub frontmatter. Precedence at spawn:
+-- an explicit session / swarm / requirement setting overrides; absent an
+-- override, the pin is what you get.
+--
+-- ai_model is VARCHAR, NOT an ENUM — it holds a RESOLVED model id ('opus[1m]')
+-- rather than one of Darwin's haiku|sonnet|opus|fable family names, and resolved
+-- ids change with every model release. An ENUM would demand a migration per
+-- release. `effort` IS constrained (low|medium|high|xhigh|ultracode is a stable,
+-- Darwin-owned vocabulary — same set as requirements.effort, migration 063).
+-- ---------------------------------------------------------------------------
+CREATE TABLE agents (
+    id          INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    name        VARCHAR(128) NOT NULL,                    -- human-readable, e.g. "AWS Architect"; MCP key; UNIQUE
+    file_name   VARCHAR(128) NOT NULL,                    -- stub basename, e.g. "aws-architect.md"; UNIQUE
+    overview    TEXT         NULL,                        -- short delegation trigger; mirrored to stub `description`
+    ai_model    VARCHAR(32)  NOT NULL DEFAULT 'opus[1m]', -- resolved model id (see note above)
+    effort      VARCHAR(16)  NOT NULL DEFAULT 'high',     -- low|medium|high|xhigh|ultracode
+    location    VARCHAR(512) NULL,                        -- repo-relative stub path, e.g. ".claude/agents/aws-architect.md"
+    closed      TINYINT(1)   NOT NULL DEFAULT 0,          -- retire an agent without deleting its history
+    sort_order  SMALLINT     NULL,
+    creator_fk  VARCHAR(64)  NOT NULL,
+    create_ts   TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts   TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_agents_name (name),
+    UNIQUE KEY uq_agents_file_name (file_name),
+    CONSTRAINT fk_agents_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+-- ---------------------------------------------------------------------------
+-- instructions — reusable named blocks of BINDING text.
+--
+-- Its own data type precisely so one row can serve many agents: the grooming
+-- duty ("re-groom the owned document whenever its spec changes, so it never
+-- drifts") is ONE row linked to all 11 agents. Edit it once, every architect
+-- picks up the change at next boot. Per-agent instructions are ordinary rows
+-- linked to exactly one agent.
+-- ---------------------------------------------------------------------------
+CREATE TABLE instructions (
+    id          INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    name        VARCHAR(256) NOT NULL,   -- UNIQUE; the upsert key for idempotent seeding
+    content     TEXT         NOT NULL,   -- the binding text itself
+    closed      TINYINT(1)   NOT NULL DEFAULT 0,
+    sort_order  SMALLINT     NULL,
+    creator_fk  VARCHAR(64)  NOT NULL,
+    create_ts   TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts   TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_instructions_name (name),
+    CONSTRAINT fk_instructions_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+-- ---------------------------------------------------------------------------
+-- agent_instructions — which instructions bind which agent, and in what order.
+--
+-- CASCADE both sides: an unlinked instruction is meaningless, and deleting an
+-- agent should not strand junction rows. `sort_order` drives the load order the
+-- charter stub promises ("sections by sort_order").
+-- ---------------------------------------------------------------------------
+CREATE TABLE agent_instructions (
+    agent_fk        INT      NOT NULL,
+    instruction_fk  INT      NOT NULL,
+    sort_order      SMALLINT NULL,
+    PRIMARY KEY (agent_fk, instruction_fk),
+    CONSTRAINT fk_ai_agent
+        FOREIGN KEY (agent_fk) REFERENCES agents (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_ai_instruction
+        FOREIGN KEY (instruction_fk) REFERENCES instructions (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+-- ---------------------------------------------------------------------------
+-- architecture_documents — THE ONE registry of documents.
+--
+-- Exactly one documents table exists. `agent_documents` below is a junction of
+-- RELATIONSHIPS, not a second list of documents.
+--
+-- `location` is repo-relative (e.g. "memory/aws-cost.md") — the path an agent
+-- Reads at boot. `url` is the clickable form for the Phase 2 UI: a GitHub blob
+-- link for markdown, a site path for html. Both are nullable because a document
+-- may be registered before either is settled.
+-- ---------------------------------------------------------------------------
+CREATE TABLE architecture_documents (
+    id          INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    name        VARCHAR(256) NOT NULL,   -- UNIQUE; the upsert key for idempotent seeding
+    doc_type    VARCHAR(16)  NOT NULL DEFAULT 'markdown',  -- markdown|html|text
+    location    VARCHAR(512) NULL,       -- repo-relative path the agent Reads
+    url         VARCHAR(1024) NULL,      -- clickable link (GitHub blob / site path)
+    closed      TINYINT(1)   NOT NULL DEFAULT 0,
+    sort_order  SMALLINT     NULL,
+    creator_fk  VARCHAR(64)  NOT NULL,
+    create_ts   TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts   TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_architecture_documents_name (name),
+    CONSTRAINT fk_architecture_documents_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+-- ---------------------------------------------------------------------------
+-- agent_documents — the many-to-many relationship rows.
+--
+-- relationship semantics (drives what the agent does with the file at boot):
+--   owned          responsible party; reads IN FULL before starting a task
+--   groomed        keeps it current; reads IN FULL before starting a task
+--   referenced     consults on demand — NOT auto-loaded
+--   design_language  visual/structural rules it must honor
+--   guardian       a standing duty to verify (e.g. schema-of-record parity)
+--
+-- "AT MOST ONE 'owned' PER DOCUMENT" is enforced BY THE DATABASE, not by prose.
+-- MySQL has no partial/filtered unique index, so `owned_document_fk` is a
+-- VIRTUAL generated column that equals document_fk only on an 'owned' row and is
+-- NULL otherwise; a UNIQUE key over it does the work. MySQL treats NULLs as
+-- distinct in a UNIQUE key, so unlimited groomed/referenced/design_language/
+-- guardian links coexist freely while a SECOND 'owned' link on the same document
+-- raises IntegrityError. VIRTUAL (not STORED): the value is computed on read and
+-- costs no row storage; MySQL 8 indexes virtual columns natively.
+--
+-- This is the rule the whole requirement exists to enforce — one named
+-- responsible architect per document. Cross-architect polish remains allowed
+-- (an architect may polish another's document when certain the responsible one
+-- will not), but that is a fallback, not a second ownership claim.
+-- ---------------------------------------------------------------------------
+CREATE TABLE agent_documents (
+    agent_fk           INT          NOT NULL,
+    document_fk        INT          NOT NULL,
+    relationship       VARCHAR(24)  NOT NULL DEFAULT 'referenced',  -- owned|groomed|referenced|design_language|guardian
+    notes              VARCHAR(512) NULL,      -- per-link caveats (e.g. "vendored copy — upstream is Topology/")
+    sort_order         SMALLINT     NULL,
+    owned_document_fk  INT          AS (IF(relationship = 'owned', document_fk, NULL)) VIRTUAL,
+    PRIMARY KEY (agent_fk, document_fk),
+    UNIQUE KEY uq_agent_documents_owner (owned_document_fk),
+    CONSTRAINT fk_ad_agent
+        FOREIGN KEY (agent_fk) REFERENCES agents (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_ad_document
+        FOREIGN KEY (document_fk) REFERENCES architecture_documents (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);

--- a/schema.sql
+++ b/schema.sql
@@ -1,6 +1,6 @@
 -- Darwin Database Schema — Current State
 -- Database: darwin
--- This file reflects the final state of all 34 tables after all migrations.
+-- This file reflects the final state of all 44 tables after all migrations.
 -- It can be run against a fresh MySQL instance to create the complete schema.
 -- Table order respects FK dependencies.
 
@@ -859,6 +859,100 @@ CREATE TABLE IF NOT EXISTS branch_acceptance_tests (
         ON UPDATE CASCADE ON DELETE CASCADE,
     CONSTRAINT fk_bat_acceptance_test
         FOREIGN KEY (acceptance_test_fk) REFERENCES acceptance_tests (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+-- ============================================================================
+-- Agents registry (req #2997, migration 067)
+-- Agent .md files are thin charter stubs; their durable knowledge lives here
+-- and is read at boot via darwin://agents/<Agent Name>. The DB is canon —
+-- scripts/swarm/reconcile-agent-stubs.sh mirrors overview/ai_model/effort into
+-- stub frontmatter at session boundaries.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS agents (
+    id          INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    name        VARCHAR(128) NOT NULL,                    -- human-readable, e.g. "AWS Architect"; MCP lookup key
+    file_name   VARCHAR(128) NOT NULL,                    -- stub basename, e.g. "aws-architect.md"
+    overview    TEXT         NULL,                        -- short delegation trigger; mirrored to stub `description`
+    ai_model    VARCHAR(32)  NOT NULL DEFAULT 'opus[1m]', -- resolved model id, NOT the haiku|sonnet|opus|fable family enum
+    effort      VARCHAR(16)  NOT NULL DEFAULT 'high',     -- low|medium|high|xhigh|ultracode
+    location    VARCHAR(512) NULL,                        -- repo-relative stub path
+    closed      TINYINT(1)   NOT NULL DEFAULT 0,
+    sort_order  SMALLINT     NULL,
+    creator_fk  VARCHAR(64)  NOT NULL,
+    create_ts   TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts   TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_agents_name (name),
+    UNIQUE KEY uq_agents_file_name (file_name),
+    CONSTRAINT fk_agents_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS instructions (
+    id          INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    name        VARCHAR(256) NOT NULL,   -- UNIQUE; idempotent-seed key
+    content     TEXT         NOT NULL,   -- binding text; one row can bind many agents
+    closed      TINYINT(1)   NOT NULL DEFAULT 0,
+    sort_order  SMALLINT     NULL,
+    creator_fk  VARCHAR(64)  NOT NULL,
+    create_ts   TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts   TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_instructions_name (name),
+    CONSTRAINT fk_instructions_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS agent_instructions (
+    agent_fk        INT      NOT NULL,
+    instruction_fk  INT      NOT NULL,
+    sort_order      SMALLINT NULL,       -- boot load order
+    PRIMARY KEY (agent_fk, instruction_fk),
+    CONSTRAINT fk_ai_agent
+        FOREIGN KEY (agent_fk) REFERENCES agents (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_ai_instruction
+        FOREIGN KEY (instruction_fk) REFERENCES instructions (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS architecture_documents (
+    id          INT           NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    name        VARCHAR(256)  NOT NULL,  -- UNIQUE; idempotent-seed key
+    doc_type    VARCHAR(16)   NOT NULL DEFAULT 'markdown',  -- markdown|html|text
+    location    VARCHAR(512)  NULL,      -- repo-relative path the agent Reads
+    url         VARCHAR(1024) NULL,      -- clickable link (GitHub blob / site path)
+    closed      TINYINT(1)    NOT NULL DEFAULT 0,
+    sort_order  SMALLINT      NULL,
+    creator_fk  VARCHAR(64)   NOT NULL,
+    create_ts   TIMESTAMP     NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts   TIMESTAMP     NULL ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_architecture_documents_name (name),
+    CONSTRAINT fk_architecture_documents_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+-- owned_document_fk: a VIRTUAL generated column that equals document_fk only on
+-- an 'owned' row, NULL otherwise. The UNIQUE key over it enforces AT MOST ONE
+-- 'owned' agent per document (MySQL has no partial index; NULLs are distinct in
+-- a UNIQUE key, so non-owned links coexist freely).
+CREATE TABLE IF NOT EXISTS agent_documents (
+    agent_fk           INT          NOT NULL,
+    document_fk        INT          NOT NULL,
+    relationship       VARCHAR(24)  NOT NULL DEFAULT 'referenced',  -- owned|groomed|referenced|design_language|guardian
+    notes              VARCHAR(512) NULL,
+    sort_order         SMALLINT     NULL,
+    owned_document_fk  INT          AS (IF(relationship = 'owned', document_fk, NULL)) VIRTUAL,
+    PRIMARY KEY (agent_fk, document_fk),
+    UNIQUE KEY uq_agent_documents_owner (owned_document_fk),
+    CONSTRAINT fk_ad_agent
+        FOREIGN KEY (agent_fk) REFERENCES agents (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_ad_document
+        FOREIGN KEY (document_fk) REFERENCES architecture_documents (id)
         ON UPDATE CASCADE ON DELETE CASCADE
 );
 

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -1,13 +1,15 @@
 -- Recreate darwin_dev test/dev tables from scratch
 -- Uses production-identical table names (same DDL as schema.sql)
 -- Idempotent: safe to run repeatedly to reset darwin_dev to canonical state
--- All 34 tables in FK-dependency order
+-- All 44 tables in FK-dependency order
 
 USE darwin_dev;
 
 SET FOREIGN_KEY_CHECKS = 0;
 DROP TABLE IF EXISTS customer_releases, builds, branches, build_projects,
     customers,
+    agent_documents, agent_instructions,
+    architecture_documents, instructions, agents,
     test_results, test_runs, test_plan_cases, test_plans,
     feature_test_cases, test_cases, features,
     user_integrations,
@@ -813,3 +815,87 @@ CREATE TABLE branch_acceptance_tests (
 );
 
 SET FOREIGN_KEY_CHECKS = 1;
+
+-- Agents registry (req #2997, migration 067). Production tables, mirrored here
+-- so a rebuilt darwin_dev matches schema.sql column-for-column.
+CREATE TABLE agents (
+    id          INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    name        VARCHAR(128) NOT NULL,
+    file_name   VARCHAR(128) NOT NULL,
+    overview    TEXT         NULL,
+    ai_model    VARCHAR(32)  NOT NULL DEFAULT 'opus[1m]',
+    effort      VARCHAR(16)  NOT NULL DEFAULT 'high',
+    location    VARCHAR(512) NULL,
+    closed      TINYINT(1)   NOT NULL DEFAULT 0,
+    sort_order  SMALLINT     NULL,
+    creator_fk  VARCHAR(64)  NOT NULL,
+    create_ts   TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts   TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_agents_name (name),
+    UNIQUE KEY uq_agents_file_name (file_name),
+    CONSTRAINT fk_agents_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE instructions (
+    id          INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    name        VARCHAR(256) NOT NULL,
+    content     TEXT         NOT NULL,
+    closed      TINYINT(1)   NOT NULL DEFAULT 0,
+    sort_order  SMALLINT     NULL,
+    creator_fk  VARCHAR(64)  NOT NULL,
+    create_ts   TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts   TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_instructions_name (name),
+    CONSTRAINT fk_instructions_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE agent_instructions (
+    agent_fk        INT      NOT NULL,
+    instruction_fk  INT      NOT NULL,
+    sort_order      SMALLINT NULL,
+    PRIMARY KEY (agent_fk, instruction_fk),
+    CONSTRAINT fk_ai_agent
+        FOREIGN KEY (agent_fk) REFERENCES agents (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_ai_instruction
+        FOREIGN KEY (instruction_fk) REFERENCES instructions (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE architecture_documents (
+    id          INT           NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    name        VARCHAR(256)  NOT NULL,
+    doc_type    VARCHAR(16)   NOT NULL DEFAULT 'markdown',
+    location    VARCHAR(512)  NULL,
+    url         VARCHAR(1024) NULL,
+    closed      TINYINT(1)    NOT NULL DEFAULT 0,
+    sort_order  SMALLINT      NULL,
+    creator_fk  VARCHAR(64)   NOT NULL,
+    create_ts   TIMESTAMP     NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts   TIMESTAMP     NULL ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_architecture_documents_name (name),
+    CONSTRAINT fk_architecture_documents_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE TABLE agent_documents (
+    agent_fk           INT          NOT NULL,
+    document_fk        INT          NOT NULL,
+    relationship       VARCHAR(24)  NOT NULL DEFAULT 'referenced',
+    notes              VARCHAR(512) NULL,
+    sort_order         SMALLINT     NULL,
+    owned_document_fk  INT          AS (IF(relationship = 'owned', document_fk, NULL)) VIRTUAL,
+    PRIMARY KEY (agent_fk, document_fk),
+    UNIQUE KEY uq_agent_documents_owner (owned_document_fk),
+    CONSTRAINT fk_ad_agent
+        FOREIGN KEY (agent_fk) REFERENCES agents (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_ad_document
+        FOREIGN KEY (document_fk) REFERENCES architecture_documents (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,13 @@ def seed_test_profile(db_connection, test_creator_fk):
         # AFTER those three (all cleared just above) to satisfy the constraint.
         cur.execute("DELETE FROM swarm_starts WHERE creator_fk = %s", (test_creator_fk,))
         cur.execute("DELETE FROM machines WHERE creator_fk = %s", (test_creator_fk,))
+        # Req #2997: agents registry. Junctions CASCADE from both parents, so
+        # deleting agents + instructions + architecture_documents is sufficient;
+        # agents is deleted first so its links go before the shared catalogs.
+        cur.execute("DELETE FROM agents WHERE creator_fk = %s", (test_creator_fk,))
+        cur.execute("DELETE FROM instructions WHERE creator_fk = %s", (test_creator_fk,))
+        cur.execute("DELETE FROM architecture_documents WHERE creator_fk = %s",
+                    (test_creator_fk,))
         # Req #2380: features/test_cases/test_plans RESTRICT on categories,
         # so delete these BEFORE categories. test_results and test_runs also
         # clean up explicitly to handle tests that commit mid-run.

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1219,3 +1219,237 @@ def test_machines_creator_fk_cascade(db_connection):
         cur.execute("SELECT COUNT(*) AS c FROM machines WHERE creator_fk = %s", (cfk,))
         assert cur.fetchone()['c'] == 0
     db_connection.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Req #2997 — agents registry constraints
+#
+# The rule this requirement exists to enforce: AT MOST ONE 'owned' agent per
+# architecture document. It is a DB constraint, not a convention — these tests
+# are what prove that.
+# ---------------------------------------------------------------------------
+
+def _insert_agent(cur, creator_fk, name=None):
+    """Insert an agents row and return its id."""
+    name = name or f"Test Agent {uuid.uuid4().hex[:8]}"
+    cur.execute(
+        "INSERT INTO agents (name, file_name, creator_fk) VALUES (%s, %s, %s)",
+        (name, f"{name.lower().replace(' ', '-')}.md", creator_fk),
+    )
+    return cur.lastrowid
+
+
+def _insert_document(cur, creator_fk, name=None):
+    """Insert an architecture_documents row and return its id."""
+    name = name or f"Test Doc {uuid.uuid4().hex[:8]}"
+    cur.execute(
+        "INSERT INTO architecture_documents (name, doc_type, location, creator_fk) "
+        "VALUES (%s, 'markdown', %s, %s)",
+        (name, f"memory/{uuid.uuid4().hex[:8]}.md", creator_fk),
+    )
+    return cur.lastrowid
+
+
+def test_agents_name_unique(db_connection, test_creator_fk):
+    """uq_agents_name: `name` is the MCP lookup key — a duplicate would make
+    darwin://agents/<name> ambiguous, so the DB forbids it."""
+    with db_connection.cursor() as cur:
+        _insert_agent(cur, test_creator_fk, 'Duplicate Name Architect')
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO agents (name, file_name, creator_fk) VALUES (%s, %s, %s)",
+                ('Duplicate Name Architect', 'other-file.md', test_creator_fk),
+            )
+    db_connection.rollback()
+
+
+def test_agents_file_name_unique(db_connection, test_creator_fk):
+    """uq_agents_file_name: file_name is the fallback lookup key and must also
+    resolve unambiguously."""
+    with db_connection.cursor() as cur:
+        _insert_agent(cur, test_creator_fk, 'File Name Architect')
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO agents (name, file_name, creator_fk) VALUES (%s, %s, %s)",
+                ('Some Other Architect', 'file-name-architect.md', test_creator_fk),
+            )
+    db_connection.rollback()
+
+
+def test_agents_model_effort_defaults(db_connection, test_creator_fk):
+    """The standard header pin: an agent created without ai_model/effort lands on
+    opus[1m] / high (req #2997), replacing the stale per-agent claude-opus-4-6
+    pins the ownership survey found."""
+    with db_connection.cursor() as cur:
+        aid = _insert_agent(cur, test_creator_fk)
+        cur.execute("SELECT ai_model, effort, closed FROM agents WHERE id = %s", (aid,))
+        row = cur.fetchone()
+        assert row['ai_model'] == 'opus[1m]'
+        assert row['effort'] == 'high'
+        assert row['closed'] == 0
+    db_connection.rollback()
+
+
+def test_agent_documents_single_owner_on_insert(db_connection, test_creator_fk):
+    """uq_agent_documents_owner: a SECOND agent claiming 'owned' on the same
+    document is rejected. This is the core ownership rule of req #2997."""
+    with db_connection.cursor() as cur:
+        a1 = _insert_agent(cur, test_creator_fk)
+        a2 = _insert_agent(cur, test_creator_fk)
+        doc = _insert_document(cur, test_creator_fk)
+
+        cur.execute(
+            "INSERT INTO agent_documents (agent_fk, document_fk, relationship) "
+            "VALUES (%s, %s, 'owned')", (a1, doc))
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO agent_documents (agent_fk, document_fk, relationship) "
+                "VALUES (%s, %s, 'owned')", (a2, doc))
+    db_connection.rollback()
+
+
+def test_agent_documents_single_owner_on_update(db_connection, test_creator_fk):
+    """The ownership rule must not be bypassable by linking as 'groomed' and then
+    UPDATEing to 'owned' — the generated column is recomputed on update, so the
+    UNIQUE key catches this path too."""
+    with db_connection.cursor() as cur:
+        a1 = _insert_agent(cur, test_creator_fk)
+        a2 = _insert_agent(cur, test_creator_fk)
+        doc = _insert_document(cur, test_creator_fk)
+
+        cur.execute(
+            "INSERT INTO agent_documents (agent_fk, document_fk, relationship) "
+            "VALUES (%s, %s, 'owned')", (a1, doc))
+        cur.execute(
+            "INSERT INTO agent_documents (agent_fk, document_fk, relationship) "
+            "VALUES (%s, %s, 'groomed')", (a2, doc))
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "UPDATE agent_documents SET relationship = 'owned' "
+                "WHERE agent_fk = %s AND document_fk = %s", (a2, doc))
+    db_connection.rollback()
+
+
+def test_agent_documents_multiple_non_owned_allowed(db_connection, test_creator_fk):
+    """NULLs are distinct in a MySQL UNIQUE key, so any number of non-'owned'
+    links may coexist on one document. Many architects may reference a document;
+    only one may own it."""
+    with db_connection.cursor() as cur:
+        doc = _insert_document(cur, test_creator_fk)
+        for rel in ('groomed', 'referenced', 'design_language', 'guardian'):
+            cur.execute(
+                "INSERT INTO agent_documents (agent_fk, document_fk, relationship) "
+                "VALUES (%s, %s, %s)", (_insert_agent(cur, test_creator_fk), doc, rel))
+        cur.execute("SELECT COUNT(*) AS c FROM agent_documents WHERE document_fk = %s",
+                    (doc,))
+        assert cur.fetchone()['c'] == 4
+    db_connection.rollback()
+
+
+def test_agent_documents_ownership_transfer(db_connection, test_creator_fk):
+    """Ownership is transferable: once the incumbent's link is removed, another
+    agent may claim 'owned'. The constraint blocks CONCURRENT owners, not
+    reassignment."""
+    with db_connection.cursor() as cur:
+        a1 = _insert_agent(cur, test_creator_fk)
+        a2 = _insert_agent(cur, test_creator_fk)
+        doc = _insert_document(cur, test_creator_fk)
+
+        cur.execute(
+            "INSERT INTO agent_documents (agent_fk, document_fk, relationship) "
+            "VALUES (%s, %s, 'owned')", (a1, doc))
+        cur.execute(
+            "DELETE FROM agent_documents WHERE agent_fk = %s AND document_fk = %s",
+            (a1, doc))
+        cur.execute(
+            "INSERT INTO agent_documents (agent_fk, document_fk, relationship) "
+            "VALUES (%s, %s, 'owned')", (a2, doc))
+        cur.execute(
+            "SELECT agent_fk FROM agent_documents "
+            "WHERE document_fk = %s AND relationship = 'owned'", (doc,))
+        assert cur.fetchone()['agent_fk'] == a2
+    db_connection.rollback()
+
+
+def test_agent_documents_cascade_from_agent(db_connection, test_creator_fk):
+    """Deleting an agent cascades its links away; the DOCUMENT row survives
+    (documents are a shared catalog, not agent-private data)."""
+    with db_connection.cursor() as cur:
+        aid = _insert_agent(cur, test_creator_fk)
+        doc = _insert_document(cur, test_creator_fk)
+        cur.execute(
+            "INSERT INTO agent_documents (agent_fk, document_fk, relationship) "
+            "VALUES (%s, %s, 'owned')", (aid, doc))
+
+        cur.execute("DELETE FROM agents WHERE id = %s", (aid,))
+        cur.execute("SELECT COUNT(*) AS c FROM agent_documents WHERE agent_fk = %s",
+                    (aid,))
+        assert cur.fetchone()['c'] == 0
+        cur.execute("SELECT COUNT(*) AS c FROM architecture_documents WHERE id = %s",
+                    (doc,))
+        assert cur.fetchone()['c'] == 1
+    db_connection.rollback()
+
+
+def test_agent_instructions_cascade_and_sharing(db_connection, test_creator_fk):
+    """One instruction row may bind MANY agents — this is how the common grooming
+    duty reaches every architect. Deleting one agent must not disturb the others'
+    bindings."""
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO instructions (name, content, creator_fk) VALUES (%s, %s, %s)",
+            (f"shared-{uuid.uuid4().hex[:8]}", 'binding text', test_creator_fk))
+        instr = cur.lastrowid
+        a1 = _insert_agent(cur, test_creator_fk)
+        a2 = _insert_agent(cur, test_creator_fk)
+        for aid in (a1, a2):
+            cur.execute(
+                "INSERT INTO agent_instructions (agent_fk, instruction_fk, sort_order) "
+                "VALUES (%s, %s, 1)", (aid, instr))
+
+        cur.execute("DELETE FROM agents WHERE id = %s", (a1,))
+        cur.execute("SELECT COUNT(*) AS c FROM agent_instructions WHERE instruction_fk = %s",
+                    (instr,))
+        assert cur.fetchone()['c'] == 1, "surviving agent's binding must remain"
+        cur.execute("SELECT COUNT(*) AS c FROM instructions WHERE id = %s", (instr,))
+        assert cur.fetchone()['c'] == 1, "shared instruction row must survive"
+    db_connection.rollback()
+
+
+def test_instructions_name_unique(db_connection, test_creator_fk):
+    """uq_instructions_name: `name` is the idempotent-seed key, so the seeder can
+    upsert rather than duplicate on every run."""
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO instructions (name, content, creator_fk) VALUES (%s, %s, %s)",
+            ('dup-instruction-name', 'a', test_creator_fk))
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO instructions (name, content, creator_fk) VALUES (%s, %s, %s)",
+                ('dup-instruction-name', 'b', test_creator_fk))
+    db_connection.rollback()
+
+
+def test_architecture_documents_name_unique(db_connection, test_creator_fk):
+    """uq_architecture_documents_name: the document registry's upsert key."""
+    with db_connection.cursor() as cur:
+        _insert_document(cur, test_creator_fk, 'Duplicate Doc Name')
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO architecture_documents (name, doc_type, creator_fk) "
+                "VALUES (%s, 'markdown', %s)", ('Duplicate Doc Name', test_creator_fk))
+    db_connection.rollback()
+
+
+def test_agents_creator_fk_cascade(db_connection):
+    """agents.creator_fk is ON DELETE CASCADE — removing the owning profile takes
+    its agents with it."""
+    cfk = f"schema-test-agent-{uuid.uuid4().hex[:8]}"
+    with db_connection.cursor() as cur:
+        cur.execute("INSERT INTO profiles (id, name, email) VALUES (%s, %s, %s)",
+                    (cfk, 'Agent Cascade', 'ac@test.com'))
+        _insert_agent(cur, cfk)
+        cur.execute("DELETE FROM profiles WHERE id = %s", (cfk,))
+        cur.execute("SELECT COUNT(*) AS c FROM agents WHERE creator_fk = %s", (cfk,))
+        assert cur.fetchone()['c'] == 0
+    db_connection.rollback()

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1681,6 +1681,9 @@ def test_table_count(db_connection):
         'swarm_completes', 'swarm_complete_sessions',
         # Req #2943 — machine registry
         'machines',
+        # Req #2997 — agents registry (ownership of architecture documents)
+        'agents', 'instructions', 'agent_instructions',
+        'architecture_documents', 'agent_documents',
     }
     assert expected_tables == tables, \
         f"Unexpected tables: {tables - expected_tables}, missing: {expected_tables - tables}"
@@ -1868,3 +1871,157 @@ def test_customer_releases_columns(db_connection):
     assert cols['release_notes']['Null'] == 'YES'
     assert cols['creator_fk']['Null'] == 'NO'
     assert 'closed' not in cols
+
+
+# ============================================================================
+# Req #2997 — Agents registry column tests
+#
+# Agent .md files are thin charter stubs; their durable knowledge lives in these
+# five tables and is read at boot via darwin://agents/<Agent Name>.
+# ============================================================================
+
+def test_agents_columns(db_connection):
+    """agents: narrow and FIXED by design (req #2997) — the user does not
+    anticipate many new agent-level fields, so there is no JSON column, no
+    key-value attribute table, and no spare fields. All growth pressure lands in
+    instruction/document ROWS instead.
+
+    No category_fk (infrastructure entity, like machines). name AND file_name are
+    both UNIQUE so either resolves an agent unambiguously."""
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'agents')
+    expected = {'id', 'name', 'file_name', 'overview', 'ai_model', 'effort',
+                'location', 'closed', 'sort_order', 'creator_fk',
+                'create_ts', 'update_ts'}
+    assert set(cols.keys()) == expected
+    assert 'category_fk' not in cols
+
+    assert cols['id']['Type'] == 'int'
+    assert cols['id']['Key'] == 'PRI'
+    assert cols['id']['Extra'] == 'auto_increment'
+
+    # The MCP lookup key — matches the charter stub's H1.
+    assert cols['name']['Type'] == 'varchar(128)'
+    assert cols['name']['Null'] == 'NO'
+    assert cols['name']['Key'] == 'UNI'
+
+    assert cols['file_name']['Type'] == 'varchar(128)'
+    assert cols['file_name']['Null'] == 'NO'
+    assert cols['file_name']['Key'] == 'UNI'
+
+    # Short delegation trigger, mirrored into stub frontmatter `description`.
+    assert cols['overview']['Type'] == 'text'
+    assert cols['overview']['Null'] == 'YES'
+
+    # ai_model is VARCHAR, not an enum: it holds a RESOLVED model id
+    # ('opus[1m]'), which changes with every model release. effort uses Darwin's
+    # stable low|medium|high|xhigh|ultracode vocabulary.
+    assert cols['ai_model']['Type'] == 'varchar(32)'
+    assert cols['ai_model']['Null'] == 'NO'
+    assert cols['ai_model']['Default'] == 'opus[1m]'
+    assert cols['effort']['Type'] == 'varchar(16)'
+    assert cols['effort']['Null'] == 'NO'
+    assert cols['effort']['Default'] == 'high'
+
+    assert cols['location']['Type'] == 'varchar(512)'
+    assert cols['location']['Null'] == 'YES'
+
+    assert cols['closed']['Type'] == 'tinyint(1)'
+    assert cols['closed']['Null'] == 'NO'
+    assert cols['closed']['Default'] == '0'
+    assert cols['sort_order']['Type'] == 'smallint'
+    assert cols['creator_fk']['Type'] == 'varchar(64)'
+    assert cols['creator_fk']['Null'] == 'NO'
+    assert cols['creator_fk']['Key'] == 'MUL'
+
+
+def test_instructions_columns(db_connection):
+    """instructions: reusable named blocks of BINDING text (req #2997). Its own
+    data type precisely so ONE row can bind many agents — the common grooming
+    duty is a single row referenced by every architect."""
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'instructions')
+    expected = {'id', 'name', 'content', 'closed', 'sort_order', 'creator_fk',
+                'create_ts', 'update_ts'}
+    assert set(cols.keys()) == expected
+
+    assert cols['id']['Key'] == 'PRI'
+    # name is the idempotent-seed key.
+    assert cols['name']['Type'] == 'varchar(256)'
+    assert cols['name']['Null'] == 'NO'
+    assert cols['name']['Key'] == 'UNI'
+    assert cols['content']['Type'] == 'text'
+    assert cols['content']['Null'] == 'NO'
+    assert cols['closed']['Default'] == '0'
+    assert cols['creator_fk']['Null'] == 'NO'
+
+
+def test_agent_instructions_columns(db_connection):
+    """agent_instructions: plain junction (req #2997). Composite PK, sort_order
+    drives boot load order."""
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'agent_instructions')
+    assert set(cols.keys()) == {'agent_fk', 'instruction_fk', 'sort_order'}
+    assert cols['agent_fk']['Null'] == 'NO'
+    assert cols['agent_fk']['Key'] == 'PRI'
+    assert cols['instruction_fk']['Null'] == 'NO'
+    assert cols['instruction_fk']['Key'] == 'PRI'
+    assert cols['sort_order']['Type'] == 'smallint'
+    assert cols['sort_order']['Null'] == 'YES'
+
+
+def test_architecture_documents_columns(db_connection):
+    """architecture_documents: THE ONE registry of documents (req #2997).
+    agent_documents is a junction of RELATIONSHIPS, not a second document list.
+
+    `location` is the repo-relative path an agent Reads at boot; `url` is the
+    clickable form for the Phase 2 UI. Both nullable — a document may be
+    registered before either is settled."""
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'architecture_documents')
+    expected = {'id', 'name', 'doc_type', 'location', 'url', 'closed',
+                'sort_order', 'creator_fk', 'create_ts', 'update_ts'}
+    assert set(cols.keys()) == expected
+
+    assert cols['id']['Key'] == 'PRI'
+    assert cols['name']['Type'] == 'varchar(256)'
+    assert cols['name']['Null'] == 'NO'
+    assert cols['name']['Key'] == 'UNI'
+    assert cols['doc_type']['Type'] == 'varchar(16)'
+    assert cols['doc_type']['Null'] == 'NO'
+    assert cols['doc_type']['Default'] == 'markdown'
+    assert cols['location']['Type'] == 'varchar(512)'
+    assert cols['location']['Null'] == 'YES'
+    assert cols['url']['Type'] == 'varchar(1024)'
+    assert cols['url']['Null'] == 'YES'
+    assert cols['closed']['Default'] == '0'
+
+
+def test_agent_documents_columns(db_connection):
+    """agent_documents: the many-to-many relationship rows (req #2997).
+
+    owned_document_fk is the mechanism behind 'at most one owned agent per
+    document': a VIRTUAL generated column equal to document_fk only on an 'owned'
+    row (NULL otherwise), carrying a UNIQUE key. MySQL has no partial index, and
+    NULLs are distinct in a UNIQUE key — so unlimited non-owned links coexist
+    while a second 'owned' claim raises IntegrityError."""
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'agent_documents')
+    expected = {'agent_fk', 'document_fk', 'relationship', 'notes',
+                'sort_order', 'owned_document_fk'}
+    assert set(cols.keys()) == expected
+
+    assert cols['agent_fk']['Null'] == 'NO'
+    assert cols['agent_fk']['Key'] == 'PRI'
+    assert cols['document_fk']['Null'] == 'NO'
+    assert cols['document_fk']['Key'] == 'PRI'
+    assert cols['relationship']['Type'] == 'varchar(24)'
+    assert cols['relationship']['Null'] == 'NO'
+    assert cols['relationship']['Default'] == 'referenced'
+    assert cols['notes']['Type'] == 'varchar(512)'
+    assert cols['notes']['Null'] == 'YES'
+
+    # The ownership-uniqueness machinery: VIRTUAL (computed on read, no row
+    # storage) and UNIQUE.
+    assert 'VIRTUAL GENERATED' in cols['owned_document_fk']['Extra'].upper()
+    assert cols['owned_document_fk']['Key'] == 'UNI'

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -100,6 +100,14 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         # stops the regex at `machines` only when followed by _ibfk or a word
         # boundary, not the `_fk`/`_port`/`_hostname` suffixes).
         'machines',
+        # Req #2997 — agents registry (migration 067). Longest-first ordering:
+        # agent_instructions and agent_documents must precede `agents` and
+        # `instructions`, or the shorter names would match inside them first.
+        'agent_instructions',
+        'agent_documents',
+        'architecture_documents',
+        'instructions',
+        'agents',
         'requirements',
         'priorities',            # pre-038 name (for RENAME TABLE in migration 038)
         'categories',
@@ -174,6 +182,13 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         'fk_swarm_sessions_machine', 'fk_swarm_starts_machine',
         'fk_dev_servers_machine',
         'uq_machines_hostname', 'uq_machine_port',
+        # Migration 067 — agents registry (req #2997)
+        'fk_agents_creator', 'fk_instructions_creator',
+        'fk_architecture_documents_creator',
+        'fk_ai_agent', 'fk_ai_instruction',
+        'fk_ad_agent', 'fk_ad_document',
+        'uq_agents_name', 'uq_agents_file_name', 'uq_instructions_name',
+        'uq_architecture_documents_name', 'uq_agent_documents_owner',
     ]
     for cname in named_constraints:
         sql = sql.replace(cname, f'{table_prefix}_{cname}')
@@ -264,6 +279,10 @@ ALL_TABLE_SUFFIXES = [
     # Req #2943 — machines (dropped with FK_CHECKS=0, so order is not critical;
     # placed among the leaves for readability).
     'machines',
+    # Req #2997 — agents registry. FK-safe order: junctions first, then the
+    # catalogs they reference.
+    'agent_documents', 'agent_instructions',
+    'architecture_documents', 'instructions', 'agents',
     # Req #2606 — Build Visualizer (migrations 050-054). FK-safe order: leaves
     # first — customer_releases → builds → branches → build_projects (the
     # build_projects<->branches circular FK is handled by FK_CHECKS=0 in cleanup).
@@ -444,6 +463,9 @@ def test_migration_sequence_applies(db_connection, migration_test_prefix):
             'swarm_completes', 'swarm_complete_sessions',
             # Req #2943 — machine registry (migration 064)
             'machines',
+            # Req #2997 — agents registry (migration 067)
+            'agents', 'instructions', 'agent_instructions',
+            'architecture_documents', 'agent_documents',
         ]
     }
     assert tables == expected_tables, \


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-07-19T12:40:22Z
- chore: init swarm session feature/2997-architect-architecture-document-1

## Files changed
```
 migrations/067_add_agents_registry.sql | 188 ++++++++++++++++++++++++++
 schema.sql                             |  96 +++++++++++++-
 scripts/recreate_darwin_dev.sql        |  88 ++++++++++++-
 tests/conftest.py                      |   7 +
 tests/test_constraints.py              | 234 +++++++++++++++++++++++++++++++++
 tests/test_data_types.py               | 157 ++++++++++++++++++++++
 tests/test_migrations.py               |  22 ++++
 7 files changed, 790 insertions(+), 2 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Related PRs: BillWilliams79/DarwinAI-Config#573 (MCP surface, charter stub, reconcile script, seed)