### PR TITLE
Persist agent-context telemetry runs + render the actual-token view (multi-run, variable agent count)

### DIFF
--- a/migrations/069_add_agent_telemetry.sql
+++ b/migrations/069_add_agent_telemetry.sql
@@ -1,0 +1,94 @@
+-- 069_add_agent_telemetry.sql
+--
+-- Req #3031: Persist agent-context telemetry runs + render the actual-token view.
+--
+-- PROBLEM. Req #3009/#3025 produced a one-off actual-token characterization of the
+-- agents pattern (write-up: memory/agent-context-telemetry.md; visual spec artifact
+-- 660a8b6b-b215-4b7a-b5a4-91c31e82460d). It was a snapshot in a markdown table — not
+-- stored, not repeatable, not viewable. We want to WATCH context cost move as the
+-- registry, the skill set, the MCP surface, and the Claude Code harness change, so
+-- each capture must persist as data and the published view must render from it.
+--
+-- SHAPE. A run header + N per-agent rows — the parent/child shape Darwin already has
+-- (test_runs -> test_results). The run is the container: deleting it CASCADEs its
+-- rows. Every capture is the SAME schema with a VARIABLE number of agent rows —
+-- nothing here assumes a fixed roster, so a future run with more/fewer agents (or a
+-- reviewer/primary alongside the architects) stores and renders as-is.
+--
+-- All token columns are ACTUAL tokens (real tokenizer via transcript usage deltas),
+-- never chars/4 estimates. They are nullable where a phase does not apply: PrimaryAI
+-- is a top-level session with no boot/autoload phase; the Code Reviewer bundles its
+-- charter stub into CC base.
+--
+-- PRODUCTION tables (darwin + darwin_dev). The report route renders in the deployed
+-- app, so the rows must live in production `darwin`; darwin_dev carries the same
+-- schema for dev review. Same call as the agents registry (migration 067) and
+-- `machines` (migration 064): first-class production concern, NOT darwin_dev-only.
+--
+-- Log/infrastructure tables describing the tooling itself, so — same call as
+-- `machines`/`swarm_starts` — NO `title`, NO status enum, NO `closed` flag, and NO
+-- `category_fk`. `label` is the human name; `captured_at` is the event timestamp.
+
+-- ---------------------------------------------------------------------------
+-- agent_telemetry_runs — one row per capture (the run header).
+--
+-- `agent_count` is the value the capture recorded at write time (denormalized for a
+-- cheap list view); the live COUNT of child rows is the display source of truth, the
+-- same relationship swarm_starts.session_count has to its junction.
+-- ---------------------------------------------------------------------------
+CREATE TABLE agent_telemetry_runs (
+    id               INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    captured_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,  -- when this capture ran
+    label            VARCHAR(256) NOT NULL,                            -- human name, e.g. "2026-07-22 baseline"
+    agent_count      INT          NOT NULL DEFAULT 0,                  -- rows recorded at capture time (live COUNT is canon)
+    harness_version  VARCHAR(64)  NULL,                                -- Claude Code harness version at capture
+    source_note      TEXT         NULL,                                -- freeform provenance / method note
+    creator_fk       VARCHAR(64)  NOT NULL,
+    create_ts        TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts        TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_agent_telemetry_runs_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE INDEX ix_agent_telemetry_runs_captured_at ON agent_telemetry_runs (captured_at);
+
+-- ---------------------------------------------------------------------------
+-- agent_telemetry_rows — one row per agent measured in a run (variable N).
+--
+-- run_fk CASCADEs: the run is the container, deleting it takes its rows. Token
+-- columns are ACTUAL tokens, nullable where the phase is n/a. `sort_order` fixes the
+-- render order within a run (architects first, PrimaryAI last, matching the published
+-- artifact) independent of insertion order. `footnote` holds the per-row asterisk/
+-- dagger text the artifact carries (Code Reviewer's pinned-tools note, PrimaryAI's
+-- top-level-session note).
+-- ---------------------------------------------------------------------------
+CREATE TABLE agent_telemetry_rows (
+    id                          INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    run_fk                      INT          NOT NULL,
+    agent_name                  VARCHAR(128) NOT NULL,                        -- display label, e.g. "AWS", "Darwin PrimaryAI"
+    role                        VARCHAR(16)  NOT NULL DEFAULT 'architect',    -- architect|reviewer|primary
+    session_kind                VARCHAR(16)  NOT NULL DEFAULT 'subagent',     -- subagent|top_level
+    boot_time_ms                INT          NULL,                            -- sequential boot latency; NULL for PrimaryAI
+    cc_base_tokens              INT          NULL,                            -- Claude Code base (harness + tool schemas + listings)
+    claude_md_tokens            INT          NULL,                            -- CLAUDE.md
+    charter_stub_tokens         INT          NULL,                            -- charter stub; NULL when bundled/n/a
+    boot_payload_tokens         INT          NULL,                            -- context added by the boot call; NULL for PrimaryAI
+    autoload_tokens             INT          NULL,                            -- context added by reading autoload docs; NULL for PrimaryAI
+    docs_loaded                 INT          NULL,                            -- autoload documents actually loaded
+    docs_expected               INT          NULL,                            -- autoload documents expected
+    start_work_context_tokens   INT          NULL,                            -- total ready-to-work context (the /context figure)
+    footnote                    VARCHAR(512) NULL,                            -- per-row caveat text (the artifact's *, dagger)
+    sort_order                  SMALLINT     NULL,                            -- render order within the run
+    creator_fk                  VARCHAR(64)  NOT NULL,
+    create_ts                   TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts                   TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_agent_telemetry_rows_run
+        FOREIGN KEY (run_fk) REFERENCES agent_telemetry_runs (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_agent_telemetry_rows_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE INDEX ix_agent_telemetry_rows_run_fk ON agent_telemetry_rows (run_fk);

--- a/schema.sql
+++ b/schema.sql
@@ -957,3 +957,58 @@ CREATE TABLE IF NOT EXISTS agent_documents (
 );
 
 SET FOREIGN_KEY_CHECKS = 1;
+
+-- ---------------------------------------------------------------------------
+-- Agent Context Telemetry (req #3031, migration 069) — persisted actual-token
+-- captures of the agents pattern. Run header + N per-agent rows (parent/child,
+-- run is the container -> CASCADE). Token columns are ACTUAL tokens, nullable
+-- where a phase is n/a (PrimaryAI has no boot/autoload; Code Reviewer bundles
+-- its stub into CC base). Log/infra tables: no title/status/closed/category_fk.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS agent_telemetry_runs (
+    id               INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    captured_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    label            VARCHAR(256) NOT NULL,
+    agent_count      INT          NOT NULL DEFAULT 0,
+    harness_version  VARCHAR(64)  NULL,
+    source_note      TEXT         NULL,
+    creator_fk       VARCHAR(64)  NOT NULL,
+    create_ts        TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts        TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_agent_telemetry_runs_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE INDEX ix_agent_telemetry_runs_captured_at ON agent_telemetry_runs (captured_at);
+
+CREATE TABLE IF NOT EXISTS agent_telemetry_rows (
+    id                          INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    run_fk                      INT          NOT NULL,
+    agent_name                  VARCHAR(128) NOT NULL,
+    role                        VARCHAR(16)  NOT NULL DEFAULT 'architect',   -- architect|reviewer|primary
+    session_kind                VARCHAR(16)  NOT NULL DEFAULT 'subagent',    -- subagent|top_level
+    boot_time_ms                INT          NULL,
+    cc_base_tokens              INT          NULL,
+    claude_md_tokens            INT          NULL,
+    charter_stub_tokens         INT          NULL,
+    boot_payload_tokens         INT          NULL,
+    autoload_tokens             INT          NULL,
+    docs_loaded                 INT          NULL,
+    docs_expected               INT          NULL,
+    start_work_context_tokens   INT          NULL,
+    footnote                    VARCHAR(512) NULL,
+    sort_order                  SMALLINT     NULL,
+    creator_fk                  VARCHAR(64)  NOT NULL,
+    create_ts                   TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts                   TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_agent_telemetry_rows_run
+        FOREIGN KEY (run_fk) REFERENCES agent_telemetry_runs (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_agent_telemetry_rows_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE INDEX ix_agent_telemetry_rows_run_fk ON agent_telemetry_rows (run_fk);

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -1,12 +1,13 @@
 -- Recreate darwin_dev test/dev tables from scratch
 -- Uses production-identical table names (same DDL as schema.sql)
 -- Idempotent: safe to run repeatedly to reset darwin_dev to canonical state
--- All 44 tables in FK-dependency order
+-- All 46 tables in FK-dependency order
 
 USE darwin_dev;
 
 SET FOREIGN_KEY_CHECKS = 0;
-DROP TABLE IF EXISTS customer_releases, builds, branches, build_projects,
+DROP TABLE IF EXISTS agent_telemetry_rows, agent_telemetry_runs,
+    customer_releases, builds, branches, build_projects,
     customers,
     agent_documents, agent_instructions,
     architecture_documents, instructions, agents,
@@ -899,3 +900,52 @@ CREATE TABLE agent_documents (
         FOREIGN KEY (document_fk) REFERENCES architecture_documents (id)
         ON UPDATE CASCADE ON DELETE CASCADE
 );
+
+-- Agent Context Telemetry (req #3031, migration 069) — run header + N per-agent
+-- rows (parent/child, run is the container -> CASCADE). ACTUAL-token captures.
+CREATE TABLE agent_telemetry_runs (
+    id               INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    captured_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    label            VARCHAR(256) NOT NULL,
+    agent_count      INT          NOT NULL DEFAULT 0,
+    harness_version  VARCHAR(64)  NULL,
+    source_note      TEXT         NULL,
+    creator_fk       VARCHAR(64)  NOT NULL,
+    create_ts        TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts        TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_agent_telemetry_runs_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE INDEX ix_agent_telemetry_runs_captured_at ON agent_telemetry_runs (captured_at);
+
+CREATE TABLE agent_telemetry_rows (
+    id                          INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    run_fk                      INT          NOT NULL,
+    agent_name                  VARCHAR(128) NOT NULL,
+    role                        VARCHAR(16)  NOT NULL DEFAULT 'architect',
+    session_kind                VARCHAR(16)  NOT NULL DEFAULT 'subagent',
+    boot_time_ms                INT          NULL,
+    cc_base_tokens              INT          NULL,
+    claude_md_tokens            INT          NULL,
+    charter_stub_tokens         INT          NULL,
+    boot_payload_tokens         INT          NULL,
+    autoload_tokens             INT          NULL,
+    docs_loaded                 INT          NULL,
+    docs_expected               INT          NULL,
+    start_work_context_tokens   INT          NULL,
+    footnote                    VARCHAR(512) NULL,
+    sort_order                  SMALLINT     NULL,
+    creator_fk                  VARCHAR(64)  NOT NULL,
+    create_ts                   TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts                   TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_agent_telemetry_rows_run
+        FOREIGN KEY (run_fk) REFERENCES agent_telemetry_runs (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_agent_telemetry_rows_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE INDEX ix_agent_telemetry_rows_run_fk ON agent_telemetry_rows (run_fk);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,11 @@ def seed_test_profile(db_connection, test_creator_fk):
         # AFTER those three (all cleared just above) to satisfy the constraint.
         cur.execute("DELETE FROM swarm_starts WHERE creator_fk = %s", (test_creator_fk,))
         cur.execute("DELETE FROM machines WHERE creator_fk = %s", (test_creator_fk,))
+        # Req #3031: agent context telemetry. rows CASCADE from runs, so deleting
+        # runs is sufficient; rows deleted first defensively for tests that commit
+        # rows without a run parent.
+        cur.execute("DELETE FROM agent_telemetry_rows WHERE creator_fk = %s", (test_creator_fk,))
+        cur.execute("DELETE FROM agent_telemetry_runs WHERE creator_fk = %s", (test_creator_fk,))
         # Req #2997: agents registry. Junctions CASCADE from both parents, so
         # deleting agents + instructions + architecture_documents is sufficient;
         # agents is deleted first so its links go before the shared catalogs.

--- a/tests/test_cascades.py
+++ b/tests/test_cascades.py
@@ -1280,3 +1280,68 @@ def test_delete_profile_cascades_to_swarm_undos(db_connection):
             "swarm_undo row should be cascade-deleted when its creator profile is deleted"
 
     db_connection.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Req #3031 — agent context telemetry cascade behavior (migration 069)
+# ---------------------------------------------------------------------------
+
+def test_delete_run_cascades_to_rows(db_connection):
+    """DELETE agent_telemetry_run → its per-agent rows are deleted
+    (run is the container; run_fk ON DELETE CASCADE)."""
+    test_creator = 'cascade-test-telem-creator-1'
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO profiles (id, name, email) VALUES (%s, %s, %s)",
+            (test_creator, 'Cascade Test Profile', 'cascade-telem-1@test.com')
+        )
+        cur.execute(
+            "INSERT INTO agent_telemetry_runs (label, creator_fk) VALUES (%s, %s)",
+            ('cascade-test-run', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        run_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO agent_telemetry_rows (run_fk, agent_name, creator_fk) "
+            "VALUES (%s, %s, %s)",
+            (run_id, 'AWS', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        row_id = cur.fetchone()['id']
+
+        cur.execute("DELETE FROM agent_telemetry_runs WHERE id = %s", (run_id,))
+
+        cur.execute("SELECT id FROM agent_telemetry_rows WHERE id = %s", (row_id,))
+        assert cur.fetchone() is None, \
+            "telemetry row should be cascade-deleted when its run is deleted"
+    db_connection.rollback()
+
+
+def test_delete_profile_cascades_to_telemetry(db_connection):
+    """DELETE profile → its telemetry runs AND rows are deleted
+    (both carry creator_fk ON DELETE CASCADE)."""
+    test_creator = 'cascade-test-telem-creator-2'
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO profiles (id, name, email) VALUES (%s, %s, %s)",
+            (test_creator, 'Cascade Test Profile', 'cascade-telem-2@test.com')
+        )
+        cur.execute(
+            "INSERT INTO agent_telemetry_runs (label, creator_fk) VALUES (%s, %s)",
+            ('cascade-test-run-2', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        run_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO agent_telemetry_rows (run_fk, agent_name, creator_fk) "
+            "VALUES (%s, %s, %s)",
+            (run_id, 'Frontend', test_creator)
+        )
+
+        cur.execute("DELETE FROM profiles WHERE id = %s", (test_creator,))
+
+        cur.execute("SELECT id FROM agent_telemetry_runs WHERE creator_fk = %s", (test_creator,))
+        assert cur.fetchone() is None
+        cur.execute("SELECT id FROM agent_telemetry_rows WHERE creator_fk = %s", (test_creator,))
+        assert cur.fetchone() is None
+    db_connection.rollback()

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1686,6 +1686,8 @@ def test_table_count(db_connection):
         # Req #2997 — agents registry (ownership of architecture documents)
         'agents', 'instructions', 'agent_instructions',
         'architecture_documents', 'agent_documents',
+        # Req #3031 — agent context telemetry (run header + per-agent rows)
+        'agent_telemetry_runs', 'agent_telemetry_rows',
     }
     assert expected_tables == tables, \
         f"Unexpected tables: {tables - expected_tables}, missing: {expected_tables - tables}"
@@ -2027,3 +2029,60 @@ def test_agent_documents_columns(db_connection):
     # storage) and UNIQUE.
     assert 'VIRTUAL GENERATED' in cols['owned_document_fk']['Extra'].upper()
     assert cols['owned_document_fk']['Key'] == 'UNI'
+
+
+# ============================================================================
+# Req #3031 — Agent context telemetry column tests (migration 069)
+# ============================================================================
+
+def test_agent_telemetry_runs_columns(db_connection):
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'agent_telemetry_runs')
+    expected = {'id', 'captured_at', 'label', 'agent_count', 'harness_version',
+                'source_note', 'creator_fk', 'create_ts', 'update_ts'}
+    assert set(cols.keys()) == expected
+    assert cols['id']['Key'] == 'PRI'
+    assert cols['captured_at']['Null'] == 'NO'
+    assert cols['label']['Type'] == 'varchar(256)'
+    assert cols['label']['Null'] == 'NO'
+    assert cols['agent_count']['Null'] == 'NO'
+    assert cols['agent_count']['Default'] == '0'
+    assert cols['harness_version']['Type'] == 'varchar(64)'
+    assert cols['harness_version']['Null'] == 'YES'
+    assert cols['source_note']['Type'] == 'text'
+    assert cols['source_note']['Null'] == 'YES'
+    assert cols['creator_fk']['Null'] == 'NO'
+    # Log/infra table — no title/status/closed/category_fk/sort_order on the header.
+    assert 'title' not in cols
+    assert 'closed' not in cols
+    assert 'category_fk' not in cols
+
+
+def test_agent_telemetry_rows_columns(db_connection):
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'agent_telemetry_rows')
+    expected = {'id', 'run_fk', 'agent_name', 'role', 'session_kind',
+                'boot_time_ms', 'cc_base_tokens', 'claude_md_tokens',
+                'charter_stub_tokens', 'boot_payload_tokens', 'autoload_tokens',
+                'docs_loaded', 'docs_expected', 'start_work_context_tokens',
+                'footnote', 'sort_order', 'creator_fk', 'create_ts', 'update_ts'}
+    assert set(cols.keys()) == expected
+    assert cols['id']['Key'] == 'PRI'
+    assert cols['run_fk']['Null'] == 'NO'
+    assert cols['run_fk']['Key'] == 'MUL'          # indexed FK
+    assert cols['agent_name']['Type'] == 'varchar(128)'
+    assert cols['agent_name']['Null'] == 'NO'
+    assert cols['role']['Type'] == 'varchar(16)'
+    assert cols['role']['Null'] == 'NO'
+    assert cols['role']['Default'] == 'architect'
+    assert cols['session_kind']['Null'] == 'NO'
+    assert cols['session_kind']['Default'] == 'subagent'
+    # ACTUAL-token columns are nullable (phase may be n/a — PrimaryAI, Code Reviewer).
+    for c in ('boot_time_ms', 'cc_base_tokens', 'claude_md_tokens',
+              'charter_stub_tokens', 'boot_payload_tokens', 'autoload_tokens',
+              'docs_loaded', 'docs_expected', 'start_work_context_tokens'):
+        assert cols[c]['Null'] == 'YES', c
+        assert cols[c]['Type'] in ('int', 'int(11)'), (c, cols[c]['Type'])
+    assert cols['footnote']['Type'] == 'varchar(512)'
+    assert cols['footnote']['Null'] == 'YES'
+    assert cols['creator_fk']['Null'] == 'NO'

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -59,6 +59,11 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
     # (e.g., 'tasks' inside 'recurring_tasks') while preserving FK constraint
     # name replacement (e.g., 'domains_ibfk_1' → 'mig_xxx_domains_ibfk_1').
     table_names = [
+        # Req #3031 — agent context telemetry (migration 069). Listed first
+        # (longest-first): agent_telemetry_rows/runs must precede the shorter
+        # `agents` token so the longer match wins.
+        'agent_telemetry_rows',
+        'agent_telemetry_runs',
         # Req #2380 — Swarm Features & Test Cases registry (migrations 042/043/044).
         # Listed longest-first within this group to avoid partial matches
         # (e.g., 'test_cases' inside 'feature_test_cases' is blocked by the
@@ -189,6 +194,9 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         'fk_ad_agent', 'fk_ad_document',
         'uq_agents_name', 'uq_agents_file_name', 'uq_instructions_name',
         'uq_architecture_documents_name', 'uq_agent_documents_owner',
+        # Migration 069 — agent context telemetry (req #3031)
+        'fk_agent_telemetry_runs_creator',
+        'fk_agent_telemetry_rows_run', 'fk_agent_telemetry_rows_creator',
     ]
     for cname in named_constraints:
         sql = sql.replace(cname, f'{table_prefix}_{cname}')
@@ -266,6 +274,8 @@ def _get_dependency_ordered_migrations():
 # recurring_tasks must be dropped before tasks (tasks.recurring_task_fk → recurring_tasks)
 # map_coordinates → map_runs → map_routes (FK chain)
 ALL_TABLE_SUFFIXES = [
+    # Req #3031 — agent context telemetry. FK-safe: rows (child) before runs.
+    'agent_telemetry_rows', 'agent_telemetry_runs',
     # Req #2380 validation registry — FK-safe drop order (leaves first).
     # test_results → test_runs CASCADE; test_runs → test_plans RESTRICT;
     # feature_test_cases/test_plan_cases CASCADE from both sides;
@@ -466,6 +476,8 @@ def test_migration_sequence_applies(db_connection, migration_test_prefix):
             # Req #2997 — agents registry (migration 067)
             'agents', 'instructions', 'agent_instructions',
             'architecture_documents', 'agent_documents',
+            # Req #3031 — agent context telemetry (migration 069)
+            'agent_telemetry_runs', 'agent_telemetry_rows',
         ]
     }
     assert tables == expected_tables, \


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-07-23T08:10:07Z
- chore: init swarm session feature/3031-persist-agent-context-telemetry-1

## Files changed
```
 migrations/069_add_agent_telemetry.sql | 94 ++++++++++++++++++++++++++++++++++
 schema.sql                             | 55 ++++++++++++++++++++
 scripts/recreate_darwin_dev.sql        | 54 ++++++++++++++++++-
 tests/conftest.py                      |  5 ++
 tests/test_cascades.py                 | 65 +++++++++++++++++++++++
 tests/test_data_types.py               | 59 +++++++++++++++++++++
 tests/test_migrations.py               | 12 +++++
 7 files changed, 342 insertions(+), 2 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)