### PR TITLE
Refactor Agent Harness

### DIFF
--- a/migrations/070_agent_documents_relationship_set.sql
+++ b/migrations/070_agent_documents_relationship_set.sql
@@ -1,0 +1,70 @@
+-- 070_agent_documents_relationship_set.sql
+--
+-- Req #3012: Refactor Agent Harness — independent document relationship tags.
+--
+-- PROBLEM. `agent_documents.relationship` was a single VARCHAR value per link
+-- (owned | groomed | referenced | design_language | guardian), and `autoload`
+-- was DERIVED (owned+groomed). That made the roles dependent: a document could
+-- not be `owned` AND separately `autoload`, and `groomed` was the outdated term
+-- for keeping a document current.
+--
+-- SHAPE. `relationship` becomes a MySQL SET so one link carries one or more
+-- INDEPENDENT roles. The role vocabulary is collapsed and renamed:
+--   groomed                -> curated        (kept-current duty; new vocabulary)
+--   design_language        -> referenced     (folded away)
+--   guardian               -> referenced     (folded away)
+--   autoload               -> a STORED role  (no longer derived from owned+groomed)
+-- Final vocabulary: owned | curated | autoload | referenced.
+--
+-- BEHAVIOUR PRESERVED. Every document that autoloaded before (the old owned OR
+-- groomed set) gets an explicit `autoload` role here, so nothing changes about
+-- what an agent reads at boot until an owner later prunes it. `notes`/`sort_order`
+-- stay per-link (one row per agent+document); the one-`owned`-per-document rule
+-- is preserved via the same VIRTUAL generated column + UNIQUE key, now testing
+-- membership with FIND_IN_SET instead of string equality.
+--
+-- ORDERING IS LOAD-BEARING. The old virtual column keys off `relationship='owned'`
+-- (exact match). Appending ',autoload' to an owned row would make that exact
+-- match fail and silently drop the owner from the unique key. So we DROP the
+-- owner key + virtual column BEFORE mutating owned/curated rows, then rebuild the
+-- virtual column with FIND_IN_SET after the SET conversion.
+
+-- 1. Rename single-value roles while still VARCHAR (virtual column stays correct:
+--    curated/referenced != 'owned', owned rows untouched).
+UPDATE agent_documents SET relationship = 'curated'    WHERE relationship = 'groomed';
+UPDATE agent_documents SET relationship = 'referenced' WHERE relationship IN ('design_language', 'guardian');
+
+-- 2. Drop the owner unique key + virtual column so we can (a) mutate owned rows
+--    without the exact-match column mislabelling them and (b) alter the column type.
+ALTER TABLE agent_documents DROP KEY uq_agent_documents_owner;
+ALTER TABLE agent_documents DROP COLUMN owned_document_fk;
+
+-- 3. Give every currently-autoloaded link (owned or curated) an explicit autoload
+--    role. VARCHAR(24) holds "owned,autoload" (14) / "curated,autoload" (16) fine.
+UPDATE agent_documents SET relationship = CONCAT(relationship, ',autoload')
+    WHERE relationship IN ('owned', 'curated');
+
+-- 4. Convert to a SET. MySQL parses each comma-separated string into set members;
+--    all existing values ("owned,autoload", "curated,autoload", "referenced") are
+--    valid members, so the conversion is lossless.
+ALTER TABLE agent_documents
+    MODIFY COLUMN relationship SET('owned','curated','autoload','referenced')
+    NOT NULL DEFAULT 'referenced'
+    COMMENT 'independent roles: owned|curated|autoload|referenced (req #3012)';
+
+-- 5. Rebuild the one-owner virtual column + unique key against SET membership.
+ALTER TABLE agent_documents
+    ADD COLUMN owned_document_fk INT
+        AS (IF(FIND_IN_SET('owned', relationship) > 0, document_fk, NULL)) VIRTUAL;
+ALTER TABLE agent_documents
+    ADD UNIQUE KEY uq_agent_documents_owner (owned_document_fk);
+
+-- 6. Retire instructions renamed/replaced by req #3012. The two former common
+--    rows are subsumed by the new `common-documents` instruction; the darwin
+--    grooming row is renamed to `darwin-curating-does-not-transfer-ownership`.
+--    All three are re-seeded (where still needed) by scripts/seed-agents-registry.py;
+--    agent_instructions links cascade on delete.
+DELETE FROM instructions
+    WHERE name IN ('common-document-grooming-duty',
+                   'common-load-owned-documents-first',
+                   'darwin-grooming-does-not-transfer-ownership');

