### PR TITLE
Pipeline 2.0 - the requirement_test_cases junction and the re-homed MCP test-case surface

### DIFF
--- a/migrations/20260809002149_add_requirement_test_cases_junction_table.sql
+++ b/migrations/20260809002149_add_requirement_test_cases_junction_table.sql
@@ -1,0 +1,132 @@
+-- 20260809002149_add_requirement_test_cases_junction_table.sql
+--
+-- Req #3352: create requirement_test_cases, the junction Pipeline 2.0's
+-- Feature retirement leaves unowned when test cases re-home from Feature
+-- onto Requirement (memory/pipeline-2-mcp-surface.md § 6.4, § 7.6).
+--
+-- PROBLEM.  Stage 1 decides test cases attach to Requirement, not Feature.
+--           `feature_test_cases` is the only table that links a test_case to
+--           anything, and no stage-2 schema record claims the replacement —
+--           left this way, the re-pointed MCP tools (req #3332) would have
+--           no table to write to.
+--
+-- SHAPE.    `requirement_test_cases (requirement_fk, test_case_fk)`, shaped
+--           directly on `feature_test_cases` which it stands beside (that
+--           table is NOT dropped here — see below). Composite PRIMARY KEY,
+--           both sides CASCADE: a link is neither parent's identity, and a
+--           test case that loses its last requirement is still a test case.
+--           The table exists because a test case asserts a deliverable and
+--           Requirement, not Feature, is the level that organizes
+--           deliverables — that is the whole of the design; there is no
+--           second shape to weigh against it.
+--
+-- TARGET.   NEVER write `USE <db>;` or `CREATE DATABASE` into this file. A
+--           `USE` is a statement, not a declaration: it re-points the session
+--           the moment it executes and overrides whatever database the caller
+--           named — which on 2026-08-01 sent a dev-aimed apply to production.
+--           load_sql.py REFUSES a file that names its own database, and
+--           DarwinSQL/tests/test_sql_targets.py fails the build (req #3196).
+--           No `-- darwin:targets` declaration here, deliberately: this is
+--           ordinary DDL that will eventually apply to production too (the
+--           data-architecture record's own `planned` requirement is that
+--           gate), so declaring `darwin_dev` here would be a target list
+--           omitting `darwin` — an ABSOLUTE, unoverridable production ban
+--           per db_guard.py that would block that later requirement from
+--           ever applying this exact file. Req #3352's darwin_dev-only scope
+--           is enforced procedurally, by which command is actually run below.
+--
+-- APPLY.    darwin_dev ONLY, for this requirement. Production DDL is
+--           explicitly out of scope (req #3352 body item 2) and is a later
+--           requirement's gate, not this one's:
+--
+--             python3 DarwinSQL/scripts/load_sql.py \
+--               DarwinSQL/migrations/20260809002149_add_requirement_test_cases_junction_table.sql darwin_dev
+--
+-- Migration id 20260809002149 is a UTC timestamp allocated by
+-- DarwinSQL/scripts/new-migration.sh (req #3121). Do not renumber it.
+
+CREATE TABLE IF NOT EXISTS requirement_test_cases (
+    requirement_fk  INT             NOT NULL,
+    test_case_fk    INT             NOT NULL,
+    PRIMARY KEY (requirement_fk, test_case_fk),
+    CONSTRAINT fk_rtc_requirement
+        FOREIGN KEY (requirement_fk) REFERENCES requirements (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_rtc_case
+        FOREIGN KEY (test_case_fk) REFERENCES test_cases (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+-- ---------------------------------------------------------------------------
+-- BACKFILL — the 28-row translation (req #3352 body item 0)
+-- ---------------------------------------------------------------------------
+-- `feature_test_cases` holds 28 rows in PRODUCTION today — 15 on feature 23
+-- ("Aggregator Card — Combined Ride Map"), 13 on feature 24 ("Aggregator Card
+-- — Photo Aggregation") — and a feature maps to MANY requirements, so there is
+-- no mechanical feature -> requirement rule; each row below is a judgement
+-- call, made by reading every test case's title/steps/expected text and
+-- matching it against the requirement whose acceptance criteria it actually
+-- asserts. Recorded here, once, because a test case carries no back-reference
+-- to a feature — once `feature_test_cases` is gone (req #3334's eradication,
+-- not this migration) the mapping is UNRECOVERABLE if it is not captured now.
+--
+-- Disposition of all 28 (test_case_fk -> requirement_fk):
+--   Feature 23 ("Combined Ride Map", epic #6):
+--     1  -> 3174  "Aggregator card renders first..." (hybrid manual+automated;
+--                  siblings 2 and 3 both cite #3174 explicitly in their own
+--                  steps text, this one does not — LOWER CONFIDENCE, flagged)
+--     2  -> 3174  cites req #3174 directly (toggle persistence)
+--     3  -> 3174  cites req #3174 directly (scale/cap; also mentions #3315,
+--                  but #3315 is `authoring` today and the case's own describe
+--                  block is the #3174 component-coverage suite)
+--     9  -> 3158  describe block is req #3158 (core story acceptance)
+--     10 -> 3158
+--     11 -> 3158
+--     12 -> 3158
+--     13 -> 3158
+--     14 -> 3158
+--     15 -> 3158
+--     16 -> 3159  describe(... req #3159): tests the coordinate feed INTO the
+--                  photo layer, so it is #3159's acceptance despite sitting
+--                  on feature 23
+--     17 -> 3158
+--     18 -> 3158
+--     27 -> 3174  req #3174 body names this exact case ("Optional E2E: toggle
+--                  persistence across reload") as its own recorded-not-required
+--                  coverage
+--     28 -> 3174  req #3174 body names this exact case ("toggle hidden outside
+--                  cards view") the same way
+--   Feature 24 ("Photo Aggregation", epic #6):
+--     4  -> 3163  pure-function unit coverage (collectPhotosForRuns) — matches
+--                  #3163's "add targeted unit coverage for new pure logic"
+--     5  -> 3163
+--     6  -> 3163
+--     7  -> 3163
+--     8  -> 3159  core story acceptance (aggregated photo markers)
+--     19 -> 3159
+--     20 -> 3159
+--     21 -> 3159
+--     22 -> 3159
+--     23 -> 3159
+--     24 -> 3163  pure-function unit coverage (gridFitLayout)
+--     25 -> 3163  cites req #3163 directly
+--     26 -> 3163  cites req #3163 directly
+--
+-- INSERT IGNORE, not INSERT: this migration applies to darwin_dev NOW, where
+-- none of these requirement_fk/test_case_fk ids exist yet (darwin_dev's
+-- `test_cases` table is empty), so every row is silently skipped there today
+-- — the FK constraint failure becomes a warning per row instead of aborting
+-- the whole statement. The SAME file, unmodified, is what req #3352's body
+-- names as the later production apply (a separate `planned` requirement's
+-- gate, not this one's) — at that point these ids DO exist and the backfill
+-- lands for real. One migration file, one act, whichever database it runs
+-- against — no second copy of this decision to drift from this one.
+INSERT IGNORE INTO requirement_test_cases (requirement_fk, test_case_fk) VALUES
+    (3174, 1), (3174, 2), (3174, 3),
+    (3158, 9), (3158, 10), (3158, 11), (3158, 12), (3158, 13), (3158, 14), (3158, 15),
+    (3159, 16),
+    (3158, 17), (3158, 18),
+    (3174, 27), (3174, 28),
+    (3163, 4), (3163, 5), (3163, 6), (3163, 7),
+    (3159, 8), (3159, 19), (3159, 20), (3159, 21), (3159, 22), (3159, 23),
+    (3163, 24), (3163, 25), (3163, 26);

--- a/schema.sql
+++ b/schema.sql
@@ -1,5 +1,5 @@
 -- Darwin Database Schema — Current State
--- This file reflects the final state of all 58 tables after all migrations.
+-- This file reflects the final state of all 59 tables after all migrations.
 -- It can be run against a fresh MySQL instance to create the complete schema.
 -- Table order respects FK dependencies.
 --
@@ -747,6 +747,23 @@ CREATE TABLE IF NOT EXISTS feature_test_cases (
         FOREIGN KEY (feature_fk) REFERENCES features (id)
         ON UPDATE CASCADE ON DELETE CASCADE,
     CONSTRAINT fk_ftc_case
+        FOREIGN KEY (test_case_fk) REFERENCES test_cases (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+-- requirement_test_cases (req #3352, migration 20260809002149) — Pipeline 2.0
+-- re-homes test cases from Feature onto Requirement: a test case asserts a
+-- deliverable and Requirement, not Feature, is the level that organizes
+-- deliverables. Stands BESIDE feature_test_cases, not in place of it, until
+-- the Feature-era eradication sequencing (req #3334) retires the old table.
+CREATE TABLE IF NOT EXISTS requirement_test_cases (
+    requirement_fk  INT             NOT NULL,
+    test_case_fk    INT             NOT NULL,
+    PRIMARY KEY (requirement_fk, test_case_fk),
+    CONSTRAINT fk_rtc_requirement
+        FOREIGN KEY (requirement_fk) REFERENCES requirements (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_rtc_case
         FOREIGN KEY (test_case_fk) REFERENCES test_cases (id)
         ON UPDATE CASCADE ON DELETE CASCADE
 );

--- a/tests/test_cascades.py
+++ b/tests/test_cascades.py
@@ -985,6 +985,87 @@ def test_delete_test_case_cascades_to_feature_test_cases(db_connection):
     db_connection.rollback()
 
 
+# COVERS: SCH-031
+def test_delete_requirement_cascades_to_requirement_test_cases(db_connection):
+    """req #3352 — DELETE requirement → CASCADE removes its requirement_test_cases
+    rows. Mirrors test_delete_feature_cascades_to_feature_test_cases above."""
+    with db_connection.cursor() as cur:
+        creator, _project, category_id = _setup_validation_creator(cur, 'cascade-req-del')
+        cur.execute(
+            "INSERT INTO requirements (title, category_fk, creator_fk) "
+            "VALUES (%s, %s, %s)",
+            ('req', category_id, creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        requirement_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO test_cases (title, steps, expected, category_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            ('case2', '1', 'ok', category_id, creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        case_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO requirement_test_cases (requirement_fk, test_case_fk) VALUES (%s, %s)",
+            (requirement_id, case_id)
+        )
+
+        cur.execute("DELETE FROM requirements WHERE id = %s", (requirement_id,))
+
+        cur.execute(
+            "SELECT COUNT(*) AS c FROM requirement_test_cases "
+            "WHERE requirement_fk = %s OR test_case_fk = %s",
+            (requirement_id, case_id)
+        )
+        assert cur.fetchone()['c'] == 0  # CASCADE removed the junction row
+        # Test case itself is untouched
+        cur.execute("SELECT id FROM test_cases WHERE id = %s", (case_id,))
+        assert cur.fetchone() is not None
+    db_connection.rollback()
+
+
+# COVERS: SCH-031
+def test_delete_test_case_cascades_to_requirement_test_cases(db_connection):
+    """req #3352 — DELETE test_case → CASCADE removes its requirement_test_cases
+    rows. Mirrors test_delete_test_case_cascades_to_feature_test_cases above."""
+    with db_connection.cursor() as cur:
+        creator, _project, category_id = _setup_validation_creator(cur, 'cascade-req-case-del')
+        cur.execute(
+            "INSERT INTO requirements (title, category_fk, creator_fk) "
+            "VALUES (%s, %s, %s)",
+            ('req2', category_id, creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        requirement_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO test_cases (title, steps, expected, category_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            ('case3', '1', 'ok', category_id, creator)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        case_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO requirement_test_cases (requirement_fk, test_case_fk) VALUES (%s, %s)",
+            (requirement_id, case_id)
+        )
+
+        cur.execute("DELETE FROM test_cases WHERE id = %s", (case_id,))
+
+        cur.execute(
+            "SELECT COUNT(*) AS c FROM requirement_test_cases WHERE test_case_fk = %s",
+            (case_id,)
+        )
+        assert cur.fetchone()['c'] == 0
+        # Requirement itself untouched
+        cur.execute("SELECT id FROM requirements WHERE id = %s", (requirement_id,))
+        assert cur.fetchone() is not None
+    db_connection.rollback()
+
+
 def test_delete_test_plan_with_runs_rejected(db_connection):
     """DELETE test_plan with live test_runs → IntegrityError (ON DELETE RESTRICT).
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1046,6 +1046,40 @@ def test_feature_test_cases_composite_pk(db_connection, test_creator_fk, test_ca
     db_connection.rollback()
 
 
+# COVERS: SCH-031
+def test_requirement_test_cases_composite_pk(db_connection, test_creator_fk, test_category_id):
+    """req #3352 — Second INSERT requirement_test_cases with same
+    (requirement_fk, test_case_fk) → IntegrityError. Mirrors
+    test_feature_test_cases_composite_pk above."""
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO requirements (title, category_fk, creator_fk, "
+            "requirement_status, coordination_type, ai_model, effort) "
+            "VALUES (%s, %s, %s, 'authoring', 'implemented', 'opus', 'high')",
+            ('r-dup', test_category_id, test_creator_fk)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        r_id = cur.fetchone()['id']
+        cur.execute(
+            "INSERT INTO test_cases (title, steps, expected, category_fk, creator_fk) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            ('tc-dup2', '1', 'ok', test_category_id, test_creator_fk)
+        )
+        cur.execute("SELECT LAST_INSERT_ID() AS id")
+        tc_id = cur.fetchone()['id']
+
+        cur.execute(
+            "INSERT INTO requirement_test_cases (requirement_fk, test_case_fk) VALUES (%s, %s)",
+            (r_id, tc_id)
+        )
+        with pytest.raises(pymysql.IntegrityError):
+            cur.execute(
+                "INSERT INTO requirement_test_cases (requirement_fk, test_case_fk) VALUES (%s, %s)",
+                (r_id, tc_id)
+            )
+    db_connection.rollback()
+
+
 # ---------------------------------------------------------------------------
 # Req #2943 — machines registry constraints
 # ---------------------------------------------------------------------------

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1578,6 +1578,37 @@ def test_feature_test_cases_columns(db_connection):
     assert columns['test_case_fk']['Key'] in ('PRI', 'MUL')
 
 
+# COVERS: SCH-031, SCH-034
+def test_requirement_test_cases_columns(db_connection):
+    """req #3352 — requirement_test_cases junction (migration 20260809002149),
+    composite PK, no id. Mirrors test_feature_test_cases_columns above — both
+    junctions exist at once, feature_test_cases is not dropped by this one."""
+    with db_connection.cursor() as cur:
+        cur.execute("DESCRIBE requirement_test_cases")
+        columns = {row['Field']: row for row in cur.fetchall()}
+
+    expected_fields = ['requirement_fk', 'test_case_fk']
+    assert set(columns.keys()) == set(expected_fields), \
+        f"Unexpected columns: {set(columns.keys()) - set(expected_fields)}"
+
+    # Both FKs are primary key parts (composite PK)
+    assert columns['requirement_fk']['Type'] == 'int'
+    assert columns['requirement_fk']['Null'] == 'NO'
+    assert columns['requirement_fk']['Key'] == 'PRI'
+
+    assert columns['test_case_fk']['Type'] == 'int'
+    assert columns['test_case_fk']['Null'] == 'NO'
+    # MySQL reports non-leading composite PK columns as 'MUL'
+    assert columns['test_case_fk']['Key'] in ('PRI', 'MUL')
+
+    # feature_test_cases still exists — both eras run at once (req #3334's
+    # eradication sequencing is what would eventually drop it, not this one).
+    with db_connection.cursor() as cur:
+        cur.execute("SHOW TABLES LIKE 'feature_test_cases'")
+        assert cur.fetchone() is not None, \
+            "feature_test_cases must not be dropped by the junction requirement"
+
+
 def test_test_plans_columns(db_connection):
     """Verify test_plans column definitions match schema.sql (migration 043)."""
     with db_connection.cursor() as cur:
@@ -1801,6 +1832,11 @@ def test_table_count(db_connection):
         # chain Pipeline -> Epic -> Step -> Requirement.
         'pipeline2_pipelines', 'pipeline2_epics', 'pipeline2_steps',
         'pipeline2_step_requirements', 'pipeline2_step_deps',
+        # Req #3352 — Pipeline 2.0 Feature retirement: test cases re-home onto
+        # Requirement (migration 20260809002149). Stands beside
+        # feature_test_cases above, not in its place, until req #3334's
+        # eradication sequencing.
+        'requirement_test_cases',
     }
     assert expected_tables == tables, \
         f"Unexpected tables: {tables - expected_tables}, missing: {expected_tables - tables}"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -107,6 +107,10 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         # (e.g., 'test_cases' inside 'feature_test_cases' is blocked by the
         # regex lookbehind, but longest-first preserves future safety.)
         'feature_test_cases',
+        # Req #3352 — requirement_test_cases (migration 20260809002149). Listed
+        # before the shorter 'requirements' and 'test_cases' tokens (below) so
+        # the longer match wins under longest-first replace order.
+        'requirement_test_cases',
         'test_plan_cases',
         'test_results',
         'test_plans',
@@ -274,6 +278,8 @@ def _apply_migration(cur, sql_content, table_prefix, tolerant=False):
         'fk_p2_psd_step', 'fk_p2_psd_dep_step',
         'uq_p2_step_deps',
         'ix_p2_epics_pipeline_fk', 'ix_p2_steps_epic_fk', 'ix_p2_psd_dep_step_fk',
+        # Migration 20260809002149 — requirement_test_cases (req #3352)
+        'fk_rtc_requirement', 'fk_rtc_case',
     ]
     for cname in named_constraints:
         sql = sql.replace(cname, f'{table_prefix}_{cname}')
@@ -366,8 +372,11 @@ ALL_TABLE_SUFFIXES = [
     # test_results → test_runs CASCADE; test_runs → test_plans RESTRICT;
     # feature_test_cases/test_plan_cases CASCADE from both sides;
     # test_results → test_cases RESTRICT (so test_results must drop before test_cases).
+    # Req #3352 — requirement_test_cases (migration 20260809002149) CASCADEs
+    # from both requirements and test_cases, same shape as feature_test_cases;
+    # it drops here too, a leaf before both requirements (below) and test_cases.
     'test_results', 'test_runs',
-    'test_plan_cases', 'feature_test_cases',
+    'test_plan_cases', 'feature_test_cases', 'requirement_test_cases',
     'test_plans', 'test_cases', 'features',
     # Req #3111 — epics drops after features (epics -> categories is RESTRICT;
     # features.epic_fk is SET NULL so it imposes no order of its own).
@@ -610,6 +619,9 @@ def test_migration_sequence_applies(db_connection, migration_test_prefix):
             # parallel era. Stands beside the 1.0 five above; not a replacement.
             'pipeline2_pipelines', 'pipeline2_epics', 'pipeline2_steps',
             'pipeline2_step_requirements', 'pipeline2_step_deps',
+            # Req #3352 — requirement_test_cases (migration 20260809002149).
+            # Stands beside feature_test_cases above; not a replacement.
+            'requirement_test_cases',
         ]
     }
     assert tables == expected_tables, \


### PR DESCRIPTION
## Summary
- Merge branch 'main' of https://github.com/BillWilliams79/DarwinSQL into feature/3352-pipeline-20-the-requirement-test-1
- wip(DarwinSQL): 2026-08-09T01:50:00Z
- chore: init swarm session feature/3352-pipeline-20-the-requirement-test-1

## Files changed
```
 ...9_add_requirement_test_cases_junction_table.sql | 132 +++++++++++++++++++++
 schema.sql                                         |  19 ++-
 tests/test_cascades.py                             |  81 +++++++++++++
 tests/test_constraints.py                          |  34 ++++++
 tests/test_data_types.py                           |  36 ++++++
 tests/test_migrations.py                           |  14 ++-
 6 files changed, 314 insertions(+), 2 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Related PRs: BillWilliams79/DarwinAI-Config#903, BillWilliams79/AWS-Lambda-REST-API#80