### PR TITLE
agent_instructions.sort_order has no per-agent uniqueness guard — decide+implement

### DIFF
--- a/migrations/073_agent_instructions_unique_slot.sql
+++ b/migrations/073_agent_instructions_unique_slot.sql
@@ -1,0 +1,182 @@
+-- 073_agent_instructions_unique_slot.sql
+--
+-- Req #3075 — give `agent_instructions.sort_order` the per-agent uniqueness guard
+-- it has never had. DML repair + DDL. Autonomy-granted 2026-07-25.
+--
+-- THE INVARIANT THIS ESTABLISHES
+--
+--   For one agent, at most one instruction may claim any given NUMBERED boot-load
+--   slot. A NULL sort_order claims no slot and is deliberately unconstrained.
+--
+-- `agent_instructions` has PK (agent_fk, instruction_fk) and nothing else. Since
+-- migration 072 its `sort_order` is the ONLY instruction ordering left in the
+-- schema, and it is the boot load order — so two rows sharing a slot means an
+-- agent loads its binding rules in arbitrary order between the colliding pair,
+-- with no error, no warning, and a payload that still looks well-formed.
+--
+-- NOT HYPOTHETICAL. Measured on production `darwin` before writing this file:
+--   agent_fk=5 (Darwin Architect), sort_order=1 held by instruction_fk 23 AND 84.
+-- 111 junction rows, 0 NULLs, that one collision. `darwin_dev`: 90 rows, clean.
+-- The req #3063 serialized membership queue was already live and did not prevent
+-- it, because the collision did not arrive through that page. That is the whole
+-- argument for putting the guard in the database instead of in a convention.
+--
+-- WHY A PLAIN UNIQUE KEY IS SAFE HERE — the three objections, answered
+--
+-- 1. "The DELETE-then-POST reorder transiently holds both rows at overlapping
+--    values, so the re-POST would be rejected." It does not.
+--    `Darwin/src/Agents/actions/instructionsApi.js::setAgentInstructionOrder`
+--    DELETEs EVERY row in the write set first, then re-creates them all in ONE
+--    array-body POST. No instant exists where two rows of one agent hold the same
+--    numbered slot. Its rollback path re-posts the originals into slots the same
+--    loop vacated. The path is already constraint-compliant.
+--
+--    darwin-mcp's `link_agent_instruction` WAS a single delete-then-post, which
+--    this key would have made unable to express a reorder at all. It is changed in
+--    the same requirement to the same delete-all-then-post-all shape: moving an
+--    existing binding onto a slot held by another OPEN instruction now SWAPS the
+--    two, and every other move onto an occupied slot is rejected by name.
+--
+-- 2. "It would force a 1..N renumber and collapse the bands." It would not.
+--    UNIQUE forbids duplicates; it says nothing about density. The live banded
+--    layout — per-agent rules at 1..N, the shared `common-*` rows together at
+--    100+, the 4..99 gap kept free for extension — satisfies UNIQUE exactly as it
+--    stands. `repairInstructionOrders` already emits a strictly-increasing,
+--    duplicate-free, value-PRESERVING sequence and needs no change.
+--
+-- 3. "NULL is legal and MySQL UNIQUE permits multiple NULLs, so it doesn't cover
+--    the unordered case." That is the correct SCOPE, not a gap. NULL means no slot
+--    claimed. Forcing NOT NULL would invent a slot for a link that deliberately
+--    has none and would break link_agent_instruction's COALESCE contract (req
+--    #3049). Unnumbered links are ordered by a documented `id ASC` tie-break in
+--    both readers.
+--
+-- WHY `agent_documents` DOES NOT GET THE SAME KEY
+--
+-- That sibling junction sorts by RELATIONSHIP RANK first and `sort_order` second,
+-- so slot 1 in the `owned` group and slot 1 in the `referenced` group are
+-- different positions and legitimately coexist — all 12 agents do exactly that
+-- today (document 68 was bulk-linked at slot 1 alongside each agent's owned
+-- document at slot 1). Its invariant would be
+-- UNIQUE(agent_fk, relationship-rank, sort_order), which is a different question
+-- and a different requirement. Bundling it in here would have silently renumbered
+-- 12 agents' document lists.
+--
+-- STEP 1 — BAND-PRESERVING REPAIR
+--
+-- Generic, deterministic, and re-runnable (a no-op once no duplicates remain).
+-- The rule mirrors `repairInstructionOrders`: keep good values, move only what
+-- must move, never renumber a non-colliding row.
+--
+--   * Within each colliding (agent_fk, sort_order) group the LOWEST instruction_fk
+--     KEEPS the slot — so the row a reader currently sees FIRST of the colliding
+--     pair stays exactly where it is. The others necessarily move, and moving them
+--     changes their reading position relative to the keeper: seeding 5,5,5 for one
+--     agent repairs to 5,1,2, which reads as 21,22,20 rather than 20,21,22. That is
+--     unavoidable — the whole point is that their old shared position was never
+--     well-defined. Lowest-instruction_fk-wins is the tie-break BOTH readers land
+--     on today, though for different reasons:
+--     darwin-mcp's list_instructions_for_agent sorts explicitly by
+--     (link_sort_order ASC NULLS LAST, id ASC); the Darwin UI's
+--     instructionLinksByAgent does a STABLE sort on sort_order over rows arriving
+--     in the junction's clustered-PK order (agent_fk, instruction_fk) — it has no
+--     ORDER BY of its own, so its tie-break is emergent rather than declared.
+--   * Every other row of that agent takes a slot from that agent's ascending list
+--     of FREE slots (free = claimed by no pre-repair row of that agent), handed out
+--     by a per-agent global ordinal so two different colliding groups can never be
+--     assigned the same value.
+--
+-- On production that moves instruction 84 from slot 1 to slot 7 — the first free
+-- slot in the Darwin Architect's per-agent band (1..6 occupied), leaving the
+-- shared 100/101/102 band untouched.
+--
+-- RE-RUNNABILITY. Step 1 is idempotent — once no duplicate numbered slot remains,
+-- `movers` is empty and it updates nothing. The FILE as a whole is not: a second
+-- run dies at step 2 with 1061 (duplicate key name), which is the harmless shape.
+--
+-- The 1..1000 candidate range covers both bands with room to spare and stays
+-- inside MySQL's default cte_max_recursion_depth of 1000. It cannot be exhausted
+-- by any realistic data (production holds 111 junction rows in total), but be
+-- clear about what happens if it ever were: an agent with no free slot ≤ 1000
+-- loses its movers to the JOIN, they keep their duplicate values, and step 2 then
+-- FAILS on those rows. Step 1 has already COMMITTED by then — autocommit, no
+-- transactional DDL — so the database is left partly repaired rather than
+-- untouched. Recovery is to widen the range and re-run step 1, which is safe
+-- because step 1 is idempotent. The ALTER is the verification, not a rollback.
+
+UPDATE agent_instructions ai
+JOIN (
+    WITH RECURSIVE nums (n) AS (
+        SELECT 1
+        UNION ALL
+        SELECT n + 1 FROM nums WHERE n < 1000
+    ),
+    occupied AS (
+        SELECT DISTINCT agent_fk, sort_order
+          FROM agent_instructions
+         WHERE sort_order IS NOT NULL
+    ),
+    movers AS (
+        SELECT agent_fk,
+               instruction_fk,
+               ROW_NUMBER() OVER (PARTITION BY agent_fk
+                                  ORDER BY sort_order, instruction_fk) AS pick
+          FROM (
+                SELECT agent_fk,
+                       instruction_fk,
+                       sort_order,
+                       ROW_NUMBER() OVER (PARTITION BY agent_fk, sort_order
+                                          ORDER BY instruction_fk) AS rn
+                  FROM agent_instructions
+                 WHERE sort_order IS NOT NULL
+               ) ranked
+         WHERE ranked.rn > 1
+    ),
+    free_slots AS (
+        SELECT o.agent_fk,
+               nums.n,
+               ROW_NUMBER() OVER (PARTITION BY o.agent_fk ORDER BY nums.n) AS pick
+          FROM (SELECT DISTINCT agent_fk FROM occupied) o
+          CROSS JOIN nums
+         WHERE NOT EXISTS (SELECT 1
+                             FROM occupied x
+                            WHERE x.agent_fk = o.agent_fk
+                              AND x.sort_order = nums.n)
+    )
+    SELECT m.agent_fk, m.instruction_fk, f.n AS new_sort_order
+      FROM movers m
+      JOIN free_slots f
+        ON f.agent_fk = m.agent_fk
+       AND f.pick = m.pick
+) repair
+  ON repair.agent_fk = ai.agent_fk
+ AND repair.instruction_fk = ai.instruction_fk
+SET ai.sort_order = repair.new_sort_order;
+
+-- STEP 2 — THE GUARD
+--
+-- Multi-NULL-permissive by MySQL's UNIQUE semantics, which is exactly the scope
+-- argued above. This ALTER is also the repair's verification: it cannot succeed
+-- while a duplicate numbered slot remains.
+
+ALTER TABLE agent_instructions
+    ADD UNIQUE KEY uq_agent_instructions_slot (agent_fk, sort_order);
+
+-- ROLLBACK
+--   ALTER TABLE agent_instructions DROP INDEX uq_agent_instructions_slot;
+-- The repaired sort_order values are NOT restored by that drop and should not be
+-- — they are the corrected state, not damage.
+--
+-- APPLY ORDER: darwin_dev first, verify, THEN production behind an RDS snapshot.
+--
+-- Deploy ordering vs. the frontend bundle is a NON-ISSUE here, unlike migration
+-- 072. This file adds a key and rewrites at most a handful of sort_order values;
+-- it removes no column and changes no result shape, so the currently-live bundle
+-- keeps working unchanged either side of it.
+--
+-- Verification: expect an empty result (no duplicate numbered slot survives).
+-- SELECT agent_fk, sort_order, COUNT(*) c
+--   FROM agent_instructions
+--  WHERE sort_order IS NOT NULL
+--  GROUP BY agent_fk, sort_order
+-- HAVING c > 1;

