### PR TITLE
Ground-truth breakdown of the Claude Code base token figure

### DIFF
--- a/migrations/074_agent_telemetry_breakdown.sql
+++ b/migrations/074_agent_telemetry_breakdown.sql
@@ -1,0 +1,37 @@
+-- 074_agent_telemetry_breakdown.sql
+--
+-- Req #3095 — ground-truth breakdown of the Claude Code base token figure.
+--
+-- PROBLEM. `agent_telemetry_rows.cc_base_tokens` is a single number computed by
+-- SUBTRACTION (cc_base = initial - claude_md - charter_stub - probe_prompt) — it has
+-- never been a sum of independently-measured pieces, despite the glossary defining
+-- "Claude Code" as harness instructions + tool schemas + skills listing + MCP listing.
+--
+-- FEASIBILITY (verified empirically, req #3095). Claude Code's own `/context` command,
+-- scripted non-interactively (`claude -p "/context" --resume <session_id> --model
+-- <model> --output-format json`), reports a categorized breakdown — System prompt,
+-- System tools, MCP tools, Skills, Custom agents, Memory files, Messages, Compact
+-- buffer, Free space — as real numbers (cross-checked against real API `usage` for the
+-- same turn to within a few percent, far tighter than a chars/4-style estimate could
+-- ever produce). `scripts/agents/context-breakdown-probe.py` captures this. These five
+-- new columns store the first four glossary pieces plus a fifth real, measurable
+-- category (other-custom-agent listing) that was not in the original glossary but is
+-- part of the same breakdown.
+--
+-- SHAPE. Five new nullable INT columns on `agent_telemetry_rows`, matching how
+-- `claude_md_tokens`/`charter_stub_tokens` are already modeled — a fixed, small,
+-- well-known set of named pieces, not a variable-length collection, so a child table
+-- (à la test_runs -> test_results) is not warranted here. All ACTUAL tokens (never
+-- chars/4). NULL where a row's breakdown was not captured — never fabricated; an
+-- existing run's rows simply get NULL in these columns until re-captured.
+--
+-- PRODUCTION table (darwin + darwin_dev), matching migration 069 — the report route
+-- renders in the deployed app, so the columns must exist in production `darwin`;
+-- darwin_dev carries the same schema for dev review.
+
+ALTER TABLE agent_telemetry_rows
+    ADD COLUMN system_prompt_tokens  INT NULL AFTER cc_base_tokens,   -- harness instructions (Claude Code's "System prompt" category)
+    ADD COLUMN system_tools_tokens   INT NULL AFTER system_prompt_tokens,  -- built-in tool schemas ("System tools")
+    ADD COLUMN mcp_tools_tokens      INT NULL AFTER system_tools_tokens,   -- MCP tools/resources listing ("MCP tools")
+    ADD COLUMN skills_tokens         INT NULL AFTER mcp_tools_tokens,      -- available-skills listing ("Skills")
+    ADD COLUMN custom_agents_tokens  INT NULL AFTER skills_tokens;         -- other-custom-agent listing ("Custom agents")

--- a/schema.sql
+++ b/schema.sql
@@ -1000,6 +1000,11 @@ CREATE TABLE IF NOT EXISTS agent_telemetry_rows (
     session_kind                VARCHAR(16)  NOT NULL DEFAULT 'subagent',    -- subagent|top_level
     boot_time_ms                INT          NULL,
     cc_base_tokens              INT          NULL,
+    system_prompt_tokens        INT          NULL,   -- harness instructions (req #3095, migration 074)
+    system_tools_tokens         INT          NULL,   -- built-in tool schemas (req #3095, migration 074)
+    mcp_tools_tokens            INT          NULL,   -- MCP tools/resources listing (req #3095, migration 074)
+    skills_tokens               INT          NULL,   -- available-skills listing (req #3095, migration 074)
+    custom_agents_tokens        INT          NULL,   -- other-custom-agent listing (req #3095, migration 074)
     claude_md_tokens            INT          NULL,
     charter_stub_tokens         INT          NULL,
     boot_payload_tokens         INT          NULL,

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -932,6 +932,11 @@ CREATE TABLE agent_telemetry_rows (
     session_kind                VARCHAR(16)  NOT NULL DEFAULT 'subagent',
     boot_time_ms                INT          NULL,
     cc_base_tokens              INT          NULL,
+    system_prompt_tokens        INT          NULL,   -- harness instructions (req #3095, migration 074)
+    system_tools_tokens         INT          NULL,   -- built-in tool schemas (req #3095, migration 074)
+    mcp_tools_tokens            INT          NULL,   -- MCP tools/resources listing (req #3095, migration 074)
+    skills_tokens               INT          NULL,   -- available-skills listing (req #3095, migration 074)
+    custom_agents_tokens        INT          NULL,   -- other-custom-agent listing (req #3095, migration 074)
     claude_md_tokens            INT          NULL,
     charter_stub_tokens         INT          NULL,
     boot_payload_tokens         INT          NULL,

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -2110,7 +2110,10 @@ def test_agent_telemetry_rows_columns(db_connection):
     with db_connection.cursor() as cur:
         cols = _columns(cur, 'agent_telemetry_rows')
     expected = {'id', 'run_fk', 'agent_name', 'role', 'session_kind',
-                'boot_time_ms', 'cc_base_tokens', 'claude_md_tokens',
+                'boot_time_ms', 'cc_base_tokens',
+                'system_prompt_tokens', 'system_tools_tokens', 'mcp_tools_tokens',
+                'skills_tokens', 'custom_agents_tokens',
+                'claude_md_tokens',
                 'charter_stub_tokens', 'boot_payload_tokens', 'autoload_tokens',
                 'docs_loaded', 'docs_expected', 'start_work_context_tokens',
                 'footnote', 'sort_order', 'creator_fk', 'create_ts', 'update_ts'}
@@ -2128,7 +2131,11 @@ def test_agent_telemetry_rows_columns(db_connection):
     # ACTUAL-token columns are nullable (phase may be n/a — PrimaryAI, Code Reviewer).
     for c in ('boot_time_ms', 'cc_base_tokens', 'claude_md_tokens',
               'charter_stub_tokens', 'boot_payload_tokens', 'autoload_tokens',
-              'docs_loaded', 'docs_expected', 'start_work_context_tokens'):
+              'docs_loaded', 'docs_expected', 'start_work_context_tokens',
+              # ground-truth CC-base breakdown (req #3095, migration 074) — nullable,
+              # a row's breakdown may not have been captured
+              'system_prompt_tokens', 'system_tools_tokens', 'mcp_tools_tokens',
+              'skills_tokens', 'custom_agents_tokens'):
         assert cols[c]['Null'] == 'YES', c
         assert cols[c]['Type'] in ('int', 'int(11)'), (c, cols[c]['Type'])
     assert cols['footnote']['Type'] == 'varchar(512)'


### PR DESCRIPTION
## Summary
- Merge branch 'main' of https://github.com/BillWilliams79/DarwinSQL into feature/3095-ground-truth-breakdown-of-the-1
- wip(DarwinSQL): 2026-07-27T01:54:58Z
- chore: init swarm session feature/3095-ground-truth-breakdown-of-the-1

## Files changed
```
 migrations/074_agent_telemetry_breakdown.sql | 37 ++++++++++++++++++++++++++++
 schema.sql                                   |  5 ++++
 scripts/recreate_darwin_dev.sql              |  5 ++++
 tests/test_data_types.py                     | 11 +++++++--
 4 files changed, 56 insertions(+), 2 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)