### PR TITLE
Per-document actual-token capture for architecture/autoload docs

### DIFF
--- a/migrations/074_add_agent_telemetry_row_docs.sql
+++ b/migrations/074_add_agent_telemetry_row_docs.sql
@@ -1,0 +1,51 @@
+-- 074_add_agent_telemetry_row_docs.sql
+--
+-- Req #3096: Per-document actual-token capture for architecture/autoload docs.
+--
+-- PROBLEM. agent_telemetry_rows (migration 069) stores only an AGGREGATE per-agent
+-- autoload_tokens figure (the whole autoload set's actual-token weight) plus
+-- docs_loaded/docs_expected COUNTS. There is no per-document breakdown of WHICH
+-- document contributed HOW MANY actual tokens anywhere that reaches the UI — the
+-- only existing per-document figure is agent-context-telemetry.py's chars/4
+-- ESTIMATE, which is transient (scripts/agents/out/telemetry/<slug>.json only)
+-- and never persisted. This is the storage half of closing that gap — extract-
+-- actual-tokens.py now attributes each turn-to-turn transcript usage delta to the
+-- single autoload document Read that caused it (real tokenizer, never chars/4).
+--
+-- SHAPE. One more parent/child level under the existing run -> rows shape
+-- (agent_telemetry_runs -> agent_telemetry_rows): agent_telemetry_row_docs is a
+-- child of agent_telemetry_rows ONLY, FK'd to its immediate parent alone — no
+-- redundant run_fk (the `builds -> branches` precedent: builds carries only
+-- branch_fk, not a denormalized project_fk, even though builds -> branches ->
+-- build_projects is a real 3-level chain). No FK to architecture_documents
+-- either: agent_telemetry_rows.agent_name is already plain text, not FK'd to
+-- agents.id, because this is a historical log/snapshot table whose rows must
+-- keep meaning even if the live registry entry it was measured against is later
+-- renamed or deleted — doc_path follows that same convention.
+--
+-- row_fk CASCADEs: the row is the container for its own documents, same as the
+-- run is the container for its rows. actual_tokens is NOT NULL (unlike the
+-- nullable token columns on the parent row) — a doc row only exists once it has
+-- been measured, so there is no "phase not applicable" case here to leave NULL.
+--
+-- PRODUCTION table (darwin + darwin_dev), same call as its parent — the report
+-- route renders in the deployed app, so the rows must live in production `darwin`.
+
+CREATE TABLE agent_telemetry_row_docs (
+    id              INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    row_fk          INT          NOT NULL,                    -- agent_telemetry_rows(id), CASCADE
+    doc_path        VARCHAR(512) NOT NULL,                     -- repo-relative location, e.g. "memory/aws-architecture.md"
+    actual_tokens   INT          NOT NULL,                     -- real-tokenizer weight of this one document
+    sort_order      SMALLINT     NULL,                         -- render order within the row (autoload_documents order)
+    creator_fk      VARCHAR(64)  NOT NULL,
+    create_ts       TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_agent_telemetry_row_docs_row
+        FOREIGN KEY (row_fk) REFERENCES agent_telemetry_rows (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_agent_telemetry_row_docs_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE INDEX ix_agent_telemetry_row_docs_row_fk ON agent_telemetry_row_docs (row_fk);

--- a/schema.sql
+++ b/schema.sql
@@ -1021,3 +1021,28 @@ CREATE TABLE IF NOT EXISTS agent_telemetry_rows (
 );
 
 CREATE INDEX ix_agent_telemetry_rows_run_fk ON agent_telemetry_rows (run_fk);
+
+-- Req #3096, migration 074 — per-document actual-token breakdown, one level deeper
+-- than agent_telemetry_rows -> agent_telemetry_runs. row_fk CASCADEs (the row is
+-- the container for its own documents); no redundant run_fk (single immediate-
+-- parent FK, matching the builds -> branches precedent) and no FK to
+-- architecture_documents (doc_path is plain text, matching agent_name on the
+-- parent row — a historical snapshot table, not a live reference).
+CREATE TABLE IF NOT EXISTS agent_telemetry_row_docs (
+    id              INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    row_fk          INT          NOT NULL,
+    doc_path        VARCHAR(512) NOT NULL,
+    actual_tokens   INT          NOT NULL,
+    sort_order      SMALLINT     NULL,
+    creator_fk      VARCHAR(64)  NOT NULL,
+    create_ts       TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_agent_telemetry_row_docs_row
+        FOREIGN KEY (row_fk) REFERENCES agent_telemetry_rows (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_agent_telemetry_row_docs_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE INDEX ix_agent_telemetry_row_docs_row_fk ON agent_telemetry_row_docs (row_fk);

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -1,12 +1,12 @@
 -- Recreate darwin_dev test/dev tables from scratch
 -- Uses production-identical table names (same DDL as schema.sql)
 -- Idempotent: safe to run repeatedly to reset darwin_dev to canonical state
--- All 46 tables in FK-dependency order
+-- All 47 tables in FK-dependency order
 
 USE darwin_dev;
 
 SET FOREIGN_KEY_CHECKS = 0;
-DROP TABLE IF EXISTS agent_telemetry_rows, agent_telemetry_runs,
+DROP TABLE IF EXISTS agent_telemetry_row_docs, agent_telemetry_rows, agent_telemetry_runs,
     customer_releases, builds, branches, build_projects,
     customers,
     agent_documents, agent_instructions,
@@ -953,3 +953,24 @@ CREATE TABLE agent_telemetry_rows (
 );
 
 CREATE INDEX ix_agent_telemetry_rows_run_fk ON agent_telemetry_rows (run_fk);
+
+-- Per-document actual-token breakdown (req #3096, migration 074) — child of
+-- agent_telemetry_rows only, row_fk CASCADEs.
+CREATE TABLE agent_telemetry_row_docs (
+    id              INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    row_fk          INT          NOT NULL,
+    doc_path        VARCHAR(512) NOT NULL,
+    actual_tokens   INT          NOT NULL,
+    sort_order      SMALLINT     NULL,
+    creator_fk      VARCHAR(64)  NOT NULL,
+    create_ts       TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_agent_telemetry_row_docs_row
+        FOREIGN KEY (row_fk) REFERENCES agent_telemetry_rows (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_agent_telemetry_row_docs_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE INDEX ix_agent_telemetry_row_docs_row_fk ON agent_telemetry_row_docs (row_fk);

--- a/tests/test_cascades.py
+++ b/tests/test_cascades.py
@@ -1345,3 +1345,118 @@ def test_delete_profile_cascades_to_telemetry(db_connection):
         cur.execute("SELECT id FROM agent_telemetry_rows WHERE creator_fk = %s", (test_creator,))
         assert cur.fetchone() is None
     db_connection.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Req #3096 — per-document actual-token rows cascade behavior (migration 074)
+# ---------------------------------------------------------------------------
+
+def test_delete_row_cascades_to_row_docs(db_connection):
+    """DELETE agent_telemetry_row → its per-document rows are deleted
+    (row is the container for its own documents; row_fk ON DELETE CASCADE)."""
+    test_creator = 'cascade-test-telem-creator-3'
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO profiles (id, name, email) VALUES (%s, %s, %s)",
+            (test_creator, 'Cascade Test Profile', 'cascade-telem-3@test.com')
+        )
+        cur.execute(
+            "INSERT INTO agent_telemetry_runs (label, creator_fk) VALUES (%s, %s)",
+            ('cascade-test-run-3', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        run_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO agent_telemetry_rows (run_fk, agent_name, creator_fk) "
+            "VALUES (%s, %s, %s)",
+            (run_id, 'AWS', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        row_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO agent_telemetry_row_docs (row_fk, doc_path, actual_tokens, creator_fk) "
+            "VALUES (%s, %s, %s, %s)",
+            (row_id, 'memory/aws-architecture.md', 3000, test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        doc_id = cur.fetchone()['id']
+
+        cur.execute("DELETE FROM agent_telemetry_rows WHERE id = %s", (row_id,))
+
+        cur.execute("SELECT id FROM agent_telemetry_row_docs WHERE id = %s", (doc_id,))
+        assert cur.fetchone() is None, \
+            "telemetry row_doc should be cascade-deleted when its row is deleted"
+    db_connection.rollback()
+
+
+def test_delete_run_cascades_through_rows_to_row_docs(db_connection):
+    """DELETE agent_telemetry_run → cascades TWO levels deep to its rows' own
+    per-document rows (run -> rows -> row_docs, all ON DELETE CASCADE)."""
+    test_creator = 'cascade-test-telem-creator-4'
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO profiles (id, name, email) VALUES (%s, %s, %s)",
+            (test_creator, 'Cascade Test Profile', 'cascade-telem-4@test.com')
+        )
+        cur.execute(
+            "INSERT INTO agent_telemetry_runs (label, creator_fk) VALUES (%s, %s)",
+            ('cascade-test-run-4', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        run_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO agent_telemetry_rows (run_fk, agent_name, creator_fk) "
+            "VALUES (%s, %s, %s)",
+            (run_id, 'Frontend', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        row_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO agent_telemetry_row_docs (row_fk, doc_path, actual_tokens, creator_fk) "
+            "VALUES (%s, %s, %s, %s)",
+            (row_id, 'memory/frontend-architecture.md', 5000, test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        doc_id = cur.fetchone()['id']
+
+        cur.execute("DELETE FROM agent_telemetry_runs WHERE id = %s", (run_id,))
+
+        cur.execute("SELECT id FROM agent_telemetry_row_docs WHERE id = %s", (doc_id,))
+        assert cur.fetchone() is None, \
+            "telemetry row_doc should be cascade-deleted two levels up when its run is deleted"
+    db_connection.rollback()
+
+
+def test_delete_profile_cascades_to_row_docs(db_connection):
+    """DELETE profile → its telemetry run_docs are deleted too
+    (creator_fk ON DELETE CASCADE, same as the run and row levels)."""
+    test_creator = 'cascade-test-telem-creator-5'
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO profiles (id, name, email) VALUES (%s, %s, %s)",
+            (test_creator, 'Cascade Test Profile', 'cascade-telem-5@test.com')
+        )
+        cur.execute(
+            "INSERT INTO agent_telemetry_runs (label, creator_fk) VALUES (%s, %s)",
+            ('cascade-test-run-5', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        run_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO agent_telemetry_rows (run_fk, agent_name, creator_fk) "
+            "VALUES (%s, %s, %s)",
+            (run_id, 'Data', test_creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        row_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO agent_telemetry_row_docs (row_fk, doc_path, actual_tokens, creator_fk) "
+            "VALUES (%s, %s, %s, %s)",
+            (row_id, 'memory/database.md', 2000, test_creator)
+        )
+
+        cur.execute("DELETE FROM profiles WHERE id = %s", (test_creator,))
+
+        cur.execute("SELECT id FROM agent_telemetry_row_docs WHERE creator_fk = %s", (test_creator,))
+        assert cur.fetchone() is None
+    db_connection.rollback()

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1688,6 +1688,8 @@ def test_table_count(db_connection):
         'architecture_documents', 'agent_documents',
         # Req #3031 — agent context telemetry (run header + per-agent rows)
         'agent_telemetry_runs', 'agent_telemetry_rows',
+        # Req #3096 — per-document actual-token rows (child of agent_telemetry_rows)
+        'agent_telemetry_row_docs',
     }
     assert expected_tables == tables, \
         f"Unexpected tables: {tables - expected_tables}, missing: {expected_tables - tables}"
@@ -2134,3 +2136,31 @@ def test_agent_telemetry_rows_columns(db_connection):
     assert cols['footnote']['Type'] == 'varchar(512)'
     assert cols['footnote']['Null'] == 'YES'
     assert cols['creator_fk']['Null'] == 'NO'
+
+
+# ============================================================================
+# Req #3096 — Per-document actual-token rows (migration 074)
+# ============================================================================
+
+def test_agent_telemetry_row_docs_columns(db_connection):
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'agent_telemetry_row_docs')
+    expected = {'id', 'row_fk', 'doc_path', 'actual_tokens', 'sort_order',
+                'creator_fk', 'create_ts', 'update_ts'}
+    assert set(cols.keys()) == expected
+    assert cols['id']['Key'] == 'PRI'
+    assert cols['row_fk']['Null'] == 'NO'
+    assert cols['row_fk']['Key'] == 'MUL'          # indexed FK
+    assert cols['doc_path']['Type'] == 'varchar(512)'
+    assert cols['doc_path']['Null'] == 'NO'
+    # actual_tokens is NOT NULL — unlike the parent row's phase-nullable token
+    # columns, a doc row only exists once it has been measured.
+    assert cols['actual_tokens']['Null'] == 'NO'
+    assert cols['actual_tokens']['Type'] in ('int', 'int(11)')
+    assert cols['sort_order']['Type'] == 'smallint'
+    assert cols['sort_order']['Null'] == 'YES'
+    assert cols['creator_fk']['Null'] == 'NO'
+    # Log/infra table like its parent — no title/status/closed/category_fk.
+    assert 'title' not in cols
+    assert 'closed' not in cols
+    assert 'category_fk' not in cols

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -60,6 +60,11 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
     # (e.g., 'tasks' inside 'recurring_tasks') while preserving FK constraint
     # name replacement (e.g., 'domains_ibfk_1' → 'mig_xxx_domains_ibfk_1').
     table_names = [
+        # Req #3096 — per-document actual-token rows (migration 074), child of
+        # agent_telemetry_rows. Listed before agent_telemetry_rows/runs (longest-
+        # first): agent_telemetry_row_docs must precede the shorter `agents` token
+        # so the longer match wins.
+        'agent_telemetry_row_docs',
         # Req #3031 — agent context telemetry (migration 069). Listed first
         # (longest-first): agent_telemetry_rows/runs must precede the shorter
         # `agents` token so the longer match wins.
@@ -200,6 +205,8 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         # Migration 069 — agent context telemetry (req #3031)
         'fk_agent_telemetry_runs_creator',
         'fk_agent_telemetry_rows_run', 'fk_agent_telemetry_rows_creator',
+        # Migration 074 — per-document actual-token rows (req #3096)
+        'fk_agent_telemetry_row_docs_row', 'fk_agent_telemetry_row_docs_creator',
     ]
     for cname in named_constraints:
         sql = sql.replace(cname, f'{table_prefix}_{cname}')
@@ -277,8 +284,9 @@ def _get_dependency_ordered_migrations():
 # recurring_tasks must be dropped before tasks (tasks.recurring_task_fk → recurring_tasks)
 # map_coordinates → map_runs → map_routes (FK chain)
 ALL_TABLE_SUFFIXES = [
-    # Req #3031 — agent context telemetry. FK-safe: rows (child) before runs.
-    'agent_telemetry_rows', 'agent_telemetry_runs',
+    # Req #3096 — per-document actual-token rows, child of agent_telemetry_rows.
+    # Req #3031 — agent context telemetry. FK-safe: row_docs, then rows, then runs.
+    'agent_telemetry_row_docs', 'agent_telemetry_rows', 'agent_telemetry_runs',
     # Req #2380 validation registry — FK-safe drop order (leaves first).
     # test_results → test_runs CASCADE; test_runs → test_plans RESTRICT;
     # feature_test_cases/test_plan_cases CASCADE from both sides;
@@ -481,6 +489,8 @@ def test_migration_sequence_applies(db_connection, migration_test_prefix):
             'architecture_documents', 'agent_documents',
             # Req #3031 — agent context telemetry (migration 069)
             'agent_telemetry_runs', 'agent_telemetry_rows',
+            # Req #3096 — per-document actual-token rows (migration 074)
+            'agent_telemetry_row_docs',
         ]
     }
     assert tables == expected_tables, \


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-07-26T12:40:24Z
- chore: init swarm session feature/3096-per-document-actual-token-capture-1

## Files changed
```
 migrations/074_add_agent_telemetry_row_docs.sql |  51 +++++++++++
 schema.sql                                      |  25 ++++++
 scripts/recreate_darwin_dev.sql                 |  25 +++++-
 tests/test_cascades.py                          | 115 ++++++++++++++++++++++++
 tests/test_data_types.py                        |  30 +++++++
 tests/test_migrations.py                        |  14 ++-
 6 files changed, 256 insertions(+), 4 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)