### PR TITLE
req #3129

### DIFF
--- a/migrations/20260727091519_add_principles_role_to_agent_documents_relationship.sql
+++ b/migrations/20260727091519_add_principles_role_to_agent_documents_relationship.sql
@@ -1,0 +1,85 @@
+-- 20260727091519_add_principles_role_to_agent_documents_relationship.sql
+--
+-- Req #3129: give every agent ONE guiding-principles document, identified by a
+-- role on the existing agent_documents link rather than by a new column or table.
+--
+-- PROBLEM.  Nothing in the data marks which of an agent's documents carries its
+--           guiding principles, so nothing can load it first or render it apart
+--           from the rest. In practice the eleven `*-architect-charter.md` files
+--           already ARE that document -- req #3129's audit found 54 of 78
+--           instruction rows were verbatim restatements of them -- but that
+--           status lives only in a naming convention, which no query can read.
+--
+-- SHAPE.    One new role in the `relationship` SET, plus a uniqueness rule that
+--           is the MIRROR IMAGE of the existing owner rule:
+--
+--             uq_agent_documents_owner       one 'owned' link per DOCUMENT
+--             uq_agent_documents_principles  one 'principles' link per AGENT
+--
+--           Hence the new virtual column keys on `agent_fk`, NOT `document_fk`.
+--           Copying the owner rule verbatim would have let one agent hold many
+--           principles documents while forbidding two agents from each having
+--           their own -- exactly backwards. MySQL has no partial index, so the
+--           same VIRTUAL-generated-column-plus-UNIQUE trick applies: the column
+--           is NULL unless the SET contains 'principles', and NULLs are distinct
+--           in a MySQL UNIQUE key, so unlimited non-principles links coexist.
+--
+--           Why not an `agents.principles` TEXT column? It would be editable in
+--           the UI but would break the standing rule that `agents` stays narrow
+--           and all growth lands in instruction/document ROWS -- and it would
+--           strand the content outside git, losing PR review of doctrine.
+--           Tagging a document keeps the file, its history, and its review, and
+--           the UI already knows how to render and link a document.
+--
+--           ORDER MATTERS BELOW: the SET must accept 'principles' before any row
+--           can carry it, and the generated column's expression references the
+--           SET, so the MODIFY runs first.
+--
+-- APPLY.    darwin_dev FIRST, production SECOND. Two separate commands -- the
+--           only difference is the trailing database name, so read it twice:
+--
+--             python3 DarwinSQL/scripts/load_sql.py \
+--               DarwinSQL/migrations/20260727091519_add_principles_role_to_agent_documents_relationship.sql darwin_dev
+--
+--             python3 DarwinSQL/scripts/load_sql.py \
+--               DarwinSQL/migrations/20260727091519_add_principles_role_to_agent_documents_relationship.sql darwin
+--
+--           The production command above requires
+--           `bash scripts/db/rds-snapshot.sh 20260727091519` to report status=ok
+--           first. See memory/database.md § Schema Migration Workflow.
+--
+--           NOTE: agent_documents is a PRODUCTION table -- the registry daemon
+--           runs with DB_NAME=darwin -- so unlike most Darwin features this one
+--           is not exercised by real data until the production apply lands.
+--
+-- Migration id 20260727091519 is a UTC timestamp allocated by
+-- DarwinSQL/scripts/new-migration.sh (req #3121). Do not renumber it.
+
+-- 1. Widen the SET so a link may carry the new role.
+--    'principles' is listed FIRST: it is the highest-precedence role, and the
+--    services layer ranks roles in this same declared order.
+ALTER TABLE agent_documents
+    MODIFY COLUMN relationship
+        SET('principles','owned','curated','autoload','referenced')
+        NOT NULL DEFAULT 'referenced';
+
+-- 2. One principles document per AGENT, enforced the way the one-owner rule is.
+--    Guarded on INFORMATION_SCHEMA so a re-run is a no-op rather than an error
+--    (ADD COLUMN is not idempotent on its own).
+SET @col_exists := (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME   = 'agent_documents'
+      AND COLUMN_NAME  = 'principles_agent_fk'
+);
+
+SET @ddl := IF(@col_exists = 0,
+    'ALTER TABLE agent_documents
+        ADD COLUMN principles_agent_fk INT
+            AS (IF(FIND_IN_SET(''principles'', relationship) > 0, agent_fk, NULL)) VIRTUAL,
+        ADD UNIQUE KEY uq_agent_documents_principles (principles_agent_fk)',
+    'SELECT ''principles_agent_fk already present - skipping'' AS note');
+
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/schema.sql
+++ b/schema.sql
@@ -1006,12 +1006,17 @@ CREATE TABLE IF NOT EXISTS architecture_documents (
 CREATE TABLE IF NOT EXISTS agent_documents (
     agent_fk           INT          NOT NULL,
     document_fk        INT          NOT NULL,
-    relationship       SET('owned','curated','autoload','referenced') NOT NULL DEFAULT 'referenced',
+    relationship       SET('principles','owned','curated','autoload','referenced') NOT NULL DEFAULT 'referenced',
     notes              VARCHAR(512) NULL,
     sort_order         SMALLINT     NULL,
     owned_document_fk  INT          AS (IF(FIND_IN_SET('owned', relationship) > 0, document_fk, NULL)) VIRTUAL,
+    -- req #3129: the MIRROR IMAGE of the owner rule -- one 'owned' link per
+    -- DOCUMENT, one 'principles' link per AGENT. Note the key column differs:
+    -- document_fk above, agent_fk here. Swapping them inverts both rules.
+    principles_agent_fk INT         AS (IF(FIND_IN_SET('principles', relationship) > 0, agent_fk, NULL)) VIRTUAL,
     PRIMARY KEY (agent_fk, document_fk),
     UNIQUE KEY uq_agent_documents_owner (owned_document_fk),
+    UNIQUE KEY uq_agent_documents_principles (principles_agent_fk),
     CONSTRAINT fk_ad_agent
         FOREIGN KEY (agent_fk) REFERENCES agents (id)
         ON UPDATE CASCADE ON DELETE CASCADE,

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -932,12 +932,16 @@ CREATE TABLE architecture_documents (
 CREATE TABLE agent_documents (
     agent_fk           INT          NOT NULL,
     document_fk        INT          NOT NULL,
-    relationship       SET('owned','curated','autoload','referenced') NOT NULL DEFAULT 'referenced',
+    relationship       SET('principles','owned','curated','autoload','referenced') NOT NULL DEFAULT 'referenced',
     notes              VARCHAR(512) NULL,
     sort_order         SMALLINT     NULL,
     owned_document_fk  INT          AS (IF(FIND_IN_SET('owned', relationship) > 0, document_fk, NULL)) VIRTUAL,
+    -- req #3129: mirror image of the owner rule -- one 'owned' per DOCUMENT,
+    -- one 'principles' per AGENT. The key column differs on purpose.
+    principles_agent_fk INT         AS (IF(FIND_IN_SET('principles', relationship) > 0, agent_fk, NULL)) VIRTUAL,
     PRIMARY KEY (agent_fk, document_fk),
     UNIQUE KEY uq_agent_documents_owner (owned_document_fk),
+    UNIQUE KEY uq_agent_documents_principles (principles_agent_fk),
     CONSTRAINT fk_ad_agent
         FOREIGN KEY (agent_fk) REFERENCES agents (id)
         ON UPDATE CASCADE ON DELETE CASCADE,

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -2088,18 +2088,25 @@ def test_agent_documents_columns(db_connection):
     document': a VIRTUAL generated column equal to document_fk only on an 'owned'
     row (NULL otherwise), carrying a UNIQUE key. MySQL has no partial index, and
     NULLs are distinct in a UNIQUE key — so unlimited non-owned links coexist
-    while a second 'owned' claim raises IntegrityError."""
+    while a second 'owned' claim raises IntegrityError.
+
+    principles_agent_fk (req #3129) is the same machinery pointed the OTHER WAY:
+    one 'owned' link per DOCUMENT, one 'principles' link per AGENT. It is keyed
+    on agent_fk, not document_fk — the assertion below is what catches that
+    inversion, because both columns are INT/VIRTUAL/UNIQUE and are otherwise
+    indistinguishable from a DESCRIBE."""
     with db_connection.cursor() as cur:
         cols = _columns(cur, 'agent_documents')
     expected = {'agent_fk', 'document_fk', 'relationship', 'notes',
-                'sort_order', 'owned_document_fk'}
+                'sort_order', 'owned_document_fk', 'principles_agent_fk'}
     assert set(cols.keys()) == expected
 
     assert cols['agent_fk']['Null'] == 'NO'
     assert cols['agent_fk']['Key'] == 'PRI'
     assert cols['document_fk']['Null'] == 'NO'
     assert cols['document_fk']['Key'] == 'PRI'
-    assert cols['relationship']['Type'] == "set('owned','curated','autoload','referenced')"
+    assert cols['relationship']['Type'] == \
+        "set('principles','owned','curated','autoload','referenced')"
     assert cols['relationship']['Null'] == 'NO'
     assert cols['relationship']['Default'] == 'referenced'
     assert cols['notes']['Type'] == 'varchar(512)'
@@ -2109,6 +2116,41 @@ def test_agent_documents_columns(db_connection):
     # storage) and UNIQUE.
     assert 'VIRTUAL GENERATED' in cols['owned_document_fk']['Extra'].upper()
     assert cols['owned_document_fk']['Key'] == 'UNI'
+
+    # req #3129: same machinery, opposite key column.
+    assert 'VIRTUAL GENERATED' in cols['principles_agent_fk']['Extra'].upper()
+    assert cols['principles_agent_fk']['Key'] == 'UNI'
+
+
+def test_agent_documents_principles_is_keyed_per_agent(db_connection):
+    """req #3129 — the generated-column EXPRESSION, not just its shape.
+
+    A DESCRIBE cannot tell principles_agent_fk from owned_document_fk: both are
+    INT, VIRTUAL and UNIQUE. Only the expression distinguishes 'one per agent'
+    from 'one per document', and getting it backwards would let one agent hold
+    many principles documents while forbidding two agents from each having their
+    own. Assert the expression text directly."""
+    with db_connection.cursor() as cur:
+        cur.execute("""
+            SELECT COLUMN_NAME, GENERATION_EXPRESSION
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = 'agent_documents'
+              AND GENERATION_EXPRESSION <> ''
+        """)
+        # DictCursor — rows are dicts, not tuples.
+        exprs = {r['COLUMN_NAME']: r['GENERATION_EXPRESSION']
+                 for r in cur.fetchall()}
+
+    assert set(exprs) == {'owned_document_fk', 'principles_agent_fk'}
+    owned = exprs['owned_document_fk'].replace('`', '').replace(' ', '')
+    principles = exprs['principles_agent_fk'].replace('`', '').replace(' ', '')
+
+    assert 'owned' in owned and 'document_fk' in owned
+    assert 'principles' in principles
+    # The whole point: keyed on agent_fk, and NOT on document_fk.
+    assert 'agent_fk' in principles
+    assert 'document_fk' not in principles
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- feat(3129): add principles role to agent_documents.relationship
- chore: init swarm session feature/3129-instructions-refactor-1

## Files changed
```
 ...ciples_role_to_agent_documents_relationship.sql | 85 ++++++++++++++++++++++
 schema.sql                                         |  7 +-
 scripts/recreate_darwin_dev.sql                    |  6 +-
 tests/test_data_types.py                           | 48 +++++++++++-
 4 files changed, 141 insertions(+), 5 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Related PRs (req #3129): DarwinAI-Config #683 · DarwinSQL #100 · Darwin #862