--- a/schema.sql
+++ b/schema.sql
@@ -911,6 +911,12 @@ CREATE TABLE IF NOT EXISTS agent_instructions (
     instruction_fk  INT      NOT NULL,
     sort_order      SMALLINT NULL,       -- boot load order
     PRIMARY KEY (agent_fk, instruction_fk),
+    -- req #3075, migration 073: one agent may not load two instructions at the
+    -- same NUMBERED slot. NULL claims no slot, and MySQL UNIQUE permits many
+    -- NULLs — that is the intended scope, not a gap. Deliberately NOT mirrored
+    -- on `agent_documents`, which sorts by relationship rank first and so has
+    -- legitimate same-slot pairs across rank groups.
+    UNIQUE KEY uq_agent_instructions_slot (agent_fk, sort_order),
     CONSTRAINT fk_ai_agent
         FOREIGN KEY (agent_fk) REFERENCES agents (id)
         ON UPDATE CASCADE ON DELETE CASCADE,

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -857,8 +857,12 @@ CREATE TABLE instructions (
 CREATE TABLE agent_instructions (
     agent_fk        INT      NOT NULL,
     instruction_fk  INT      NOT NULL,
-    sort_order      SMALLINT NULL,
+    sort_order      SMALLINT NULL,       -- boot load order
     PRIMARY KEY (agent_fk, instruction_fk),
+    -- req #3075, migration 073: one agent may not load two instructions at the
+    -- same NUMBERED slot. NULL claims no slot, and MySQL UNIQUE permits many
+    -- NULLs — that is the intended scope, not a gap.
+    UNIQUE KEY uq_agent_instructions_slot (agent_fk, sort_order),
     CONSTRAINT fk_ai_agent
         FOREIGN KEY (agent_fk) REFERENCES agents (id)
         ON UPDATE CASCADE ON DELETE CASCADE,

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1455,3 +1455,164 @@ def test_agents_creator_fk_cascade(db_connection):
         cur.execute("SELECT COUNT(*) AS c FROM agents WHERE creator_fk = %s", (cfk,))
         assert cur.fetchone()['c'] == 0
     db_connection.rollback()
+
+
+# ===========================================================================
+# Req #3075 — agent_instructions per-agent load-slot uniqueness (migration 073)
+# ===========================================================================
+#
+# `agent_instructions.sort_order` is the BOOT LOAD ORDER, and since migration 072
+# it is the only instruction ordering left in the schema. Before migration 073
+# nothing stopped two instructions from claiming the same slot on one agent — the
+# composite PK (agent_fk, instruction_fk) is satisfied by both rows — so the agent
+# booted with those two rules in arbitrary relative order, with no error and a
+# payload that still looked well-formed. Production `darwin` was carrying exactly
+# one such pair (agent 5, slot 1) when this key was added.
+
+
+def _insert_instruction(cur, creator_fk, name=None):
+    """Insert an instructions row and return its id."""
+    name = name or f"Test Instruction {uuid.uuid4().hex[:8]}"
+    cur.execute(
+        "INSERT INTO instructions (name, content, creator_fk) VALUES (%s, %s, %s)",
+        (name, 'binding text', creator_fk))
+    return cur.lastrowid
+
+
+def test_agent_instructions_duplicate_slot_rejected_on_insert(
+        db_connection, test_creator_fk):
+    """uq_agent_instructions_slot: THE guard. One agent, one numbered slot, one
+    instruction. This is the insert path `nextInstructionSortOrder` feeds when two
+    concurrent binds both compute max+1 from the same pre-write cache."""
+    with db_connection.cursor() as cur:
+        agent = _insert_agent(cur, test_creator_fk)
+        first = _insert_instruction(cur, test_creator_fk)
+        second = _insert_instruction(cur, test_creator_fk)
+
+        cur.execute("INSERT INTO agent_instructions (agent_fk, instruction_fk, "
+                    "sort_order) VALUES (%s, %s, 1)", (agent, first))
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute("INSERT INTO agent_instructions (agent_fk, instruction_fk, "
+                        "sort_order) VALUES (%s, %s, 1)", (agent, second))
+    db_connection.rollback()
+
+
+def test_agent_instructions_duplicate_slot_rejected_on_update(
+        db_connection, test_creator_fk):
+    """The guard must not be bypassable by inserting at a free slot and then
+    UPDATEing onto an occupied one — the same shape as the agent_documents
+    owner-key update test. This is the path a reorder takes when it moves a row
+    onto a slot it did not first vacate."""
+    with db_connection.cursor() as cur:
+        agent = _insert_agent(cur, test_creator_fk)
+        first = _insert_instruction(cur, test_creator_fk)
+        second = _insert_instruction(cur, test_creator_fk)
+
+        cur.execute("INSERT INTO agent_instructions (agent_fk, instruction_fk, "
+                    "sort_order) VALUES (%s, %s, 1)", (agent, first))
+        cur.execute("INSERT INTO agent_instructions (agent_fk, instruction_fk, "
+                    "sort_order) VALUES (%s, %s, 2)", (agent, second))
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute("UPDATE agent_instructions SET sort_order = 1 "
+                        "WHERE agent_fk = %s AND instruction_fk = %s",
+                        (agent, second))
+    db_connection.rollback()
+
+
+def test_agent_instructions_slot_is_per_agent_not_global(
+        db_connection, test_creator_fk):
+    """agent_fk LEADS the key on purpose. Every agent has its own slot 1 — the
+    banded scheme puts per-agent rules at 1..N on all of them — so a global
+    UNIQUE(sort_order) would have been catastrophically wrong."""
+    with db_connection.cursor() as cur:
+        agent_a = _insert_agent(cur, test_creator_fk)
+        agent_b = _insert_agent(cur, test_creator_fk)
+        instruction = _insert_instruction(cur, test_creator_fk)
+
+        cur.execute("INSERT INTO agent_instructions (agent_fk, instruction_fk, "
+                    "sort_order) VALUES (%s, %s, 1)", (agent_a, instruction))
+        cur.execute("INSERT INTO agent_instructions (agent_fk, instruction_fk, "
+                    "sort_order) VALUES (%s, %s, 1)", (agent_b, instruction))
+
+        cur.execute("SELECT COUNT(*) AS c FROM agent_instructions "
+                    "WHERE instruction_fk = %s AND sort_order = 1", (instruction,))
+        assert cur.fetchone()['c'] == 2
+    db_connection.rollback()
+
+
+def test_agent_instructions_multiple_null_slots_allowed(
+        db_connection, test_creator_fk):
+    """NULL claims NO slot, and MySQL UNIQUE treats NULLs as distinct — so one
+    agent may hold any number of unordered links. That is the deliberate scope of
+    the invariant, not a hole in it: forcing NOT NULL would invent a slot for a
+    link that has none and would break link_agent_instruction's COALESCE contract
+    (req #3049), where an omitted sort_order must leave the stored value alone.
+
+    Unnumbered links stay deterministically ordered anyway: darwin-mcp sorts
+    NULLs last then by id, and the Darwin UI's stable sort leaves them in the
+    junction's clustered-PK order."""
+    with db_connection.cursor() as cur:
+        agent = _insert_agent(cur, test_creator_fk)
+        first = _insert_instruction(cur, test_creator_fk)
+        second = _insert_instruction(cur, test_creator_fk)
+        third = _insert_instruction(cur, test_creator_fk)
+
+        for instruction in (first, second, third):
+            cur.execute("INSERT INTO agent_instructions (agent_fk, instruction_fk, "
+                        "sort_order) VALUES (%s, %s, NULL)", (agent, instruction))
+
+        cur.execute("SELECT COUNT(*) AS c FROM agent_instructions "
+                    "WHERE agent_fk = %s AND sort_order IS NULL", (agent,))
+        assert cur.fetchone()['c'] == 3
+    db_connection.rollback()
+
+
+def test_agent_instructions_banded_sparse_slots_allowed(
+        db_connection, test_creator_fk):
+    """The live layout must remain legal: per-agent rules at 1..N, the shared
+    `common-*` rows together at 100+, and the 4..99 gap kept free for extension.
+    UNIQUE forbids duplicates, not sparseness — nothing here pushes toward a 1..N
+    renumber, which is what `repairInstructionOrders` exists to avoid."""
+    with db_connection.cursor() as cur:
+        agent = _insert_agent(cur, test_creator_fk)
+        for slot in (1, 2, 3, 100, 101, 102):
+            instruction = _insert_instruction(cur, test_creator_fk)
+            cur.execute("INSERT INTO agent_instructions (agent_fk, instruction_fk, "
+                        "sort_order) VALUES (%s, %s, %s)", (agent, instruction, slot))
+
+        cur.execute("SELECT sort_order FROM agent_instructions "
+                    "WHERE agent_fk = %s ORDER BY sort_order", (agent,))
+        assert [r['sort_order'] for r in cur.fetchall()] == [1, 2, 3, 100, 101, 102]
+    db_connection.rollback()
+
+
+def test_agent_instructions_delete_then_repost_swap_is_legal(
+        db_connection, test_creator_fk):
+    """The reorder path, replayed exactly as the UI performs it.
+
+    `setAgentInstructionOrder` DELETEs EVERY row in the write set and only then
+    re-creates them all in one array-body POST — it never holds two rows of one
+    agent at the same numbered slot, not even transiently. That sequencing is the
+    reason a plain UNIQUE key is safe here, so it is pinned as a test rather than
+    left as a claim in a comment."""
+    with db_connection.cursor() as cur:
+        agent = _insert_agent(cur, test_creator_fk)
+        first = _insert_instruction(cur, test_creator_fk)
+        second = _insert_instruction(cur, test_creator_fk)
+
+        cur.execute("INSERT INTO agent_instructions (agent_fk, instruction_fk, "
+                    "sort_order) VALUES (%s, %s, 1), (%s, %s, 2)",
+                    (agent, first, agent, second))
+
+        # DELETE both, then re-POST both swapped — the real write sequence.
+        cur.execute("DELETE FROM agent_instructions WHERE agent_fk = %s AND "
+                    "instruction_fk IN (%s, %s)", (agent, first, second))
+        cur.execute("INSERT INTO agent_instructions (agent_fk, instruction_fk, "
+                    "sort_order) VALUES (%s, %s, 2), (%s, %s, 1)",
+                    (agent, first, agent, second))
+
+        cur.execute("SELECT instruction_fk, sort_order FROM agent_instructions "
+                    "WHERE agent_fk = %s ORDER BY sort_order", (agent,))
+        assert [(r['instruction_fk'], r['sort_order']) for r in cur.fetchall()] == \
+            [(second, 1), (first, 2)]
+    db_connection.rollback()

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1979,6 +1979,12 @@ def test_agent_instructions_columns(db_connection):
     after committing. Adding an `id` here would silently invalidate that whole
     strategy, so assert it explicitly rather than leaving it implied by the
     column set.
+
+    sort_order STAYS NULLABLE under migration 073 (req #3075). The new
+    uq_agent_instructions_slot key constrains NUMBERED slots only; NULL means "no
+    slot claimed" and MySQL UNIQUE permits many NULLs per agent. Making the column
+    NOT NULL would invent a slot for a link that deliberately has none and would
+    break link_agent_instruction's COALESCE contract (req #3049).
     """
     with db_connection.cursor() as cur:
         cols = _columns(cur, 'agent_instructions')
@@ -1991,6 +1997,29 @@ def test_agent_instructions_columns(db_connection):
     assert cols['instruction_fk']['Key'] == 'PRI'
     assert cols['sort_order']['Type'] == 'smallint'
     assert cols['sort_order']['Null'] == 'YES'
+    # DESCRIBE reports Key only for the LEADING column of an index, and
+    # uq_agent_instructions_slot leads on agent_fk (already 'PRI') — so
+    # sort_order's Key stays blank even with the new key in place. The key
+    # itself is asserted by SHOW INDEX in the next test, which is the reliable
+    # place to look for it.
+    assert cols['sort_order']['Key'] == ''
+
+
+def test_agent_instructions_slot_key_exists(db_connection):
+    """migration 073 (req #3075): the per-agent load-slot uniqueness guard.
+
+    Asserted as an index shape rather than only as behaviour because the KEY is
+    the whole deliverable — the behavioural half lives in test_constraints.py.
+    """
+    with db_connection.cursor() as cur:
+        cur.execute("SHOW INDEX FROM agent_instructions "
+                    "WHERE Key_name = 'uq_agent_instructions_slot'")
+        rows = sorted(cur.fetchall(), key=lambda r: r['Seq_in_index'])
+
+    assert rows, 'uq_agent_instructions_slot is missing — migration 073 not applied'
+    assert [r['Column_name'] for r in rows] == ['agent_fk', 'sort_order'], \
+        'agent_fk must lead: the invariant is per-agent, not global'
+    assert all(r['Non_unique'] == 0 for r in rows), 'the key must be UNIQUE'
 
 
 def test_architecture_documents_columns(db_connection):

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -19,6 +19,7 @@ Migration 016 retroactively tracks those table definitions. Tests must apply
 import os
 import glob
 import re
+import pymysql
 import pytest
 
 
@@ -194,6 +195,8 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         'fk_ad_agent', 'fk_ad_document',
         'uq_agents_name', 'uq_agents_file_name', 'uq_instructions_name',
         'uq_architecture_documents_name', 'uq_agent_documents_owner',
+        # Migration 073 — agent_instructions per-agent load-slot guard (req #3075)
+        'uq_agent_instructions_slot',
         # Migration 069 — agent context telemetry (req #3031)
         'fk_agent_telemetry_runs_creator',
         'fk_agent_telemetry_rows_run', 'fk_agent_telemetry_rows_creator',
@@ -930,3 +933,128 @@ def test_migration_040_drops_scheduled_column(db_connection, migration_test_pref
         # Cleanup
         cur.execute(f"DROP TABLE {table_name}")
         db_connection.commit()
+
+
+def test_migration_073_repairs_duplicate_slots_then_adds_the_key(
+        db_connection, migration_test_prefix):
+    """Migration 073 (req #3075) — the band-preserving repair, exercised for real.
+
+    NON-TOLERANT on purpose. `test_migration_sequence_applies` replays every
+    migration with tolerant=True, which silently swallows any non-CREATE failure —
+    so it can prove 073 does not break the replay, but it can NOT prove the repair
+    runs or is correct. This test applies the actual file text through the same
+    prefix-rewrite machinery with tolerant=False, against seeded collisions.
+
+    The seeded shapes, and what each one is here to catch:
+      agent 1  the production shape — per-agent band 1..6, shared band 100..102,
+               one collider at slot 1. Asserts the collider lands at 7 (first free
+               slot in its own band) and that NOTHING else is renumbered.
+      agent 2  TWO separate colliding groups on one agent. A per-group "next free
+               slot" formulation hands both movers slot 3; only a per-agent GLOBAL
+               ordinal keeps them distinct. This is the case that dictated the
+               shape of the migration.
+      agent 3  a three-way collision.
+      agent 4  several NULL slots — must survive untouched and unconstrained.
+      agent 5  already clean and SPARSE — must not be renumbered, because the
+               banded layout is deliberate (see repairInstructionOrders).
+      agent 6  shares a slot VALUE with agent 5, which stays legal: agent_fk leads
+               the key.
+    """
+    table = f"{migration_test_prefix}_agent_instructions"
+
+    seed = [
+        (1, 1, 1), (1, 2, 2), (1, 3, 3), (1, 4, 4), (1, 5, 5), (1, 6, 6),
+        (1, 83, 100), (1, 85, 101), (1, 86, 102), (1, 84, 1),
+        (2, 10, 1), (2, 11, 1), (2, 12, 2), (2, 13, 2),
+        (3, 20, 5), (3, 21, 5), (3, 22, 5),
+        (4, 30, None), (4, 31, None), (4, 32, 1),
+        (5, 40, 2), (5, 41, 9), (5, 42, 100),
+        (6, 40, 2),
+    ]
+
+    with db_connection.cursor() as cur:
+        # Standalone: migration 073 touches only agent_instructions, so the FK
+        # parents are not needed and their absence keeps the fixture honest about
+        # what the migration actually reads.
+        cur.execute(f"""
+            CREATE TABLE {table} (
+                agent_fk       INT      NOT NULL,
+                instruction_fk INT      NOT NULL,
+                sort_order     SMALLINT NULL,
+                PRIMARY KEY (agent_fk, instruction_fk)
+            )
+        """)
+        cur.executemany(
+            f"INSERT INTO {table} (agent_fk, instruction_fk, sort_order) "
+            "VALUES (%s, %s, %s)", seed)
+        db_connection.commit()
+
+        sql = _read_migration_file(os.path.join(
+            _get_migrations_dir(), '073_agent_instructions_unique_slot.sql'))
+        _apply_migration(cur, sql, migration_test_prefix, tolerant=False)
+        db_connection.commit()
+
+        cur.execute(f"SELECT agent_fk, instruction_fk, sort_order FROM {table}")
+        after = {(r['agent_fk'], r['instruction_fk']): r['sort_order']
+                 for r in cur.fetchall()}
+
+    assert len(after) == len(seed), 'the repair must not add or drop rows'
+
+    # No duplicate NUMBERED slot survives anywhere.
+    numbered = [k for k, v in after.items() if v is not None]
+    slots = [(agent, after[(agent, instr)]) for agent, instr in numbered]
+    assert len(slots) == len(set(slots)), f'duplicate slot survived: {after}'
+
+    # agent 1 — the collider moves to the first free slot in its own band; every
+    # other row, in BOTH bands, keeps its stored value.
+    assert after[(1, 84)] == 7
+    for instr in (1, 2, 3, 4, 5, 6):
+        assert after[(1, instr)] == instr, 'per-agent band was renumbered'
+    assert (after[(1, 83)], after[(1, 85)], after[(1, 86)]) == (100, 101, 102), \
+        'shared band was disturbed'
+
+    # agent 2 — keepers hold; the two movers take DISTINCT free slots.
+    assert (after[(2, 10)], after[(2, 12)]) == (1, 2)
+    assert sorted((after[(2, 11)], after[(2, 13)])) == [3, 4]
+
+    # agent 3 — lowest instruction_fk keeps the slot, matching the tie-break both
+    # readers land on for a colliding pair (declared as `id ASC` in darwin-mcp;
+    # emergent from a stable sort over clustered-PK order in the Darwin UI).
+    assert after[(3, 20)] == 5
+    assert sorted((after[(3, 21)], after[(3, 22)])) == [1, 2]
+
+    # agent 4 — NULLs are left alone.
+    assert (after[(4, 30)], after[(4, 31)], after[(4, 32)]) == (None, None, 1)
+
+    # agent 5 — clean and sparse, untouched. agent 6 shares the value 2 with it.
+    assert (after[(5, 40)], after[(5, 41)], after[(5, 42)]) == (2, 9, 100)
+    assert after[(6, 40)] == 2
+
+    # The key is live on the repaired table, and still permits many NULLs.
+    with db_connection.cursor() as cur:
+        cur.execute(f"SHOW INDEX FROM {table} WHERE Key_name = "
+                    f"'{migration_test_prefix}_uq_agent_instructions_slot'")
+        index = sorted(cur.fetchall(), key=lambda r: r['Seq_in_index'])
+        assert [r['Column_name'] for r in index] == ['agent_fk', 'sort_order']
+        assert all(r['Non_unique'] == 0 for r in index)
+
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(f"UPDATE {table} SET sort_order = 5 "
+                        "WHERE agent_fk = 3 AND instruction_fk = 21")
+        db_connection.rollback()
+
+        cur.execute(f"UPDATE {table} SET sort_order = NULL "
+                    "WHERE agent_fk = 4 AND instruction_fk = 32")
+        db_connection.commit()
+
+    # Re-running the repair is a no-op — it must converge in one pass.
+    with db_connection.cursor() as cur:
+        repair_only = sql.split('ALTER TABLE')[0]
+        _apply_migration(cur, repair_only, migration_test_prefix, tolerant=False)
+        db_connection.commit()
+        cur.execute(f"SELECT agent_fk, instruction_fk, sort_order FROM {table}")
+        again = {(r['agent_fk'], r['instruction_fk']): r['sort_order']
+                 for r in cur.fetchall()}
+    expected = dict(after)
+    expected[(4, 32)] = None
+    assert again == expected, 'the repair is not idempotent'


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-07-26T09:44:43Z
- chore: init swarm session feature/3075-agent-instructionssort-order-has-no-1

## Files changed
```
 migrations/073_agent_instructions_unique_slot.sql | 182 ++++++++++++++++++++++
 schema.sql                                        |   6 +
 scripts/recreate_darwin_dev.sql                   |   6 +-
 tests/test_constraints.py                         | 161 +++++++++++++++++++
 tests/test_data_types.py                          |  29 ++++
 tests/test_migrations.py                          | 128 +++++++++++++++
 6 files changed, 511 insertions(+), 1 deletion(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)