### PR TITLE
Blast-radius verification of execution_mode after #3388 lands

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,5 +1,5 @@
 -- Darwin Database Schema — Current State
--- This file reflects the final state of all 52 tables after all migrations.
+-- This file reflects the final state of all 53 tables after all migrations.
 -- It can be run against a fresh MySQL instance to create the complete schema.
 -- Table order respects FK dependencies.
 --
@@ -1213,6 +1213,10 @@ CREATE TABLE IF NOT EXISTS pipelines (
     title           VARCHAR(256) NOT NULL,
     description     TEXT         NULL,                     -- the goal
     pipeline_status VARCHAR(16)  NOT NULL DEFAULT 'draft', -- draft|active|paused|completed|aborted
+    execution_mode  ENUM('parallel', 'serial')
+                              NOT NULL DEFAULT 'parallel', -- req #3388: parallel = every epic at
+                                                           -- once; serial = one at a time, live
+                                                           -- epic DERIVED
     machine_fk      INT          NULL DEFAULT NULL,        -- NULL = any machine
     creator_fk      VARCHAR(64)  NOT NULL,
     started_at      TIMESTAMP    NULL,                     -- set on draft -> active (NULL-able: a

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -1,10 +1,10 @@
 -- Recreate darwin_dev test/dev tables from scratch
 -- Uses production-identical table names (same DDL as schema.sql)
 -- Idempotent: safe to run repeatedly to reset darwin_dev to canonical state
--- All 52 tables in FK-dependency order
+-- All 53 tables in FK-dependency order
 --
 -- ============================================================================
--- THIS FILE DROPS 52 TABLES. (req #3196)
+-- THIS FILE DROPS 53 TABLES. (req #3196)
 -- ============================================================================
 -- It opened with `USE darwin_dev;`, which LOOKED like protection and was not:
 -- a `USE` is a statement the caller's loader may strip, reorder or never reach,
@@ -39,6 +39,8 @@ DROP TABLE IF EXISTS orchestration_claims,
     map_views, map_coordinates, map_runs, map_routes,
     priority_card_order, dev_servers,
     swarm_undos,
+    branch_acceptance_tests, acceptance_tests,
+    swarm_complete_sessions, swarm_completes,
     swarm_start_sessions, swarm_starts,
     requirement_sessions,
     requirements, swarm_sessions, machines, categories, projects,
@@ -1093,6 +1095,10 @@ CREATE TABLE pipelines (
     title           VARCHAR(256) NOT NULL,
     description     TEXT         NULL,                     -- the goal
     pipeline_status VARCHAR(16)  NOT NULL DEFAULT 'draft', -- draft|active|paused|completed|aborted
+    execution_mode  ENUM('parallel', 'serial')
+                              NOT NULL DEFAULT 'parallel', -- req #3388: parallel = every epic at
+                                                           -- once; serial = one at a time, live
+                                                           -- epic DERIVED
     machine_fk      INT          NULL DEFAULT NULL,
     creator_fk      VARCHAR(64)  NOT NULL,
     started_at      TIMESTAMP    NULL,

--- a/tests/test_sql_targets.py
+++ b/tests/test_sql_targets.py
@@ -155,7 +155,7 @@ def test_restricted_files_declare_their_target(relpath, expected):
 
 
 def test_recreate_darwin_dev_is_declared_destructive():
-    """It DROPs 52 tables. `--destructive` is the only way it runs."""
+    """It DROPs 53 tables. `--destructive` is the only way it runs."""
     path = os.path.join(DARWINSQL_ROOT, 'scripts', 'recreate_darwin_dev.sql')
     with open(path) as handle:
         body = handle.read()
@@ -163,6 +163,34 @@ def test_recreate_darwin_dev_is_declared_destructive():
     assert 'darwin' not in db_guard.declared_targets(body), (
         'recreate_darwin_dev.sql must never list production as a target — that '
         'list is the absolute ban'
+    )
+
+
+def test_recreate_darwin_dev_drop_list_matches_create_list():
+    """The `DROP TABLE IF EXISTS` list must name exactly the tables this file creates.
+
+    Req #3395: `execution_mode` surfaced a pre-existing, independent bug — the DROP
+    list was missing `acceptance_tests`, `branch_acceptance_tests`,
+    `swarm_complete_sessions` and `swarm_completes`, all four created later in this
+    same file. Running the destructive rebuild against a database that already had
+    them died partway through with MySQL 1050 ("table already exists"), having
+    already dropped most of `darwin_dev` first — a hand-maintained list nothing
+    verified. A table CREATEd here but not DROPped first makes every future rebuild
+    fail the same way; a table DROPped here but never CREATEd back would leave
+    `darwin_dev` permanently missing it. Both directions are a hard failure, not a
+    style nit — this file is destructive and shared.
+    """
+    path = os.path.join(DARWINSQL_ROOT, 'scripts', 'recreate_darwin_dev.sql')
+    with open(path) as handle:
+        body = handle.read()
+    drop_section = re.search(r'DROP TABLE IF EXISTS(.*?);', body, re.S)
+    assert drop_section, 'no DROP TABLE IF EXISTS statement found'
+    dropped = {name for name in re.findall(r'(\w+)', drop_section.group(1))}
+    created = set(re.findall(r'CREATE TABLE (\w+)', body))
+    assert dropped == created, (
+        f'DROP/CREATE table-list mismatch — created but not dropped: '
+        f'{sorted(created - dropped)}; dropped but not created: '
+        f'{sorted(dropped - created)}'
     )
 
 


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-08-08T11:37:13Z
- chore: init swarm session feature/3395-blast-radius-verification-of-1

## Files changed
```
 schema.sql                      |  6 +++++-
 scripts/recreate_darwin_dev.sql | 10 ++++++++--
 tests/test_sql_targets.py       | 30 +++++++++++++++++++++++++++++-
 3 files changed, 42 insertions(+), 4 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)