### PR TITLE
Pause enforcement: stop swarm-starting a paused scope, and the pause/unpause commands

### DIFF
--- a/migrations/20260801125029_add_epics_epic_status_for_pause_enforcement.sql
+++ b/migrations/20260801125029_add_epics_epic_status_for_pause_enforcement.sql
@@ -1,0 +1,79 @@
+-- 20260801125029_add_epics_epic_status_for_pause_enforcement.sql
+--
+-- Req #3223: give an EPIC a durable, shared "do not swarm-start this" state, so
+-- pause enforcement has somewhere to live at epic scope.
+--
+-- PROBLEM.  Pause exists today only as an AGREEMENT. `pipelines.pipeline_status`
+--           already carries the value `paused`, but nothing reads it: the
+--           Pipeline Engine's only reference to the column is a comment saying
+--           it does not touch it, and the derivation never consults it — so a
+--           step on a paused plan derives eligible exactly as on an active one,
+--           and `/pipeline-start` silently flipped `paused` to `active` without
+--           a word. At EPIC scope there was no state at all: `epics` carries
+--           `closed` and nothing else, and `closed` is a lifecycle fact ("this
+--           epic is finished"), not a suppression one ("don't start its work
+--           right now"). Overloading `closed` for pause would make finishing an
+--           epic and parking it the same act.
+--
+--           The consequence is the failure this requirement names: two parties
+--           can both believe a plan is paused while work launches. That belief
+--           has to survive a Claude session ending, a different machine picking
+--           the plan up, and a night with no engine running at all — which is
+--           what makes it a COLUMN in the shared database rather than anything
+--           held by a process.
+--
+-- SHAPE.    One VARCHAR(16) on `epics`, `NOT NULL DEFAULT 'active'`, values
+--           `active` | `paused`.
+--
+--           A STATUS COLUMN, not a boolean and not a new table:
+--
+--             * It matches every sibling in this schema — `pipeline_status`,
+--               `requirement_status`, `feature_status`, `swarm_status` — so an
+--               epic's suppression state is read, written and rendered exactly
+--               like everything else's, and `darwin://pipeline/{id}` picks it up
+--               for free on a row it already fetches (design rule 5's fixed
+--               seven gateway reads is unchanged).
+--             * A scope-keyed pause TABLE would be the shape that could express
+--               "paused in THAT plan". It is deliberately NOT built: an epic
+--               seated in two pipelines is hypothetical today, and the moment it
+--               stops being hypothetical is the moment that table becomes
+--               justified. The LIMIT is therefore stated rather than designed
+--               around — pausing an epic pauses it everywhere it is seated.
+--
+--           TWO VALUES ONLY, and no `draft`/`completed`/`aborted` alongside
+--           them. An epic's lifecycle is already `closed`; adding a parallel
+--           lifecycle enum here would create two columns that can disagree about
+--           whether an epic is finished. This column answers exactly one
+--           question — may this epic's work be swarm-started — and every value
+--           it has is an answer to it.
+--
+--           NOT NULL DEFAULT 'active' backfills every existing row to the only
+--           safe answer: nothing that was launching yesterday stops launching
+--           because this column appeared.
+--
+--           No index. `epics` holds single-digit rows, and every read of this
+--           column arrives by primary key or as part of a whole-table list.
+--
+--           Not an FK and not creator-scoped by itself, so `CREATOR_FK_TABLES`
+--           / `CREATOR_TABLE_REFERENCES` (Lambda-Rest/auth_utils.py) are
+--           unchanged: `epics` already carries `creator_fk`, and this adds no
+--           column that POINTS at another creator-scoped row.
+--
+-- APPLY.    darwin_dev FIRST, production SECOND. Two separate commands — the
+--           only difference is the trailing database name, so read it twice:
+--
+--             python3 DarwinSQL/scripts/load_sql.py \
+--               DarwinSQL/migrations/20260801125029_add_epics_epic_status_for_pause_enforcement.sql darwin_dev
+--
+--             python3 DarwinSQL/scripts/load_sql.py \
+--               DarwinSQL/migrations/20260801125029_add_epics_epic_status_for_pause_enforcement.sql darwin
+--
+--           The production command above requires
+--           `bash scripts/db/rds-snapshot.sh 20260801125029` to report status=ok
+--           first. See memory/database.md § Schema Migration Workflow.
+--
+-- Migration id 20260801125029 is a UTC timestamp allocated by
+-- DarwinSQL/scripts/new-migration.sh (req #3121). Do not renumber it.
+
+ALTER TABLE epics
+    ADD COLUMN epic_status VARCHAR(16) NOT NULL DEFAULT 'active' AFTER description;

--- a/schema.sql
+++ b/schema.sql
@@ -184,6 +184,18 @@ CREATE TABLE IF NOT EXISTS epics (
     id           INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
     title        VARCHAR(256) NOT NULL,
     description  TEXT         NULL,
+    epic_status  VARCHAR(16)  NOT NULL DEFAULT 'active',  -- active|paused (req #3223,
+                                            -- migration 20260801125029). SUPPRESSION, not
+                                            -- lifecycle: `closed` still says an epic is
+                                            -- finished, this says whether its work may be
+                                            -- swarm-started. `paused` stops the Pipeline
+                                            -- Engine announcing launches for the epic's
+                                            -- steps under ANY orchestrator — an epic-scoped
+                                            -- one and a whole-plan one alike — and nothing
+                                            -- else: orchestration, running sessions and a
+                                            -- directly user-initiated /swarm-start are all
+                                            -- unaffected. Read for free by
+                                            -- darwin://pipeline/{id}.
     category_fk  INT          NOT NULL,
     creator_fk   VARCHAR(64)  NOT NULL,
     closed       TINYINT(1)   NOT NULL DEFAULT 0,

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -184,6 +184,9 @@ CREATE TABLE epics (
     id           INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
     title        VARCHAR(256) NOT NULL,
     description  TEXT         NULL,
+    epic_status  VARCHAR(16)  NOT NULL DEFAULT 'active',  -- active|paused (req #3223,
+                                            -- migration 20260801125029). SUPPRESSION, not
+                                            -- lifecycle — see schema.sql for the full note.
     category_fk  INT          NOT NULL,
     creator_fk   VARCHAR(64)  NOT NULL,
     closed       TINYINT(1)   NOT NULL DEFAULT 0,

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -2289,13 +2289,19 @@ def test_agent_telemetry_row_docs_columns(db_connection):
 # ============================================================================
 
 def test_epics_columns(db_connection):
-    """epics is a CONTENT table: full baseline, no status enum (MVP discipline —
-    an epic is open until its features are done; a second hand-maintained
-    lifecycle buys nothing)."""
+    """epics is a CONTENT table, plus ONE status column and it is not a lifecycle.
+
+    `closed` remains the lifecycle answer — an epic is open until its features
+    are done, and a second hand-maintained lifecycle enum buys nothing. What req
+    #3223 added is a SUPPRESSION answer, which `closed` cannot give: "do not
+    swarm-start this epic's work right now" is not "this epic is finished", and
+    overloading `closed` would make parking an epic and completing it the same
+    act. See `test_epics_status_is_suppression_not_lifecycle` below.
+    """
     with db_connection.cursor() as cur:
         cols = _columns(cur, 'epics')
-    expected = {'id', 'title', 'description', 'category_fk', 'creator_fk',
-                'closed', 'sort_order', 'create_ts', 'update_ts'}
+    expected = {'id', 'title', 'description', 'epic_status', 'category_fk',
+                'creator_fk', 'closed', 'sort_order', 'create_ts', 'update_ts'}
     assert set(cols.keys()) == expected
 
     assert cols['id']['Type'] == 'int'
@@ -2325,9 +2331,32 @@ def test_epics_columns(db_connection):
     assert cols['sort_order']['Type'] == 'smallint'
     assert cols['sort_order']['Null'] == 'YES'
 
-    # No lifecycle enum — deliberate.
-    assert 'epic_status' not in cols
+    # No SECOND lifecycle column — still deliberate. `closed` is the lifecycle;
+    # `epic_status` (asserted below) answers a different question entirely.
     assert 'status' not in cols
+
+
+def test_epics_status_is_suppression_not_lifecycle(db_connection):
+    """req #3223, migration 20260801125029 — `epics.epic_status`.
+
+    NOT NULL DEFAULT 'active' is the load-bearing part: every epic that existed
+    before this column backfills to the only safe answer, so nothing that was
+    launching yesterday stops launching because a column appeared.
+
+    VARCHAR(16), matching `pipelines.pipeline_status` /
+    `requirements.requirement_status` / `features.feature_status` rather than an
+    ENUM, because every status column in this schema is a VARCHAR whose value set
+    is enforced in the service layer — an ENUM here would be the one table where
+    adding a value needs DDL.
+    """
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'epics')
+    assert cols['epic_status']['Type'] == 'varchar(16)'
+    assert cols['epic_status']['Null'] == 'NO'
+    assert cols['epic_status']['Default'] == 'active'
+    # Unindexed on purpose: `epics` holds single-digit rows and every read of
+    # this column arrives by primary key or as part of a whole-table list.
+    assert cols['epic_status']['Key'] == ''
 
 
 def test_features_epic_fk_column(db_connection):


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-08-01T14:51:49Z
- chore: init swarm session feature/3223-pause-enforcement-stop-swarm-1

## Files changed
```
 ...add_epics_epic_status_for_pause_enforcement.sql | 79 ++++++++++++++++++++++
 schema.sql                                         | 12 ++++
 scripts/recreate_darwin_dev.sql                    |  3 +
 tests/test_data_types.py                           | 43 ++++++++++--
 4 files changed, 130 insertions(+), 7 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)