### PR TITLE
Capture machine, model, and effort for agent telemetry runs

### DIFF
--- a/migrations/074_add_machine_model_effort_to_agent_telemetry_runs.sql
+++ b/migrations/074_add_machine_model_effort_to_agent_telemetry_runs.sql
@@ -1,0 +1,39 @@
+-- 074_add_machine_model_effort_to_agent_telemetry_runs.sql
+--
+-- Req #3098: capture WHICH machine, WHICH Claude model, and WHAT effort level
+-- ran each agent-context telemetry capture.
+--
+-- agent_telemetry_runs (migration 069) already stores `captured_at` (WHEN) and
+-- `harness_version` (Claude Code build), surfaced in the /agents/context header
+-- under req #3065. It has no columns for WHERE the capture ran, or under which
+-- model/effort — some historical runs mention these informally in free-text
+-- `source_note` (e.g. "WSL Test on machine_fk=3", "per-call model:sonnet
+-- override"), but that is prose, not queryable/displayable data.
+--
+-- machine_fk: nullable FK to `machines` (req #2943, migration 064), same
+-- convention as swarm_sessions/swarm_starts/dev_servers: ON UPDATE CASCADE ON
+-- DELETE RESTRICT (a machine with capture history cannot be hard-deleted;
+-- retire it via `closed` instead).
+--
+-- ai_model / effort: NOT NULL with a fixed DEFAULT ('opus' / 'high') for BOTH
+-- the backfill of the 3 pre-existing rows AND all future inserts. This mirrors
+-- swarm_starts/swarm_completes (migration 065) rather than
+-- requirements/swarm_sessions (whose ai_model/effort are user-editable current
+-- settings, and whose swarm_sessions.effort default was later bumped to
+-- 'xhigh'): a telemetry run is a terminal capture-log row recording what
+-- already happened, not a setting someone edits going forward, so a single
+-- fixed default for "unknown historical value" is correct permanently, the
+-- same reasoning migration 065 gives for swarm_starts/swarm_completes.
+--
+-- No structured backfill of the 3 existing runs' free-text source_note here —
+-- filed as explicitly optional/low-priority in req #3098; parsing prose
+-- reliably for 3 rows isn't worth the misattribution risk. They land on the
+-- column DEFAULT like migration 065's unparseable-telemetry rows do.
+
+ALTER TABLE agent_telemetry_runs
+    ADD COLUMN ai_model   VARCHAR(16) NOT NULL DEFAULT 'opus' AFTER source_note,
+    ADD COLUMN effort     VARCHAR(16) NOT NULL DEFAULT 'high' AFTER ai_model,
+    ADD COLUMN machine_fk INT         NULL                    AFTER effort,
+    ADD CONSTRAINT fk_agent_telemetry_runs_machine
+        FOREIGN KEY (machine_fk) REFERENCES machines (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT;

--- a/schema.sql
+++ b/schema.sql
@@ -982,12 +982,21 @@ CREATE TABLE IF NOT EXISTS agent_telemetry_runs (
     agent_count      INT          NOT NULL DEFAULT 0,
     harness_version  VARCHAR(64)  NULL,
     source_note      TEXT         NULL,
+    ai_model         VARCHAR(16)  NOT NULL DEFAULT 'opus',
+                                            -- req #3098, migration 074; fixed default for both backfill and future rows (capture-log row, not an editable setting)
+    effort           VARCHAR(16)  NOT NULL DEFAULT 'high',
+                                            -- req #3098, migration 074; see ai_model comment
+    machine_fk       INT          NULL,
+                                            -- req #3098, migration 074; which machine ran the capture (NULL = unknown)
     creator_fk       VARCHAR(64)  NOT NULL,
     create_ts        TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
     update_ts        TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
     CONSTRAINT fk_agent_telemetry_runs_creator
         FOREIGN KEY (creator_fk) REFERENCES profiles (id)
-        ON UPDATE CASCADE ON DELETE CASCADE
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_agent_telemetry_runs_machine
+        FOREIGN KEY (machine_fk) REFERENCES machines (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT
 );
 
 CREATE INDEX ix_agent_telemetry_runs_captured_at ON agent_telemetry_runs (captured_at);

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -914,12 +914,18 @@ CREATE TABLE agent_telemetry_runs (
     agent_count      INT          NOT NULL DEFAULT 0,
     harness_version  VARCHAR(64)  NULL,
     source_note      TEXT         NULL,
+    ai_model         VARCHAR(16)  NOT NULL DEFAULT 'opus',
+    effort           VARCHAR(16)  NOT NULL DEFAULT 'high',
+    machine_fk       INT          NULL,
     creator_fk       VARCHAR(64)  NOT NULL,
     create_ts        TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
     update_ts        TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
     CONSTRAINT fk_agent_telemetry_runs_creator
         FOREIGN KEY (creator_fk) REFERENCES profiles (id)
-        ON UPDATE CASCADE ON DELETE CASCADE
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_agent_telemetry_runs_machine
+        FOREIGN KEY (machine_fk) REFERENCES machines (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT
 );
 
 CREATE INDEX ix_agent_telemetry_runs_captured_at ON agent_telemetry_runs (captured_at);

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -2087,7 +2087,8 @@ def test_agent_telemetry_runs_columns(db_connection):
     with db_connection.cursor() as cur:
         cols = _columns(cur, 'agent_telemetry_runs')
     expected = {'id', 'captured_at', 'label', 'agent_count', 'harness_version',
-                'source_note', 'creator_fk', 'create_ts', 'update_ts'}
+                'source_note', 'ai_model', 'effort', 'machine_fk',
+                'creator_fk', 'create_ts', 'update_ts'}
     assert set(cols.keys()) == expected
     assert cols['id']['Key'] == 'PRI'
     assert cols['captured_at']['Null'] == 'NO'
@@ -2099,6 +2100,15 @@ def test_agent_telemetry_runs_columns(db_connection):
     assert cols['harness_version']['Null'] == 'YES'
     assert cols['source_note']['Type'] == 'text'
     assert cols['source_note']['Null'] == 'YES'
+    # req #3098, migration 074 — fixed default for both backfill and future rows.
+    assert cols['ai_model']['Type'] == 'varchar(16)'
+    assert cols['ai_model']['Null'] == 'NO'
+    assert cols['ai_model']['Default'] == 'opus'
+    assert cols['effort']['Type'] == 'varchar(16)'
+    assert cols['effort']['Null'] == 'NO'
+    assert cols['effort']['Default'] == 'high'
+    assert cols['machine_fk']['Null'] == 'YES'
+    assert cols['machine_fk']['Key'] == 'MUL'          # indexed FK
     assert cols['creator_fk']['Null'] == 'NO'
     # Log/infra table — no title/status/closed/category_fk/sort_order on the header.
     assert 'title' not in cols

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -200,6 +200,8 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         # Migration 069 — agent context telemetry (req #3031)
         'fk_agent_telemetry_runs_creator',
         'fk_agent_telemetry_rows_run', 'fk_agent_telemetry_rows_creator',
+        # Migration 074 — machine/model/effort on agent telemetry runs (req #3098)
+        'fk_agent_telemetry_runs_machine',
     ]
     for cname in named_constraints:
         sql = sql.replace(cname, f'{table_prefix}_{cname}')


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-07-26T22:03:25Z
- wip(DarwinSQL): 2026-07-26T21:50:03Z
- chore: init swarm session feature/3098-capture-machine-model-and-effort-on-1

## Files changed
```
 ...achine_model_effort_to_agent_telemetry_runs.sql | 39 ++++++++++++++++++++++
 schema.sql                                         | 11 +++++-
 scripts/recreate_darwin_dev.sql                    |  8 ++++-
 tests/test_data_types.py                           | 12 ++++++-
 tests/test_migrations.py                           |  2 ++
 5 files changed, 69 insertions(+), 3 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)