### PR TITLE
Pipeline 2.0 - the five parallel plan-layer tables, registration and test surfaces

### DIFF
--- a/migrations/20260808115509_pipeline2_plan_layer_tables.sql
+++ b/migrations/20260808115509_pipeline2_plan_layer_tables.sql
@@ -1,0 +1,252 @@
+-- 20260808115509_pipeline2_plan_layer_tables.sql
+--
+-- Req #3337: create the five Pipeline 2.0 plan-layer tables in darwin_dev.
+--
+-- PROBLEM.  Pipeline 2.0 (req #3322/#3328) is a first-principles rebuild of the
+--           pipeline layer onto one containment chain — Pipeline -> Epic ->
+--           Step -> Requirement — where the Step is the launch unit carrying
+--           many requirements. It stands up beside 1.0 on parallel tables
+--           until the old era is eradicated; this migration is that stand-up.
+--
+-- SHAPE.    Five tables, `pipeline2_`-prefixed (the era token; not a `_v2`
+--           suffix — see memory/pipeline-2-data-architecture.md § 2). Full
+--           design and rationale in that document § 3; the two columns below
+--           differ from it per the stage-2 gate deltas (req #3336, which win
+--           where the record disagrees):
+--             - `pipeline2_epics.sort_order` is NULLABLE, no default (not the
+--               record's NOT NULL DEFAULT 0): NULL = derived order, a value =
+--               manual placement that wins.
+--             - `pipeline2_step_requirements` carries PRIMARY KEY
+--               (requirement_fk) ALONE, `step_fk` NOT NULL beside it — one
+--               step per requirement, structural. No composite key, and no
+--               `ix_p2_psr_requirement_fk` (the PK already serves it).
+--
+-- TARGET.   NEVER write `USE <db>;` or `CREATE DATABASE` into this file. A
+--           `USE` is a statement, not a declaration: it re-points the session
+--           the moment it executes and overrides whatever database the caller
+--           named — which on 2026-08-01 sent a dev-aimed apply to production.
+--           load_sql.py REFUSES a file that names its own database, and
+--           DarwinSQL/tests/test_sql_targets.py fails the build (req #3196).
+--           No `-- darwin:targets` declaration here, deliberately: unlike a
+--           file with a real database-specific constraint, this migration is
+--           ordinary DDL that both eras' operators will eventually run against
+--           `darwin` — declaring `darwin_dev` would be a target list omitting
+--           production, which db_guard.py treats as an ABSOLUTE, unoverridable
+--           ban and would make it impossible for req #3339 to ever apply this
+--           exact file to production. req #3337's own scope (darwin_dev only,
+--           right now) is enforced procedurally — by which command is actually
+--           run below — not by a DDL-level restriction on the file itself.
+--
+-- APPLY.    darwin_dev only, for this requirement:
+--
+--             python3 DarwinSQL/scripts/load_sql.py \
+--               DarwinSQL/migrations/20260808115509_pipeline2_plan_layer_tables.sql darwin_dev
+--
+--           Production application is req #3339's, not this requirement's:
+--
+--             python3 DarwinSQL/scripts/load_sql.py \
+--               DarwinSQL/migrations/20260808115509_pipeline2_plan_layer_tables.sql darwin --production
+--
+-- Migration id 20260808115509 is a UTC timestamp allocated by
+-- DarwinSQL/scripts/new-migration.sh (req #3121). Do not renumber it.
+
+-- ---------------------------------------------------------------------------
+-- Pipeline 2.0 — the plan layer (req #3328 design; parallel era)
+-- ---------------------------------------------------------------------------
+-- FIVE tables standing BESIDE the 1.0 five, not replacing them. Both eras run
+-- at once until 1.0 is eradicated, and requirements are NOT doubled: one
+-- `requirements` table carries two plan layers above it, because duplicating a
+-- requirement row would split its sessions, history and identity across two ids
+-- for the same work.
+--
+-- CONTAINMENT IS IN THE DDL, NOT IN CONVENTION. An epic belongs to exactly one
+-- pipeline and a step to exactly one epic, both NOT NULL. That single change is
+-- what removes the session-attribution tie-break, gives epic pause a scope key,
+-- makes reservation scoping a containment question rather than an inferred one,
+-- and turns display order into a tree walk.
+--
+-- Containment STOPS at Requirement: a step ORGANIZES requirements and does not
+-- own them, so membership is an edge table. Three levels of ownership, one of
+-- membership — the one asymmetry in the chain, and deliberate.
+
+CREATE TABLE IF NOT EXISTS pipeline2_pipelines (
+    id              INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title           VARCHAR(256) NOT NULL,
+    description     TEXT         NULL,                     -- the goal; PURPOSE only (design rule 11)
+    pipeline_status VARCHAR(16)  NOT NULL DEFAULT 'draft', -- draft|active|paused|completed|aborted
+    execution_mode  ENUM('parallel', 'serial')
+                                 NOT NULL DEFAULT 'parallel', -- req #3388: parallel = every epic at
+                                                              -- once; serial = one at a time, live
+                                                              -- epic DERIVED. Carried forward from
+                                                              -- 1.0 `pipelines` — a real plan
+                                                              -- property, not 1.0-specific debt, so
+                                                              -- the #3356 importer must copy it.
+    machine_fk      INT          NULL DEFAULT NULL,        -- NULL = any machine
+    creator_fk      VARCHAR(64)  NOT NULL,
+    started_at      TIMESTAMP    NULL,                     -- derived from the status transition
+    completed_at    TIMESTAMP    NULL,                     -- ditto; never passed by a caller
+    create_ts       TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_p2_pipelines_machine
+        FOREIGN KEY (machine_fk) REFERENCES machines (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_p2_pipelines_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+-- `pipeline_fk` NOT NULL is the containment. An epic cannot float free and
+-- cannot be reached from a second plan, which is what makes `epic_status` a
+-- scoped pause rather than a global one: 1.0's epic pause has no scope key, so
+-- pausing an epic pauses it in every plan holding it.
+--
+-- `category_fk` is DISPLAY ONLY and gates nothing. An epic owns its steps; it
+-- does not govern their attributes, and the work of one epic routinely spans
+-- several categories. It must not be read by orchestration, launch, repo
+-- resolution or any eligibility predicate — the category that matters is the one
+-- on the requirement, which the requirement already carries.
+--
+-- `sort_order` IS LOAD-BEARING HERE, unlike in 1.0. A dependency edge may not
+-- cross an epic, so epic order is the ONLY way to sequence one epic after
+-- another. NULLABLE, no default (stage-2 gate ruling, req #3336, supersedes
+-- this record's original NOT NULL DEFAULT 0): NULL = derived order (started
+-- epics by start date earliest-first, unstarted after in creation order); a
+-- non-NULL value is manual placement and wins over the derivation.
+CREATE TABLE IF NOT EXISTS pipeline2_epics (
+    id          INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    pipeline_fk INT          NOT NULL,                     -- CONTAINMENT
+    title       VARCHAR(256) NOT NULL,
+    description TEXT         NULL,                         -- PURPOSE only (design rule 11)
+    epic_status VARCHAR(16)  NOT NULL DEFAULT 'active',    -- active|paused; SUPPRESSION, not lifecycle
+    category_fk INT          NOT NULL,                     -- DISPLAY ONLY; gates nothing
+    sort_order  SMALLINT     NULL,                         -- NULL=derived order; value=manual, wins
+    closed      TINYINT(1)   NOT NULL DEFAULT 0,           -- finished; distinct from paused
+    creator_fk  VARCHAR(64)  NOT NULL,
+    create_ts   TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts   TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_p2_epics_pipeline
+        FOREIGN KEY (pipeline_fk) REFERENCES pipeline2_pipelines (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_p2_epics_category
+        FOREIGN KEY (category_fk) REFERENCES categories (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_p2_epics_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE INDEX ix_p2_epics_pipeline_fk ON pipeline2_epics (pipeline_fk);
+
+-- NO `pipeline_fk`. A step's pipeline is its epic's, and § 6 shows the composed
+-- read costs one FEWER gateway read without it, not one more — so storing both
+-- would buy nothing and cost the invariant that they agree.
+--
+-- `epic_fk` NOT NULL also deletes a derivation. In 1.0 a step's epic is reached
+-- through its requirements' `feature_fk` -> `features.epic_fk`, and a step with
+-- no requirements INHERITS the label from a dependency: 17 of the 188 live steps
+-- do exactly that. Here the epic is stored, so `label_inherited` and the whole
+-- inheritance walk stop existing.
+--
+-- `not_before` is the time gate, as a column. 1.0 holds it as a ROW in the
+-- dependency table, which forces that table to carry two condition kinds and
+-- forces every derivation to branch on which kind a row is. One instant per step
+-- is the same capability with one fewer shape: several time gates on one step is
+-- not a lost capability, because the latest instant always wins and is therefore
+-- one value. ZERO of the 175 live dependency rows is a time gate, so this is
+-- kept for its stated future use — organising around token windows — and not
+-- because anything depends on it today.
+--
+-- `completed_at` stays a manual stamp valid ONLY for a step with no GATING
+-- requirement. A requirement-backed step's state is DERIVED and has no column,
+-- here as in 1.0.
+CREATE TABLE IF NOT EXISTS pipeline2_steps (
+    id           INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,  -- STABLE: never renumbered/reused
+    epic_fk      INT          NOT NULL,                     -- CONTAINMENT; the pipeline is derived
+    title        VARCHAR(256) NOT NULL,
+    run          VARCHAR(8)   NOT NULL DEFAULT 'auto',      -- auto|manual
+    not_before   TIMESTAMP    NULL,                         -- the time gate, one instant per step
+    notes        TEXT         NULL,                         -- evidence / findings / dispositions
+    completed_at TIMESTAMP    NULL,                         -- manual stamp; gating-requirement-free steps only
+    creator_fk   VARCHAR(64)  NOT NULL,
+    create_ts    TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts    TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_p2_steps_epic
+        FOREIGN KEY (epic_fk) REFERENCES pipeline2_epics (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_p2_steps_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE INDEX ix_p2_steps_epic_fk ON pipeline2_steps (epic_fk);
+
+-- Membership, not ownership. Asymmetric on purpose and unchanged from 1.0:
+-- `step_fk` CASCADE because the links are the step's own data, `requirement_fk`
+-- RESTRICT because a requirement that appears in a plan cannot be deleted out
+-- from under it. This deviates from the junction default of CASCADE on both
+-- sides, deliberately.
+--
+-- Points at the SHARED `requirements` table, not at a doubled copy. Held here
+-- rather than as a column on `requirements` because during the parallel era that
+-- column would have to be doubled on the core table for the whole migration,
+-- which is the mess the parallel-table scheme exists to avoid.
+--
+-- PRIMARY KEY (requirement_fk) ALONE — stage-2 gate ruling, req #3336, supersedes
+-- this record's original composite PK: ONE STEP PER REQUIREMENT, structural (a
+-- requirement must not run twice; duplicate it if it needs to run 2). `step_fk`
+-- stays NOT NULL beside it. No `ix_p2_psr_requirement_fk`: the PK already serves
+-- lookup by `requirement_fk`, and the `fk_p2_psr_step` FK auto-index covers
+-- lookup by `step_fk` for the composed read.
+CREATE TABLE IF NOT EXISTS pipeline2_step_requirements (
+    step_fk        INT NOT NULL,
+    requirement_fk INT NOT NULL PRIMARY KEY,
+    CONSTRAINT fk_p2_psr_step
+        FOREIGN KEY (step_fk) REFERENCES pipeline2_steps (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_p2_psr_requirement
+        FOREIGN KEY (requirement_fk) REFERENCES requirements (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT
+);
+
+-- ONE ROW = ONE EDGE, and nothing else. The time gate left this table for a
+-- column on the step, so `dep_step_fk` is NOT NULL and the row has exactly one
+-- meaning — no condition-kind discriminator, no derivation branching on which
+-- kind a row is.
+--
+-- THAT NOT NULL IS WHAT MAKES THE UNIQUE KEY TOTAL. 1.0 declares a
+-- byte-identical `UNIQUE (step_fk, dep_step_fk)` that does NOT prevent
+-- duplicates, because `dep_step_fk` is nullable there and MySQL treats NULLs in
+-- a UNIQUE index as DISTINCT — so 1.0 can hold two time-gate rows on one step
+-- with no constraint objecting. (Same NULL semantics that force
+-- `orchestration_claims.epic_key` to exist.) Nothing exploits it today: 0 of the
+-- 175 live rows is a time gate.
+--
+-- The surrogate `id` is RETAINED deliberately, not by inertia. `delete(table,
+-- ids=[...])` is the REST client's one-round-trip bulk primitive and the only one
+-- with gateway-level cross-tenant test coverage; it targets `id`. ONE live code
+-- path uses it on the 1.0 dep table -- `delete_pipeline`, which deletes a whole
+-- plan's edges at once and is exactly the case a per-row delete would punish.
+-- (The other two dep deletes use the `where`-dict form and need no `id`.)
+-- Dropping the column would buy nothing the composite UNIQUE key does not
+-- already give.
+--
+-- `dep_step_fk` RESTRICT is design rule 4's teeth: a step something else gates
+-- on cannot be deleted or merged away.
+--
+-- AN EDGE MAY NOT CROSS AN EPIC, and the schema cannot say so — the constraint
+-- is between two rows' parents. Enforced in the service layer, the same place
+-- the cycle check and the cross-pipeline check already live.
+CREATE TABLE IF NOT EXISTS pipeline2_step_deps (
+    id          INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    step_fk     INT NOT NULL,
+    dep_step_fk INT NOT NULL,                              -- NOT NULL: the time gate is a step column now
+    UNIQUE KEY uq_p2_step_deps (step_fk, dep_step_fk),
+    CONSTRAINT fk_p2_psd_step
+        FOREIGN KEY (step_fk) REFERENCES pipeline2_steps (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_p2_psd_dep_step
+        FOREIGN KEY (dep_step_fk) REFERENCES pipeline2_steps (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT
+);
+
+CREATE INDEX ix_p2_psd_dep_step_fk ON pipeline2_step_deps (dep_step_fk);

--- a/schema.sql
+++ b/schema.sql
@@ -1,5 +1,5 @@
 -- Darwin Database Schema — Current State
--- This file reflects the final state of all 53 tables after all migrations.
+-- This file reflects the final state of all 58 tables after all migrations.
 -- It can be run against a fresh MySQL instance to create the complete schema.
 -- Table order respects FK dependencies.
 --
@@ -1348,3 +1348,204 @@ CREATE TABLE IF NOT EXISTS orchestration_claims (
 );
 
 CREATE INDEX ix_orchestration_claims_epic_fk ON orchestration_claims (epic_fk);
+
+-- ---------------------------------------------------------------------------
+-- Pipeline 2.0 — the plan layer (req #3328 design; parallel era)
+-- ---------------------------------------------------------------------------
+-- FIVE tables standing BESIDE the 1.0 five, not replacing them. Both eras run
+-- at once until 1.0 is eradicated, and requirements are NOT doubled: one
+-- `requirements` table carries two plan layers above it, because duplicating a
+-- requirement row would split its sessions, history and identity across two ids
+-- for the same work.
+--
+-- CONTAINMENT IS IN THE DDL, NOT IN CONVENTION. An epic belongs to exactly one
+-- pipeline and a step to exactly one epic, both NOT NULL. That single change is
+-- what removes the session-attribution tie-break, gives epic pause a scope key,
+-- makes reservation scoping a containment question rather than an inferred one,
+-- and turns display order into a tree walk.
+--
+-- Containment STOPS at Requirement: a step ORGANIZES requirements and does not
+-- own them, so membership is an edge table. Three levels of ownership, one of
+-- membership — the one asymmetry in the chain, and deliberate.
+
+CREATE TABLE IF NOT EXISTS pipeline2_pipelines (
+    id              INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title           VARCHAR(256) NOT NULL,
+    description     TEXT         NULL,                     -- the goal; PURPOSE only (design rule 11)
+    pipeline_status VARCHAR(16)  NOT NULL DEFAULT 'draft', -- draft|active|paused|completed|aborted
+    execution_mode  ENUM('parallel', 'serial')
+                                 NOT NULL DEFAULT 'parallel', -- req #3388: parallel = every epic at
+                                                              -- once; serial = one at a time, live
+                                                              -- epic DERIVED. Carried forward from
+                                                              -- 1.0 `pipelines` — a real plan
+                                                              -- property, not 1.0-specific debt, so
+                                                              -- the #3356 importer must copy it.
+    machine_fk      INT          NULL DEFAULT NULL,        -- NULL = any machine
+    creator_fk      VARCHAR(64)  NOT NULL,
+    started_at      TIMESTAMP    NULL,                     -- derived from the status transition
+    completed_at    TIMESTAMP    NULL,                     -- ditto; never passed by a caller
+    create_ts       TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_p2_pipelines_machine
+        FOREIGN KEY (machine_fk) REFERENCES machines (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_p2_pipelines_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+-- `pipeline_fk` NOT NULL is the containment. An epic cannot float free and
+-- cannot be reached from a second plan, which is what makes `epic_status` a
+-- scoped pause rather than a global one: 1.0's epic pause has no scope key, so
+-- pausing an epic pauses it in every plan holding it.
+--
+-- `category_fk` is DISPLAY ONLY and gates nothing. An epic owns its steps; it
+-- does not govern their attributes, and the work of one epic routinely spans
+-- several categories. It must not be read by orchestration, launch, repo
+-- resolution or any eligibility predicate — the category that matters is the one
+-- on the requirement, which the requirement already carries.
+--
+-- `sort_order` IS LOAD-BEARING HERE, unlike in 1.0. A dependency edge may not
+-- cross an epic, so epic order is the ONLY way to sequence one epic after
+-- another. NULLABLE, no default (stage-2 gate ruling, req #3336, supersedes
+-- this record's original NOT NULL DEFAULT 0): NULL = derived order (started
+-- epics by start date earliest-first, unstarted after in creation order); a
+-- non-NULL value is manual placement and wins over the derivation.
+CREATE TABLE IF NOT EXISTS pipeline2_epics (
+    id          INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    pipeline_fk INT          NOT NULL,                     -- CONTAINMENT
+    title       VARCHAR(256) NOT NULL,
+    description TEXT         NULL,                         -- PURPOSE only (design rule 11)
+    epic_status VARCHAR(16)  NOT NULL DEFAULT 'active',    -- active|paused; SUPPRESSION, not lifecycle
+    category_fk INT          NOT NULL,                     -- DISPLAY ONLY; gates nothing
+    sort_order  SMALLINT     NULL,                         -- NULL=derived order; value=manual, wins
+    closed      TINYINT(1)   NOT NULL DEFAULT 0,           -- finished; distinct from paused
+    creator_fk  VARCHAR(64)  NOT NULL,
+    create_ts   TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts   TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_p2_epics_pipeline
+        FOREIGN KEY (pipeline_fk) REFERENCES pipeline2_pipelines (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_p2_epics_category
+        FOREIGN KEY (category_fk) REFERENCES categories (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_p2_epics_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE INDEX ix_p2_epics_pipeline_fk ON pipeline2_epics (pipeline_fk);
+
+-- NO `pipeline_fk`. A step's pipeline is its epic's, and § 6 shows the composed
+-- read costs one FEWER gateway read without it, not one more — so storing both
+-- would buy nothing and cost the invariant that they agree.
+--
+-- `epic_fk` NOT NULL also deletes a derivation. In 1.0 a step's epic is reached
+-- through its requirements' `feature_fk` -> `features.epic_fk`, and a step with
+-- no requirements INHERITS the label from a dependency: 17 of the 188 live steps
+-- do exactly that. Here the epic is stored, so `label_inherited` and the whole
+-- inheritance walk stop existing.
+--
+-- `not_before` is the time gate, as a column. 1.0 holds it as a ROW in the
+-- dependency table, which forces that table to carry two condition kinds and
+-- forces every derivation to branch on which kind a row is. One instant per step
+-- is the same capability with one fewer shape: several time gates on one step is
+-- not a lost capability, because the latest instant always wins and is therefore
+-- one value. ZERO of the 175 live dependency rows is a time gate, so this is
+-- kept for its stated future use — organising around token windows — and not
+-- because anything depends on it today.
+--
+-- `completed_at` stays a manual stamp valid ONLY for a step with no GATING
+-- requirement. A requirement-backed step's state is DERIVED and has no column,
+-- here as in 1.0.
+CREATE TABLE IF NOT EXISTS pipeline2_steps (
+    id           INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,  -- STABLE: never renumbered/reused
+    epic_fk      INT          NOT NULL,                     -- CONTAINMENT; the pipeline is derived
+    title        VARCHAR(256) NOT NULL,
+    run          VARCHAR(8)   NOT NULL DEFAULT 'auto',      -- auto|manual
+    not_before   TIMESTAMP    NULL,                         -- the time gate, one instant per step
+    notes        TEXT         NULL,                         -- evidence / findings / dispositions
+    completed_at TIMESTAMP    NULL,                         -- manual stamp; gating-requirement-free steps only
+    creator_fk   VARCHAR(64)  NOT NULL,
+    create_ts    TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts    TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_p2_steps_epic
+        FOREIGN KEY (epic_fk) REFERENCES pipeline2_epics (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_p2_steps_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE INDEX ix_p2_steps_epic_fk ON pipeline2_steps (epic_fk);
+
+-- Membership, not ownership. Asymmetric on purpose and unchanged from 1.0:
+-- `step_fk` CASCADE because the links are the step's own data, `requirement_fk`
+-- RESTRICT because a requirement that appears in a plan cannot be deleted out
+-- from under it. This deviates from the junction default of CASCADE on both
+-- sides, deliberately.
+--
+-- Points at the SHARED `requirements` table, not at a doubled copy. Held here
+-- rather than as a column on `requirements` because during the parallel era that
+-- column would have to be doubled on the core table for the whole migration,
+-- which is the mess the parallel-table scheme exists to avoid.
+--
+-- PRIMARY KEY (requirement_fk) ALONE — stage-2 gate ruling, req #3336, supersedes
+-- this record's original composite PK: ONE STEP PER REQUIREMENT, structural (a
+-- requirement must not run twice; duplicate it if it needs to run 2). `step_fk`
+-- stays NOT NULL beside it. No `ix_p2_psr_requirement_fk`: the PK already serves
+-- lookup by `requirement_fk`, and the `fk_p2_psr_step` FK auto-index covers
+-- lookup by `step_fk` for the composed read.
+CREATE TABLE IF NOT EXISTS pipeline2_step_requirements (
+    step_fk        INT NOT NULL,
+    requirement_fk INT NOT NULL PRIMARY KEY,
+    CONSTRAINT fk_p2_psr_step
+        FOREIGN KEY (step_fk) REFERENCES pipeline2_steps (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_p2_psr_requirement
+        FOREIGN KEY (requirement_fk) REFERENCES requirements (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT
+);
+
+-- ONE ROW = ONE EDGE, and nothing else. The time gate left this table for a
+-- column on the step, so `dep_step_fk` is NOT NULL and the row has exactly one
+-- meaning — no condition-kind discriminator, no derivation branching on which
+-- kind a row is.
+--
+-- THAT NOT NULL IS WHAT MAKES THE UNIQUE KEY TOTAL. 1.0 declares a
+-- byte-identical `UNIQUE (step_fk, dep_step_fk)` that does NOT prevent
+-- duplicates, because `dep_step_fk` is nullable there and MySQL treats NULLs in
+-- a UNIQUE index as DISTINCT — so 1.0 can hold two time-gate rows on one step
+-- with no constraint objecting. (Same NULL semantics that force
+-- `orchestration_claims.epic_key` to exist.) Nothing exploits it today: 0 of the
+-- 175 live rows is a time gate.
+--
+-- The surrogate `id` is RETAINED deliberately, not by inertia. `delete(table,
+-- ids=[...])` is the REST client's one-round-trip bulk primitive and the only one
+-- with gateway-level cross-tenant test coverage; it targets `id`. ONE live code
+-- path uses it on the 1.0 dep table -- `delete_pipeline`, which deletes a whole
+-- plan's edges at once and is exactly the case a per-row delete would punish.
+-- (The other two dep deletes use the `where`-dict form and need no `id`.)
+-- Dropping the column would buy nothing the composite UNIQUE key does not
+-- already give.
+--
+-- `dep_step_fk` RESTRICT is design rule 4's teeth: a step something else gates
+-- on cannot be deleted or merged away.
+--
+-- AN EDGE MAY NOT CROSS AN EPIC, and the schema cannot say so — the constraint
+-- is between two rows' parents. Enforced in the service layer, the same place
+-- the cycle check and the cross-pipeline check already live.
+CREATE TABLE IF NOT EXISTS pipeline2_step_deps (
+    id          INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    step_fk     INT NOT NULL,
+    dep_step_fk INT NOT NULL,                              -- NOT NULL: the time gate is a step column now
+    UNIQUE KEY uq_p2_step_deps (step_fk, dep_step_fk),
+    CONSTRAINT fk_p2_psd_step
+        FOREIGN KEY (step_fk) REFERENCES pipeline2_steps (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_p2_psd_dep_step
+        FOREIGN KEY (dep_step_fk) REFERENCES pipeline2_steps (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT
+);
+
+CREATE INDEX ix_p2_psd_dep_step_fk ON pipeline2_step_deps (dep_step_fk);

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -1,10 +1,10 @@
 -- Recreate darwin_dev test/dev tables from scratch
 -- Uses production-identical table names (same DDL as schema.sql)
 -- Idempotent: safe to run repeatedly to reset darwin_dev to canonical state
--- All 53 tables in FK-dependency order
+-- All 58 tables in FK-dependency order
 --
 -- ============================================================================
--- THIS FILE DROPS 53 TABLES. (req #3196)
+-- THIS FILE DROPS 58 TABLES. (req #3196)
 -- ============================================================================
 -- It opened with `USE darwin_dev;`, which LOOKED like protection and was not:
 -- a `USE` is a statement the caller's loader may strip, reorder or never reach,
@@ -26,6 +26,8 @@
 
 SET FOREIGN_KEY_CHECKS = 0;
 DROP TABLE IF EXISTS orchestration_claims,
+    pipeline2_step_deps, pipeline2_step_requirements, pipeline2_steps,
+    pipeline2_epics, pipeline2_pipelines,
     pipeline_step_deps, pipeline_step_requirements, pipeline_steps, pipelines,
     agent_telemetry_row_docs, agent_telemetry_rows, agent_telemetry_runs,
     customer_releases, builds, branches, build_projects,
@@ -1201,3 +1203,202 @@ CREATE TABLE orchestration_claims (
 );
 
 CREATE INDEX ix_orchestration_claims_epic_fk ON orchestration_claims (epic_fk);
+
+-- ---------------------------------------------------------------------------
+-- FIVE tables standing BESIDE the 1.0 five, not replacing them. Both eras run
+-- at once until 1.0 is eradicated, and requirements are NOT doubled: one
+-- `requirements` table carries two plan layers above it, because duplicating a
+-- requirement row would split its sessions, history and identity across two ids
+-- for the same work.
+--
+-- CONTAINMENT IS IN THE DDL, NOT IN CONVENTION. An epic belongs to exactly one
+-- pipeline and a step to exactly one epic, both NOT NULL. That single change is
+-- what removes the session-attribution tie-break, gives epic pause a scope key,
+-- makes reservation scoping a containment question rather than an inferred one,
+-- and turns display order into a tree walk.
+--
+-- Containment STOPS at Requirement: a step ORGANIZES requirements and does not
+-- own them, so membership is an edge table. Three levels of ownership, one of
+-- membership — the one asymmetry in the chain, and deliberate.
+
+CREATE TABLE pipeline2_pipelines (
+    id              INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    title           VARCHAR(256) NOT NULL,
+    description     TEXT         NULL,                     -- the goal; PURPOSE only (design rule 11)
+    pipeline_status VARCHAR(16)  NOT NULL DEFAULT 'draft', -- draft|active|paused|completed|aborted
+    execution_mode  ENUM('parallel', 'serial')
+                                 NOT NULL DEFAULT 'parallel', -- req #3388: parallel = every epic at
+                                                              -- once; serial = one at a time, live
+                                                              -- epic DERIVED. Carried forward from
+                                                              -- 1.0 `pipelines` — a real plan
+                                                              -- property, not 1.0-specific debt, so
+                                                              -- the #3356 importer must copy it.
+    machine_fk      INT          NULL DEFAULT NULL,        -- NULL = any machine
+    creator_fk      VARCHAR(64)  NOT NULL,
+    started_at      TIMESTAMP    NULL,                     -- derived from the status transition
+    completed_at    TIMESTAMP    NULL,                     -- ditto; never passed by a caller
+    create_ts       TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts       TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_p2_pipelines_machine
+        FOREIGN KEY (machine_fk) REFERENCES machines (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_p2_pipelines_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+-- `pipeline_fk` NOT NULL is the containment. An epic cannot float free and
+-- cannot be reached from a second plan, which is what makes `epic_status` a
+-- scoped pause rather than a global one: 1.0's epic pause has no scope key, so
+-- pausing an epic pauses it in every plan holding it.
+--
+-- `category_fk` is DISPLAY ONLY and gates nothing. An epic owns its steps; it
+-- does not govern their attributes, and the work of one epic routinely spans
+-- several categories. It must not be read by orchestration, launch, repo
+-- resolution or any eligibility predicate — the category that matters is the one
+-- on the requirement, which the requirement already carries.
+--
+-- `sort_order` IS LOAD-BEARING HERE, unlike in 1.0. A dependency edge may not
+-- cross an epic, so epic order is the ONLY way to sequence one epic after
+-- another. NULLABLE, no default (stage-2 gate ruling, req #3336, supersedes
+-- this record's original NOT NULL DEFAULT 0): NULL = derived order (started
+-- epics by start date earliest-first, unstarted after in creation order); a
+-- non-NULL value is manual placement and wins over the derivation.
+CREATE TABLE pipeline2_epics (
+    id          INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    pipeline_fk INT          NOT NULL,                     -- CONTAINMENT
+    title       VARCHAR(256) NOT NULL,
+    description TEXT         NULL,                         -- PURPOSE only (design rule 11)
+    epic_status VARCHAR(16)  NOT NULL DEFAULT 'active',    -- active|paused; SUPPRESSION, not lifecycle
+    category_fk INT          NOT NULL,                     -- DISPLAY ONLY; gates nothing
+    sort_order  SMALLINT     NULL,                         -- NULL=derived order; value=manual, wins
+    closed      TINYINT(1)   NOT NULL DEFAULT 0,           -- finished; distinct from paused
+    creator_fk  VARCHAR(64)  NOT NULL,
+    create_ts   TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts   TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_p2_epics_pipeline
+        FOREIGN KEY (pipeline_fk) REFERENCES pipeline2_pipelines (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_p2_epics_category
+        FOREIGN KEY (category_fk) REFERENCES categories (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_p2_epics_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE INDEX ix_p2_epics_pipeline_fk ON pipeline2_epics (pipeline_fk);
+
+-- NO `pipeline_fk`. A step's pipeline is its epic's, and § 6 shows the composed
+-- read costs one FEWER gateway read without it, not one more — so storing both
+-- would buy nothing and cost the invariant that they agree.
+--
+-- `epic_fk` NOT NULL also deletes a derivation. In 1.0 a step's epic is reached
+-- through its requirements' `feature_fk` -> `features.epic_fk`, and a step with
+-- no requirements INHERITS the label from a dependency: 17 of the 188 live steps
+-- do exactly that. Here the epic is stored, so `label_inherited` and the whole
+-- inheritance walk stop existing.
+--
+-- `not_before` is the time gate, as a column. 1.0 holds it as a ROW in the
+-- dependency table, which forces that table to carry two condition kinds and
+-- forces every derivation to branch on which kind a row is. One instant per step
+-- is the same capability with one fewer shape: several time gates on one step is
+-- not a lost capability, because the latest instant always wins and is therefore
+-- one value. ZERO of the 175 live dependency rows is a time gate, so this is
+-- kept for its stated future use — organising around token windows — and not
+-- because anything depends on it today.
+--
+-- `completed_at` stays a manual stamp valid ONLY for a step with no GATING
+-- requirement. A requirement-backed step's state is DERIVED and has no column,
+-- here as in 1.0.
+CREATE TABLE pipeline2_steps (
+    id           INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,  -- STABLE: never renumbered/reused
+    epic_fk      INT          NOT NULL,                     -- CONTAINMENT; the pipeline is derived
+    title        VARCHAR(256) NOT NULL,
+    run          VARCHAR(8)   NOT NULL DEFAULT 'auto',      -- auto|manual
+    not_before   TIMESTAMP    NULL,                         -- the time gate, one instant per step
+    notes        TEXT         NULL,                         -- evidence / findings / dispositions
+    completed_at TIMESTAMP    NULL,                         -- manual stamp; gating-requirement-free steps only
+    creator_fk   VARCHAR(64)  NOT NULL,
+    create_ts    TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts    TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_p2_steps_epic
+        FOREIGN KEY (epic_fk) REFERENCES pipeline2_epics (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_p2_steps_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE INDEX ix_p2_steps_epic_fk ON pipeline2_steps (epic_fk);
+
+-- Membership, not ownership. Asymmetric on purpose and unchanged from 1.0:
+-- `step_fk` CASCADE because the links are the step's own data, `requirement_fk`
+-- RESTRICT because a requirement that appears in a plan cannot be deleted out
+-- from under it. This deviates from the junction default of CASCADE on both
+-- sides, deliberately.
+--
+-- Points at the SHARED `requirements` table, not at a doubled copy. Held here
+-- rather than as a column on `requirements` because during the parallel era that
+-- column would have to be doubled on the core table for the whole migration,
+-- which is the mess the parallel-table scheme exists to avoid.
+--
+-- PRIMARY KEY (requirement_fk) ALONE — stage-2 gate ruling, req #3336, supersedes
+-- this record's original composite PK: ONE STEP PER REQUIREMENT, structural (a
+-- requirement must not run twice; duplicate it if it needs to run 2). `step_fk`
+-- stays NOT NULL beside it. No `ix_p2_psr_requirement_fk`: the PK already serves
+-- lookup by `requirement_fk`, and the `fk_p2_psr_step` FK auto-index covers
+-- lookup by `step_fk` for the composed read.
+CREATE TABLE pipeline2_step_requirements (
+    step_fk        INT NOT NULL,
+    requirement_fk INT NOT NULL PRIMARY KEY,
+    CONSTRAINT fk_p2_psr_step
+        FOREIGN KEY (step_fk) REFERENCES pipeline2_steps (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_p2_psr_requirement
+        FOREIGN KEY (requirement_fk) REFERENCES requirements (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT
+);
+
+-- ONE ROW = ONE EDGE, and nothing else. The time gate left this table for a
+-- column on the step, so `dep_step_fk` is NOT NULL and the row has exactly one
+-- meaning — no condition-kind discriminator, no derivation branching on which
+-- kind a row is.
+--
+-- THAT NOT NULL IS WHAT MAKES THE UNIQUE KEY TOTAL. 1.0 declares a
+-- byte-identical `UNIQUE (step_fk, dep_step_fk)` that does NOT prevent
+-- duplicates, because `dep_step_fk` is nullable there and MySQL treats NULLs in
+-- a UNIQUE index as DISTINCT — so 1.0 can hold two time-gate rows on one step
+-- with no constraint objecting. (Same NULL semantics that force
+-- `orchestration_claims.epic_key` to exist.) Nothing exploits it today: 0 of the
+-- 175 live rows is a time gate.
+--
+-- The surrogate `id` is RETAINED deliberately, not by inertia. `delete(table,
+-- ids=[...])` is the REST client's one-round-trip bulk primitive and the only one
+-- with gateway-level cross-tenant test coverage; it targets `id`. ONE live code
+-- path uses it on the 1.0 dep table -- `delete_pipeline`, which deletes a whole
+-- plan's edges at once and is exactly the case a per-row delete would punish.
+-- (The other two dep deletes use the `where`-dict form and need no `id`.)
+-- Dropping the column would buy nothing the composite UNIQUE key does not
+-- already give.
+--
+-- `dep_step_fk` RESTRICT is design rule 4's teeth: a step something else gates
+-- on cannot be deleted or merged away.
+--
+-- AN EDGE MAY NOT CROSS AN EPIC, and the schema cannot say so — the constraint
+-- is between two rows' parents. Enforced in the service layer, the same place
+-- the cycle check and the cross-pipeline check already live.
+CREATE TABLE pipeline2_step_deps (
+    id          INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    step_fk     INT NOT NULL,
+    dep_step_fk INT NOT NULL,                              -- NOT NULL: the time gate is a step column now
+    UNIQUE KEY uq_p2_step_deps (step_fk, dep_step_fk),
+    CONSTRAINT fk_p2_psd_step
+        FOREIGN KEY (step_fk) REFERENCES pipeline2_steps (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_p2_psd_dep_step
+        FOREIGN KEY (dep_step_fk) REFERENCES pipeline2_steps (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT
+);
+
+CREATE INDEX ix_p2_psd_dep_step_fk ON pipeline2_step_deps (dep_step_fk);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,22 @@ def seed_test_profile(db_connection, test_creator_fk):
                     (test_creator_fk, test_creator_fk))
         cur.execute("DELETE FROM pipeline_steps WHERE creator_fk = %s", (test_creator_fk,))
         cur.execute("DELETE FROM pipelines WHERE creator_fk = %s", (test_creator_fk,))
+        # Req #3337: Pipeline 2.0 plan layer, parallel era. Same both-ends
+        # scoping as the 1.0 pair just above, and for the identical reason —
+        # `pipeline2_step_requirements.requirement_fk` is ON DELETE RESTRICT.
+        cur.execute("DELETE FROM pipeline2_step_deps WHERE step_fk IN "
+                    "(SELECT id FROM pipeline2_steps WHERE creator_fk = %s) "
+                    "OR dep_step_fk IN "
+                    "(SELECT id FROM pipeline2_steps WHERE creator_fk = %s)",
+                    (test_creator_fk, test_creator_fk))
+        cur.execute("DELETE FROM pipeline2_step_requirements WHERE step_fk IN "
+                    "(SELECT id FROM pipeline2_steps WHERE creator_fk = %s) "
+                    "OR requirement_fk IN "
+                    "(SELECT id FROM requirements WHERE creator_fk = %s)",
+                    (test_creator_fk, test_creator_fk))
+        cur.execute("DELETE FROM pipeline2_steps WHERE creator_fk = %s", (test_creator_fk,))
+        cur.execute("DELETE FROM pipeline2_epics WHERE creator_fk = %s", (test_creator_fk,))
+        cur.execute("DELETE FROM pipeline2_pipelines WHERE creator_fk = %s", (test_creator_fk,))
         cur.execute("DELETE FROM requirements WHERE creator_fk = %s", (test_creator_fk,))
         cur.execute("DELETE FROM swarm_sessions WHERE creator_fk = %s", (test_creator_fk,))
         # Req #2943: swarm_starts + machines. machine_fk is ON DELETE RESTRICT on

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1732,6 +1732,7 @@ def test_customers_columns(db_connection):
     assert columns['sort_order']['Null'] == 'YES'
 
 
+# COVERS: SCH-018
 def test_table_count(db_connection):
     """Verify darwin_dev database contains the expected tables."""
     with db_connection.cursor() as cur:
@@ -1780,6 +1781,11 @@ def test_table_count(db_connection):
         # 20260801150404). One row per RESERVED SCOPE, so the single-orchestrator
         # guarantee crosses a machine boundary instead of living in /tmp.
         'orchestration_claims',
+        # Req #3337 — Pipeline 2.0 plan layer (migration 20260808115509). Five
+        # tables standing beside the 1.0 five above, parallel era: containment
+        # chain Pipeline -> Epic -> Step -> Requirement.
+        'pipeline2_pipelines', 'pipeline2_epics', 'pipeline2_steps',
+        'pipeline2_step_requirements', 'pipeline2_step_deps',
     }
     assert expected_tables == tables, \
         f"Unexpected tables: {tables - expected_tables}, missing: {expected_tables - tables}"

--- a/tests/test_migration_naming.py
+++ b/tests/test_migration_naming.py
@@ -120,6 +120,7 @@ def _prefix(filename):
 # Test: every filename matches the naming contract
 # ---------------------------------------------------------------------------
 
+# COVERS: SCH-029
 def test_every_migration_filename_matches_the_naming_contract():
     """Each file is a legacy 3-digit or a new-era 14-digit UTC stamp.
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -83,6 +83,15 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         'orchestration_claims',
         'pipelines',
         'epics',
+        # Req #3337 — Pipeline 2.0 plan layer (migration 20260808115509), the
+        # parallel-era family. Order does not matter here — measured with the
+        # real regex, no new name matches inside any other new name or any 1.0
+        # name in either direction — but listed longest-first as house style.
+        'pipeline2_step_requirements',
+        'pipeline2_step_deps',
+        'pipeline2_steps',
+        'pipeline2_epics',
+        'pipeline2_pipelines',
         # Req #3096 — per-document actual-token rows (migration 074), child of
         # agent_telemetry_rows. Listed before agent_telemetry_rows/runs (longest-
         # first): agent_telemetry_row_docs must precede the shorter `agents` token
@@ -252,6 +261,19 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         # fails 1061 "Duplicate key name" the second time this suite runs.
         'fk_oc_pipeline', 'fk_oc_epic', 'fk_oc_machine', 'fk_oc_creator',
         'uq_orchestration_claims_scope', 'ix_orchestration_claims_epic_fk',
+        # Migration 20260808115509 — Pipeline 2.0 plan layer (req #3337).
+        # 11 fk_p2_*, 1 uq_p2_*, 3 ix_p2_* (the fourth, ix_p2_psr_requirement_fk,
+        # does not exist — the stage-2 gate ruling made requirement_fk the sole
+        # PRIMARY KEY of pipeline2_step_requirements, which already serves that
+        # lookup). The three ix_p2_* names are, like ix_orchestration_claims_epic_fk
+        # above, NOT optional: CREATE INDEX has no IF NOT EXISTS in MySQL.
+        'fk_p2_pipelines_machine', 'fk_p2_pipelines_creator',
+        'fk_p2_epics_pipeline', 'fk_p2_epics_category', 'fk_p2_epics_creator',
+        'fk_p2_steps_epic', 'fk_p2_steps_creator',
+        'fk_p2_psr_step', 'fk_p2_psr_requirement',
+        'fk_p2_psd_step', 'fk_p2_psd_dep_step',
+        'uq_p2_step_deps',
+        'ix_p2_epics_pipeline_fk', 'ix_p2_steps_epic_fk', 'ix_p2_psd_dep_step_fk',
     ]
     for cname in named_constraints:
         sql = sql.replace(cname, f'{table_prefix}_{cname}')
@@ -326,6 +348,13 @@ ALL_TABLE_SUFFIXES = [
     # family: it points at pipelines, epics AND machines, and is pointed at by
     # nothing.
     'orchestration_claims',
+    # Req #3337 — Pipeline 2.0 plan layer (migration 20260808115509), parallel
+    # era. Placed BEFORE the 1.0 pipeline family, leaves first: deps/links, then
+    # steps, then epics, then pipelines. Unlike 1.0's epics, pipeline2_epics
+    # needs no relationship to features — 2.0's epic has no feature_fk pointing
+    # at it — so it drops with its own family instead of near features below.
+    'pipeline2_step_deps', 'pipeline2_step_requirements', 'pipeline2_steps',
+    'pipeline2_epics', 'pipeline2_pipelines',
     # Req #3111 — Swarm Orchestration foundation. FK-safe order: the dep/link
     # leaves, then steps, then pipelines. `epics` drops near features (below),
     # since features.epic_fk is SET NULL and imposes no ordering of its own.
@@ -370,6 +399,22 @@ ALL_TABLE_SUFFIXES = [
     'swarm_sessions', 'categories', 'projects',
     'tasks', 'recurring_tasks', 'areas', 'domains', 'profiles',
 ]
+
+
+# COVERS: SCH-019
+def test_pipeline2_family_drops_leaves_first_before_the_1_0_family():
+    """§ 5.4 item 2: the five 2.0 names precede the 1.0 pipeline family, and
+    within the 2.0 family the edge tables precede steps precede epics precede
+    pipelines — leaves first."""
+    p2 = ['pipeline2_step_deps', 'pipeline2_step_requirements', 'pipeline2_steps',
+          'pipeline2_epics', 'pipeline2_pipelines']
+    p1_start = ALL_TABLE_SUFFIXES.index('pipeline_step_deps')
+
+    p2_positions = [ALL_TABLE_SUFFIXES.index(name) for name in p2]
+    assert p2_positions == sorted(p2_positions), \
+        'pipeline2_* family must appear leaves-first, in this exact order'
+    assert max(p2_positions) < p1_start, \
+        'pipeline2_* family must drop entirely before the 1.0 pipeline family'
 
 
 @pytest.fixture(autouse=True)
@@ -481,8 +526,22 @@ def test_migration_016_creates_roadmap_tables(db_connection, migration_test_pref
 # Test: All migrations apply successfully in dependency order
 # ---------------------------------------------------------------------------
 
+# COVERS: SCH-020, SCH-021, SCH-022
 def test_migration_sequence_applies(db_connection, migration_test_prefix):
     """Apply all migrations in dependency order to temp tables.
+
+    This replay runs AGAINST a darwin_dev that already holds the real
+    (unprefixed) pipeline2_* tables and their real fk_p2_*/uq_p2_*/ix_p2_*
+    constraint names (applied earlier by this same requirement). Two things
+    would make this test fail rather than merely under-report if #3337's own
+    registration were wrong: table_names missing an entry (§ 5.4 item 3, SCH-020)
+    leaves the migration's CREATE TABLE unprefixed, so it silently no-ops
+    against the real table (IF NOT EXISTS) and the prefixed name this test
+    expects (SCH-022) never appears — a Missing: assertion; named_constraints
+    missing an entry (§ 5.4 item 4, SCH-021) leaves a constraint name literal,
+    which collides with the identically-named real constraint already on the
+    real table and raises MySQL 1826 (CREATE TABLE failures are never
+    tolerated, even in tolerant mode — see _apply_migration above).
 
     Order: 001-008 (core), 016 (roadmap tables), 009-015 (modifications),
     017+ (recurring_tasks, map tables, etc.).
@@ -547,6 +606,10 @@ def test_migration_sequence_applies(db_connection, migration_test_prefix):
             # Req #3224 — the durable orchestration reservation
             # (migration 20260801150404)
             'orchestration_claims',
+            # Req #3337 — Pipeline 2.0 plan layer (migration 20260808115509),
+            # parallel era. Stands beside the 1.0 five above; not a replacement.
+            'pipeline2_pipelines', 'pipeline2_epics', 'pipeline2_steps',
+            'pipeline2_step_requirements', 'pipeline2_step_deps',
         ]
     }
     assert tables == expected_tables, \

--- a/tests/test_pipeline2_behaviours.py
+++ b/tests/test_pipeline2_behaviours.py
@@ -1,0 +1,321 @@
+"""Pipeline 2.0 plan-layer schema behaviours (req #3337).
+
+# COVERS: SCH-001, SCH-002, SCH-003, SCH-004, SCH-005, SCH-006, SCH-007,
+# COVERS: SCH-008, SCH-010, SCH-011, SCH-012, SCH-030, SCH-036
+
+Structural (DESCRIBE / SHOW INDEX / information_schema) and functional
+(insert/delete against real rows) proof for the behaviours stated by
+`memory/pipeline-2-data-architecture.md` § 3 and the stage-2 gate deltas
+(req #3336) for the five `pipeline2_*` tables created by migration
+20260808115509. Runs against `darwin_dev`, the only database this
+requirement touches.
+"""
+import uuid
+
+import pymysql
+import pytest
+
+
+def _columns(cur, table):
+    cur.execute(f"DESCRIBE {table}")
+    return {row['Field']: row for row in cur.fetchall()}
+
+
+def _referential_action(cur, constraint_name):
+    """(UPDATE_RULE, DELETE_RULE) for a named FK constraint in darwin_dev."""
+    cur.execute(
+        "SELECT UPDATE_RULE, DELETE_RULE FROM "
+        "INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS "
+        "WHERE CONSTRAINT_SCHEMA = 'darwin_dev' AND CONSTRAINT_NAME = %s",
+        (constraint_name,))
+    row = cur.fetchone()
+    assert row, f'{constraint_name} not found in darwin_dev'
+    return row['UPDATE_RULE'], row['DELETE_RULE']
+
+
+# ---------------------------------------------------------------------------
+# Fixture graph: project -> category -> pipeline2_pipelines -> pipeline2_epics
+# -> pipeline2_steps, plus one requirement to link/gate with.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def p2_graph(db_connection, test_creator_fk):
+    """One owned row per table, built fresh per test and torn down after.
+
+    Function-scoped (not module-scoped) because several tests below mutate or
+    delete rows in this graph (SCH-005's duplicate-edge probe, SCH-012's
+    cascade-delete probe, SCH-036's duplicate-requirement probe).
+    """
+    ids = {}
+    with db_connection.cursor() as cur:
+        cur.execute("INSERT INTO projects (project_name, creator_fk) VALUES (%s, %s)",
+                    (f'p2-proj-{uuid.uuid4().hex[:8]}', test_creator_fk))
+        ids['project'] = cur.lastrowid
+        cur.execute("INSERT INTO categories (category_name, project_fk, creator_fk) "
+                    "VALUES (%s, %s, %s)",
+                    (f'p2-cat-{uuid.uuid4().hex[:8]}', ids['project'], test_creator_fk))
+        ids['category'] = cur.lastrowid
+        cur.execute("INSERT INTO requirements (title, category_fk, creator_fk, "
+                    "ai_model, effort) VALUES (%s, %s, %s, 'opus', 'high')",
+                    (f'p2-req-{uuid.uuid4().hex[:8]}', ids['category'], test_creator_fk))
+        ids['requirement'] = cur.lastrowid
+        cur.execute("INSERT INTO pipeline2_pipelines (title, creator_fk) VALUES (%s, %s)",
+                    (f'p2-pipeline-{uuid.uuid4().hex[:8]}', test_creator_fk))
+        ids['pipeline'] = cur.lastrowid
+        cur.execute("INSERT INTO pipeline2_epics (pipeline_fk, title, category_fk, "
+                    "creator_fk) VALUES (%s, %s, %s, %s)",
+                    (ids['pipeline'], f'p2-epic-{uuid.uuid4().hex[:8]}',
+                     ids['category'], test_creator_fk))
+        ids['epic'] = cur.lastrowid
+        cur.execute("INSERT INTO pipeline2_steps (epic_fk, title, creator_fk) "
+                    "VALUES (%s, %s, %s)",
+                    (ids['epic'], f'p2-step-a-{uuid.uuid4().hex[:8]}', test_creator_fk))
+        ids['step_a'] = cur.lastrowid
+        cur.execute("INSERT INTO pipeline2_steps (epic_fk, title, creator_fk) "
+                    "VALUES (%s, %s, %s)",
+                    (ids['epic'], f'p2-step-b-{uuid.uuid4().hex[:8]}', test_creator_fk))
+        ids['step_b'] = cur.lastrowid
+    db_connection.commit()
+
+    yield ids
+
+    with db_connection.cursor() as cur:
+        cur.execute("DELETE FROM pipeline2_step_deps WHERE step_fk IN "
+                    "(SELECT id FROM pipeline2_steps WHERE creator_fk = %s) "
+                    "OR dep_step_fk IN "
+                    "(SELECT id FROM pipeline2_steps WHERE creator_fk = %s)",
+                    (test_creator_fk, test_creator_fk))
+        cur.execute("DELETE FROM pipeline2_step_requirements WHERE step_fk IN "
+                    "(SELECT id FROM pipeline2_steps WHERE creator_fk = %s) "
+                    "OR requirement_fk IN "
+                    "(SELECT id FROM requirements WHERE creator_fk = %s)",
+                    (test_creator_fk, test_creator_fk))
+        cur.execute("DELETE FROM pipeline2_steps WHERE creator_fk = %s", (test_creator_fk,))
+        cur.execute("DELETE FROM pipeline2_epics WHERE creator_fk = %s", (test_creator_fk,))
+        cur.execute("DELETE FROM pipeline2_pipelines WHERE creator_fk = %s", (test_creator_fk,))
+        cur.execute("DELETE FROM requirements WHERE creator_fk = %s AND id = %s",
+                    (test_creator_fk, ids['requirement']))
+        cur.execute("DELETE FROM categories WHERE creator_fk = %s AND id = %s",
+                    (test_creator_fk, ids['category']))
+        cur.execute("DELETE FROM projects WHERE creator_fk = %s AND id = %s",
+                    (test_creator_fk, ids['project']))
+    db_connection.commit()
+
+
+# ---------------------------------------------------------------------------
+# SCH-001 / SCH-002 / SCH-003 — containment is in the DDL
+# ---------------------------------------------------------------------------
+
+def test_epic_belongs_to_exactly_one_pipeline(db_connection):
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'pipeline2_epics')
+    assert cols['pipeline_fk']['Null'] == 'NO'
+
+
+def test_step_belongs_to_exactly_one_epic(db_connection):
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'pipeline2_steps')
+    assert cols['epic_fk']['Null'] == 'NO'
+
+
+def test_step_carries_no_pipeline_reference(db_connection):
+    """A step's pipeline is reached through its epic — zero extra reads (§ 6)."""
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'pipeline2_steps')
+    assert 'pipeline_fk' not in cols
+
+
+# ---------------------------------------------------------------------------
+# SCH-004 — no step table in either era carries a state column
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('table', ['pipeline_steps', 'pipeline2_steps'])
+def test_no_step_table_carries_a_state_column(db_connection, table):
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, table)
+    assert 'state' not in cols and 'status' not in cols
+
+
+# ---------------------------------------------------------------------------
+# SCH-005 — dep_step_fk NOT NULL makes uq_p2_step_deps a TOTAL unique key
+# ---------------------------------------------------------------------------
+
+def test_step_deps_columns_have_no_time_gate(db_connection):
+    """SCH-006: the time gate is pipeline2_steps.not_before, not a dep row."""
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'pipeline2_step_deps')
+    assert set(cols.keys()) == {'id', 'step_fk', 'dep_step_fk'}
+    with db_connection.cursor() as cur:
+        step_cols = _columns(cur, 'pipeline2_steps')
+    assert 'not_before' in step_cols
+    assert step_cols['not_before']['Null'] == 'YES'
+
+
+def test_dep_step_fk_is_not_null(db_connection):
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'pipeline2_step_deps')
+    assert cols['dep_step_fk']['Null'] == 'NO'
+
+
+def test_duplicate_step_dependency_edge_is_refused(db_connection, p2_graph):
+    """The UNIQUE key is TOTAL (unlike 1.0's, where a nullable dep_step_fk lets
+    MySQL treat two NULLs as distinct): a second identical edge is a 1062, not
+    a silently accepted duplicate."""
+    with db_connection.cursor() as cur:
+        cur.execute("INSERT INTO pipeline2_step_deps (step_fk, dep_step_fk) "
+                    "VALUES (%s, %s)", (p2_graph['step_a'], p2_graph['step_b']))
+    db_connection.commit()
+
+    with pytest.raises(pymysql.err.IntegrityError) as exc:
+        with db_connection.cursor() as cur:
+            cur.execute("INSERT INTO pipeline2_step_deps (step_fk, dep_step_fk) "
+                        "VALUES (%s, %s)", (p2_graph['step_a'], p2_graph['step_b']))
+    db_connection.rollback()
+    assert exc.value.args[0] == 1062
+
+
+# ---------------------------------------------------------------------------
+# SCH-007 — pipeline2_step_requirements is asymmetric: step_fk CASCADE,
+# requirement_fk RESTRICT
+# ---------------------------------------------------------------------------
+
+def test_step_requirements_fk_actions_are_asymmetric(db_connection):
+    with db_connection.cursor() as cur:
+        step_update, step_delete = _referential_action(cur, 'fk_p2_psr_step')
+        req_update, req_delete = _referential_action(cur, 'fk_p2_psr_requirement')
+    assert (step_update, step_delete) == ('CASCADE', 'CASCADE')
+    assert (req_update, req_delete) == ('CASCADE', 'RESTRICT')
+
+
+# ---------------------------------------------------------------------------
+# SCH-008 — sort_order is NULLABLE, no default (stage-2 gate ruling, #3336)
+# ---------------------------------------------------------------------------
+
+def test_epics_sort_order_is_nullable_with_no_default(db_connection):
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'pipeline2_epics')
+    assert cols['sort_order']['Null'] == 'YES'
+    assert cols['sort_order']['Default'] is None
+
+
+# ---------------------------------------------------------------------------
+# SCH-010 — epic_status (suppression) and closed (completion) are distinct
+# ---------------------------------------------------------------------------
+
+def test_epic_status_and_closed_are_independent_columns(db_connection):
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'pipeline2_epics')
+    assert cols['epic_status']['Default'] == 'active'
+    assert cols['closed']['Default'] == '0'
+
+
+# ---------------------------------------------------------------------------
+# SCH-011 — pipeline_status keeps draft as the birth value
+# ---------------------------------------------------------------------------
+
+def test_pipeline_status_default_is_draft(db_connection):
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'pipeline2_pipelines')
+    assert cols['pipeline_status']['Default'] == 'draft'
+
+
+# ---------------------------------------------------------------------------
+# SCH-012 — deleting a pipeline cascades epics -> steps -> both edge tables,
+# and can never delete a requirement
+# ---------------------------------------------------------------------------
+
+def test_deleting_a_pipeline_cascades_and_spares_the_requirement(db_connection, p2_graph):
+    with db_connection.cursor() as cur:
+        cur.execute("INSERT INTO pipeline2_step_requirements (step_fk, requirement_fk) "
+                    "VALUES (%s, %s)", (p2_graph['step_a'], p2_graph['requirement']))
+        cur.execute("INSERT INTO pipeline2_step_deps (step_fk, dep_step_fk) "
+                    "VALUES (%s, %s)", (p2_graph['step_a'], p2_graph['step_b']))
+    db_connection.commit()
+
+    with db_connection.cursor() as cur:
+        cur.execute("DELETE FROM pipeline2_pipelines WHERE id = %s", (p2_graph['pipeline'],))
+    db_connection.commit()
+
+    with db_connection.cursor() as cur:
+        cur.execute("SELECT COUNT(*) AS n FROM pipeline2_epics WHERE id = %s",
+                    (p2_graph['epic'],))
+        assert cur.fetchone()['n'] == 0
+        cur.execute("SELECT COUNT(*) AS n FROM pipeline2_steps WHERE id IN (%s, %s)",
+                    (p2_graph['step_a'], p2_graph['step_b']))
+        assert cur.fetchone()['n'] == 0
+        cur.execute("SELECT COUNT(*) AS n FROM pipeline2_step_requirements "
+                    "WHERE step_fk = %s", (p2_graph['step_a'],))
+        assert cur.fetchone()['n'] == 0
+        cur.execute("SELECT COUNT(*) AS n FROM pipeline2_step_deps WHERE step_fk = %s",
+                    (p2_graph['step_a'],))
+        assert cur.fetchone()['n'] == 0
+        # The requirement itself is untouched — containment stops at Requirement.
+        cur.execute("SELECT COUNT(*) AS n FROM requirements WHERE id = %s",
+                    (p2_graph['requirement'],))
+        assert cur.fetchone()['n'] == 1
+
+
+# ---------------------------------------------------------------------------
+# SCH-030 — the explicit CREATE INDEX lines were measured, not assumed, and
+# none duplicates an FK-auto-created index
+# ---------------------------------------------------------------------------
+
+def _index_count_as_leftmost(cur, table, column):
+    cur.execute(f"SHOW INDEX FROM {table} WHERE Column_name = %s AND Seq_in_index = 1",
+                (column,))
+    return len(cur.fetchall())
+
+
+@pytest.mark.parametrize('table,column', [
+    ('pipeline2_epics', 'pipeline_fk'),
+    ('pipeline2_steps', 'epic_fk'),
+    ('pipeline2_step_deps', 'dep_step_fk'),
+    # Not a CREATE INDEX line — the gate-delta PRIMARY KEY (requirement_fk)
+    # alone already serves this lookup, which is why ix_p2_psr_requirement_fk
+    # does not exist. A future migration re-adding it alongside the PK would
+    # be the fourth duplicate the record's § 3.1 measurement excluded.
+    ('pipeline2_step_requirements', 'requirement_fk'),
+])
+def test_explicit_index_is_not_duplicated_by_the_fk_auto_index(db_connection, table, column):
+    """Measured 2026-08-08 against darwin_dev after the migration 20260808115509
+    apply: each of these four columns carries exactly ONE index with it as the
+    leftmost column — mirroring 1.0's identical measured behaviour on
+    pipeline_steps/pipeline_step_deps/pipeline_step_requirements. A second entry
+    here would mean a future migration re-introduced a duplicate."""
+    with db_connection.cursor() as cur:
+        n = _index_count_as_leftmost(cur, table, column)
+    assert n == 1, f'{table}.{column}: expected exactly 1 leftmost index, found {n}'
+
+
+# ---------------------------------------------------------------------------
+# SCH-036 — pipeline2_step_requirements PK is requirement_fk ALONE (stage-2
+# gate ruling, req #3336 §9): a requirement exists on at most one step,
+# structurally.
+# ---------------------------------------------------------------------------
+
+def test_step_requirements_primary_key_is_requirement_fk_alone(db_connection):
+    with db_connection.cursor() as cur:
+        cur.execute("SHOW KEYS FROM pipeline2_step_requirements WHERE Key_name = 'PRIMARY'")
+        pk_cols = [r['Column_name'] for r in cur.fetchall()]
+    assert pk_cols == ['requirement_fk']
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'pipeline2_step_requirements')
+    assert cols['step_fk']['Null'] == 'NO'
+    assert cols['step_fk']['Key'] != 'PRI'
+
+
+def test_a_requirement_cannot_be_seated_on_two_steps(db_connection, p2_graph):
+    """The structural proof: seating the SAME requirement on a second step is a
+    1062 on the PRIMARY KEY, not a silently accepted second row — this is what
+    'duplicate it if you need to run 2' (the user ruling) is enforcing against."""
+    with db_connection.cursor() as cur:
+        cur.execute("INSERT INTO pipeline2_step_requirements (step_fk, requirement_fk) "
+                    "VALUES (%s, %s)", (p2_graph['step_a'], p2_graph['requirement']))
+    db_connection.commit()
+
+    with pytest.raises(pymysql.err.IntegrityError) as exc:
+        with db_connection.cursor() as cur:
+            cur.execute("INSERT INTO pipeline2_step_requirements (step_fk, requirement_fk) "
+                        "VALUES (%s, %s)", (p2_graph['step_b'], p2_graph['requirement']))
+    db_connection.rollback()
+    assert exc.value.args[0] == 1062


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-08-08T12:52:34Z
- chore: init swarm session feature/3337-pipeline-20-the-five-parallel-plan-1

## Files changed
```
 .../20260808115509_pipeline2_plan_layer_tables.sql | 252 ++++++++++++++++
 schema.sql                                         | 203 ++++++++++++-
 scripts/recreate_darwin_dev.sql                    | 205 ++++++++++++-
 tests/conftest.py                                  |  16 +
 tests/test_data_types.py                           |   6 +
 tests/test_migration_naming.py                     |   1 +
 tests/test_migrations.py                           |  63 ++++
 tests/test_pipeline2_behaviours.py                 | 321 +++++++++++++++++++++
 8 files changed, 1064 insertions(+), 3 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)