--- a/schema.sql
+++ b/schema.sql
@@ -935,17 +935,19 @@ CREATE TABLE IF NOT EXISTS architecture_documents (
         ON UPDATE CASCADE ON DELETE CASCADE
 );
 
--- owned_document_fk: a VIRTUAL generated column that equals document_fk only on
--- an 'owned' row, NULL otherwise. The UNIQUE key over it enforces AT MOST ONE
--- 'owned' agent per document (MySQL has no partial index; NULLs are distinct in
--- a UNIQUE key, so non-owned links coexist freely).
+-- relationship (req #3012): a SET of INDEPENDENT roles — a link may carry several
+-- at once (e.g. 'owned,autoload'). `autoload` is a STORED role, not derived.
+-- owned_document_fk: a VIRTUAL generated column that equals document_fk only when
+-- the relationship SET contains 'owned', NULL otherwise. The UNIQUE key over it
+-- enforces AT MOST ONE 'owned' agent per document (MySQL has no partial index;
+-- NULLs are distinct in a UNIQUE key, so non-owned links coexist freely).
 CREATE TABLE IF NOT EXISTS agent_documents (
     agent_fk           INT          NOT NULL,
     document_fk        INT          NOT NULL,
-    relationship       VARCHAR(24)  NOT NULL DEFAULT 'referenced',  -- owned|groomed|referenced|design_language|guardian
+    relationship       SET('owned','curated','autoload','referenced') NOT NULL DEFAULT 'referenced',
     notes              VARCHAR(512) NULL,
     sort_order         SMALLINT     NULL,
-    owned_document_fk  INT          AS (IF(relationship = 'owned', document_fk, NULL)) VIRTUAL,
+    owned_document_fk  INT          AS (IF(FIND_IN_SET('owned', relationship) > 0, document_fk, NULL)) VIRTUAL,
     PRIMARY KEY (agent_fk, document_fk),
     UNIQUE KEY uq_agent_documents_owner (owned_document_fk),
     CONSTRAINT fk_ad_agent

--- a/schema.sql
+++ b/schema.sql
@@ -865,9 +865,8 @@ CREATE TABLE IF NOT EXISTS branch_acceptance_tests (
 -- ============================================================================
 -- Agents registry (req #2997, migration 067)
 -- Agent .md files are thin charter stubs; their durable knowledge lives here
--- and is read at boot via darwin://agents/<Agent Name>. The DB is canon —
--- scripts/swarm/reconcile-agent-stubs.sh mirrors overview/ai_model/effort into
--- stub frontmatter at session boundaries.
+-- and is read at boot via darwin://agents/<Agent Name>. The DB is canon;
+-- ai_model/effort are also kept in the stub frontmatter by hand (no reconciler).
 -- ============================================================================
 
 CREATE TABLE IF NOT EXISTS agents (

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -887,10 +887,10 @@ CREATE TABLE architecture_documents (
 CREATE TABLE agent_documents (
     agent_fk           INT          NOT NULL,
     document_fk        INT          NOT NULL,
-    relationship       VARCHAR(24)  NOT NULL DEFAULT 'referenced',
+    relationship       SET('owned','curated','autoload','referenced') NOT NULL DEFAULT 'referenced',
     notes              VARCHAR(512) NULL,
     sort_order         SMALLINT     NULL,
-    owned_document_fk  INT          AS (IF(relationship = 'owned', document_fk, NULL)) VIRTUAL,
+    owned_document_fk  INT          AS (IF(FIND_IN_SET('owned', relationship) > 0, document_fk, NULL)) VIRTUAL,
     PRIMARY KEY (agent_fk, document_fk),
     UNIQUE KEY uq_agent_documents_owner (owned_document_fk),
     CONSTRAINT fk_ad_agent

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1309,9 +1309,9 @@ def test_agent_documents_single_owner_on_insert(db_connection, test_creator_fk):
 
 
 def test_agent_documents_single_owner_on_update(db_connection, test_creator_fk):
-    """The ownership rule must not be bypassable by linking as 'groomed' and then
-    UPDATEing to 'owned' — the generated column is recomputed on update, so the
-    UNIQUE key catches this path too."""
+    """The ownership rule must not be bypassable by linking as 'curated' and then
+    UPDATEing to 'owned' — the generated column is recomputed on update (via
+    FIND_IN_SET), so the UNIQUE key catches this path too."""
     with db_connection.cursor() as cur:
         a1 = _insert_agent(cur, test_creator_fk)
         a2 = _insert_agent(cur, test_creator_fk)
@@ -1322,7 +1322,7 @@ def test_agent_documents_single_owner_on_update(db_connection, test_creator_fk):
             "VALUES (%s, %s, 'owned')", (a1, doc))
         cur.execute(
             "INSERT INTO agent_documents (agent_fk, document_fk, relationship) "
-            "VALUES (%s, %s, 'groomed')", (a2, doc))
+            "VALUES (%s, %s, 'curated')", (a2, doc))
         with pytest.raises(pymysql.IntegrityError):
             cur.execute(
                 "UPDATE agent_documents SET relationship = 'owned' "
@@ -1336,7 +1336,9 @@ def test_agent_documents_multiple_non_owned_allowed(db_connection, test_creator_
     only one may own it."""
     with db_connection.cursor() as cur:
         doc = _insert_document(cur, test_creator_fk)
-        for rel in ('groomed', 'referenced', 'design_language', 'guardian'):
+        # Non-'owned' links, including a multi-role SET value — none set the
+        # owned_document_fk virtual column, so all coexist on one document.
+        for rel in ('curated', 'autoload', 'referenced', 'curated,autoload'):
             cur.execute(
                 "INSERT INTO agent_documents (agent_fk, document_fk, relationship) "
                 "VALUES (%s, %s, %s)", (_insert_agent(cur, test_creator_fk), doc, rel))

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1394,7 +1394,7 @@ def test_agent_documents_cascade_from_agent(db_connection, test_creator_fk):
 
 
 def test_agent_instructions_cascade_and_sharing(db_connection, test_creator_fk):
-    """One instruction row may bind MANY agents — this is how the common grooming
+    """One instruction row may bind MANY agents — this is how the common curating
     duty reaches every architect. Deleting one agent must not disturb the others'
     bindings."""
     with db_connection.cursor() as cur:

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -2019,7 +2019,7 @@ def test_agent_documents_columns(db_connection):
     assert cols['agent_fk']['Key'] == 'PRI'
     assert cols['document_fk']['Null'] == 'NO'
     assert cols['document_fk']['Key'] == 'PRI'
-    assert cols['relationship']['Type'] == 'varchar(24)'
+    assert cols['relationship']['Type'] == "set('owned','curated','autoload','referenced')"
     assert cols['relationship']['Null'] == 'NO'
     assert cols['relationship']['Default'] == 'referenced'
     assert cols['notes']['Type'] == 'varchar(512)'

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1941,7 +1941,7 @@ def test_agents_columns(db_connection):
 
 def test_instructions_columns(db_connection):
     """instructions: reusable named blocks of BINDING text (req #2997). Its own
-    data type precisely so ONE row can bind many agents — the common grooming
+    data type precisely so ONE row can bind many agents — the common curating
     duty is a single row referenced by every architect."""
     with db_connection.cursor() as cur:
         cols = _columns(cur, 'instructions')


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-07-24T20:34:19Z
- wip(DarwinSQL): 2026-07-24T02:34:18Z
- chore: init swarm session feature/3012-refactor-agent-harness-2

## Files changed
```
 .../070_agent_documents_relationship_set.sql       | 70 ++++++++++++++++++++++
 schema.sql                                         | 19 +++---
 scripts/recreate_darwin_dev.sql                    |  4 +-
 tests/test_constraints.py                          | 14 +++--
 tests/test_data_types.py                           |  4 +-
 5 files changed, 92 insertions(+), 19 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)