### PR TITLE
Pipeline 2.0 - orchestration_claims serves both eras: the additive parallel-era reservation shape

### DIFF
--- a/migrations/20260809024954_add_orchestration_claims_parallel_era_reservation_columns.sql
+++ b/migrations/20260809024954_add_orchestration_claims_parallel_era_reservation_columns.sql
@@ -1,0 +1,127 @@
+-- 20260809024954_add_orchestration_claims_parallel_era_reservation_columns.sql
+--
+-- Req #3369: let `orchestration_claims` reserve a 2.0 (pipeline2_*) scope as
+-- well as a 1.0 one, so the single-orchestrator guarantee still holds when a
+-- human is orchestrating pipeline 2 in 1.0 and its 2.0 image at the same time.
+--
+-- PROBLEM.  memory/pipeline-2-first-principles.md stage 1 said this table is
+--           "re-pointed rather than created". memory/pipeline-2-data-architecture.md
+--           § 9.4 overturns that: a reservation is a MUTUAL-EXCLUSION device,
+--           so two separate tables (1.0's and a hypothetical 2.0-only one)
+--           would not exclude each other at all — the exact double-launch
+--           req #3224 exists to prevent. And re-pointing the existing FKs at
+--           the 2.0 tables does not produce sharing, it produces a 2.0-ONLY
+--           table, for three independent reasons:
+--
+--             * An FK is a static declaration, not an alternation. Point
+--               `fk_oc_pipeline` at `pipeline2_pipelines` and every 1.0 claim
+--               fails FK 1452 — 1.0 orchestration stops working outright,
+--               while 1.0 is the very plan that builds 2.0.
+--             * Mutual exclusion ACROSS two id spaces is not expressible as
+--               an FK at all — it needs a service-layer predicate reading
+--               rows from both eras, and re-pointing deletes the ability to
+--               STORE the rows that predicate would read.
+--             * The two AUTO_INCREMENT sequences are a HAZARD, not a
+--               guarantee: where they overlap, a 1.0 `pipeline_fk` would
+--               numerically satisfy a 2.0 FK while naming a DIFFERENT plan —
+--               silent mis-scoping instead of a hard error, strictly worse
+--               for a mutual-exclusion device than simply failing.
+--
+-- SHAPE.    ONE table serving BOTH eras. `pipeline2_fk` / `epic2_fk`, both
+--           NULLable, sit BESIDE the existing `pipeline_fk` / `epic_fk` pair
+--           rather than replacing them. `pipeline_fk` — NOT NULL since
+--           migration 20260801150404 — becomes NULLable here too: era is
+--           discriminated by WHICH PAIR IS NON-NULL, and that discrimination
+--           is meaningless unless a 2.0-only claim can leave the 1.0 pair
+--           empty.
+--
+--           `epic2_key = COALESCE(epic2_fk, 0)` is the SAME generated-column
+--           trick `epic_key` already carries, needed a second time for the
+--           same reason req #3224 recorded: MySQL treats NULLs in a UNIQUE
+--           index as DISTINCT, so a key written directly over a nullable
+--           `epic2_fk` would let TWO 2.0 whole-plan claims on one 2.0
+--           pipeline both insert — exactly the collision the constraint
+--           exists to stop.
+--
+--           TWO SEPARATE UNIQUE KEYS, not one widened key, and this is a
+--           correction worth stating plainly. `pipeline_fk` is now NULLable
+--           on every 2.0 claim, and MySQL's NULL-is-distinct rule means ANY
+--           NULL column in a composite key exempts that row from the whole
+--           key — so a single key over all four columns would let two 2.0
+--           whole-plan claims on the SAME 2.0 pipeline both insert (both rows
+--           read `pipeline_fk = NULL`, and NULL is never equal to NULL for
+--           uniqueness purposes), identical to the bug `epic_key` was built
+--           to close. `uq_orchestration_claims_scope` (unchanged) governs 1.0
+--           duplicates; the new `uq_orchestration_claims_scope2` governs 2.0
+--           duplicates. Rows of the OTHER era carry NULL in the columns the
+--           key does not apply to and are correctly exempt from it — which is
+--           what makes two separate keys sufficient rather than a gap.
+--
+--           BOTH-OR-NEITHER IS AN APPLICATION-LAYER REFUSAL, not a SQL CHECK
+--           constraint — Darwin does not use CHECK constraints (see
+--           memory/new-data-type-pattern.md and migration
+--           20260808101938's `machines.max_live_sessions`: "negative is
+--           refused in the application layer, since Darwin does not use CHECK
+--           constraints"). `darwin-mcp/services/orchestration_claims.py`
+--           refuses a `claim_orchestration` call that names no scope (both
+--           pairs NULL) or both scopes (both pairs non-NULL) before ever
+--           reaching the database, exactly as `machines.max_live_sessions`
+--           refuses a negative ceiling in Lambda-Rest rather than in DDL.
+--
+--           Both new FKs are `ON DELETE CASCADE`/`ON UPDATE CASCADE`, matching
+--           the existing 1.0 pair: a reservation on a deleted 2.0 plan or
+--           epic is a reservation on nothing and should not survive it.
+--
+--           THE CROSS-ERA REFUSAL ITSELF — "a 2.0 claim on a plan whose 1.0
+--           image is already claimed is refused, and vice versa" — is also a
+--           SERVICE predicate and also lives in
+--           `darwin-mcp/services/orchestration_claims.py`, not here: the
+--           mapping between a 1.0 plan/epic id and its 2.0 image is DATA (the
+--           importer's own id map, scripts/swarm/import_plan_1to2.py), and no
+--           schema constraint can read it.
+--
+--           TRANSITIONAL, and said so in the code it lives in: this whole
+--           additive shape exists only for the parallel era. #3356 phase 4
+--           drops the 1.0 columns and renames the 2.0 ones at eradication —
+--           this migration is that moment's clean seam, not a permanent
+--           design.
+--
+-- TARGET.   No `-- darwin:targets` declaration: this migration is safe on
+--           both `darwin_dev` and `darwin`, like the table's original
+--           migration (20260801150404).
+--
+-- APPLY.    darwin_dev FIRST, production SECOND. Two separate commands:
+--
+--             python3 DarwinSQL/scripts/load_sql.py \
+--               DarwinSQL/migrations/20260809024954_add_orchestration_claims_parallel_era_reservation_columns.sql darwin_dev
+--
+--             python3 DarwinSQL/scripts/load_sql.py \
+--               DarwinSQL/migrations/20260809024954_add_orchestration_claims_parallel_era_reservation_columns.sql darwin --production
+--
+--           Production is named TWICE — by name and by intent. The loader
+--           refuses `darwin` without --production, and refuses --production on
+--           any other database (req #3196). The production command also
+--           requires `bash scripts/db/rds-snapshot.sh 20260809024954` to report
+--           status=ok first. See memory/database.md § Schema Migration Workflow.
+--
+-- Migration id 20260809024954 is a UTC timestamp allocated by
+-- DarwinSQL/scripts/new-migration.sh (req #3121). Do not renumber it.
+
+ALTER TABLE orchestration_claims
+    MODIFY COLUMN pipeline_fk INT NULL,                  -- 1.0 scope; NULL on a 2.0 claim
+    ADD COLUMN pipeline2_fk   INT NULL DEFAULT NULL,      -- 2.0 scope; NULL on a 1.0 claim
+    ADD COLUMN epic2_fk       INT NULL DEFAULT NULL,      -- NULL = 2.0 whole-plan scope
+    -- Carries the SECOND unique key, the same trick as epic_key, needed again
+    -- for the same reason (see SHAPE above).
+    ADD COLUMN epic2_key      INT GENERATED ALWAYS AS (COALESCE(epic2_fk, 0)) VIRTUAL;
+
+ALTER TABLE orchestration_claims
+    ADD CONSTRAINT fk_oc_pipeline2
+        FOREIGN KEY (pipeline2_fk) REFERENCES pipeline2_pipelines (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    ADD CONSTRAINT fk_oc_epic2
+        FOREIGN KEY (epic2_fk) REFERENCES pipeline2_epics (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    ADD UNIQUE KEY uq_orchestration_claims_scope2 (pipeline2_fk, epic2_key);
+
+CREATE INDEX ix_orchestration_claims_epic2_fk ON orchestration_claims (epic2_fk);

--- a/schema.sql
+++ b/schema.sql
@@ -1382,65 +1382,6 @@ CREATE TABLE IF NOT EXISTS pipeline_step_deps (
 CREATE INDEX ix_psd_dep_step_fk ON pipeline_step_deps (dep_step_fk);
 
 -- ---------------------------------------------------------------------------
--- Orchestration reservations (req #3224, migration 20260801150404)
--- ---------------------------------------------------------------------------
--- ONE row per RESERVED SCOPE. The single-orchestrator guarantee, made durable
--- and shared so it crosses a machine boundary — the machine-local registry
--- under /tmp cannot, and `kill(pid, 0)` is only answerable on the machine that
--- owns the pid. The CONFLICT RULE is unchanged: a whole-plan scope owns every
--- step in its plan and conflicts with any scope on it; two epic scopes conflict
--- only when they are the same epic (design rule 10 makes step -> orchestrator a
--- function).
---
--- `pipeline_fk` + `epic_fk` ARE the scope; there is no `scope` string, because
--- `pipeline:2` / `epic:7@2` is a RENDERING of those ids (design rule 1).
--- `epic_key` carries the UNIQUE key because MySQL treats NULLs in a UNIQUE index
--- as DISTINCT — over `epic_fk` directly, two whole-plan claims would both
--- insert, which is the collision the constraint exists to stop. Same device as
--- agent_documents.owned_document_fk.
---
--- LIVENESS IS HEARTBEAT AGE ON A DB-STAMPED CLOCK (`update_ts`, falling back to
--- `claimed_at` before the first heartbeat), never `engine_pid` — that column is
--- there so a HUMAN can find the process, and reading a remote pid as liveness is
--- the mistake this table corrects. `polls` is the heartbeat's payload because
--- ON UPDATE CURRENT_TIMESTAMP only fires when a value actually CHANGES.
--- Staleness (600 s = ten default engine cycles) is enforced in
--- darwin-mcp/services/orchestration_claims.py; a schema cannot express it.
---
--- DISTINCT FROM PAUSE (req #3223) and deliberately not merged with it: a
--- reservation is a live claim reclaimed on staleness, a pause is a user
--- intention that must never be.
-CREATE TABLE IF NOT EXISTS orchestration_claims (
-    id            INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    pipeline_fk   INT          NOT NULL,                -- the plan this claim covers
-    epic_fk       INT          NULL DEFAULT NULL,       -- NULL = whole-plan scope
-    epic_key      INT          AS (COALESCE(epic_fk, 0)) VIRTUAL,  -- carries the UNIQUE key
-    machine_fk    INT          NULL DEFAULT NULL,       -- WHERE it runs
-    terminal_pid  INT          NULL DEFAULT NULL,       -- the Claude Code CLI process
-    engine_pid    INT          NULL DEFAULT NULL,       -- DIAGNOSTIC ONLY, never liveness
-    polls         INT          NOT NULL DEFAULT 0,      -- the heartbeat payload
-    claimed_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    creator_fk    VARCHAR(64)  NOT NULL,
-    create_ts     TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
-    update_ts     TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,  -- THE liveness clock
-    UNIQUE KEY uq_orchestration_claims_scope (pipeline_fk, epic_key),
-    CONSTRAINT fk_oc_pipeline
-        FOREIGN KEY (pipeline_fk) REFERENCES pipelines (id)
-        ON UPDATE CASCADE ON DELETE CASCADE,
-    CONSTRAINT fk_oc_epic
-        FOREIGN KEY (epic_fk) REFERENCES epics (id)
-        ON UPDATE CASCADE ON DELETE CASCADE,
-    CONSTRAINT fk_oc_machine
-        FOREIGN KEY (machine_fk) REFERENCES machines (id)
-        ON UPDATE CASCADE ON DELETE RESTRICT,
-    CONSTRAINT fk_oc_creator
-        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
-        ON UPDATE CASCADE ON DELETE CASCADE
-);
-
-CREATE INDEX ix_orchestration_claims_epic_fk ON orchestration_claims (epic_fk);
-
--- ---------------------------------------------------------------------------
 -- Pipeline 2.0 — the plan layer (req #3328 design; parallel era)
 -- ---------------------------------------------------------------------------
 -- FIVE tables standing BESIDE the 1.0 five, not replacing them. Both eras run
@@ -1640,3 +1581,97 @@ CREATE TABLE IF NOT EXISTS pipeline2_step_deps (
 );
 
 CREATE INDEX ix_p2_psd_dep_step_fk ON pipeline2_step_deps (dep_step_fk);
+
+-- ---------------------------------------------------------------------------
+-- Orchestration reservations (req #3224, migration 20260801150404) — SERVES
+-- BOTH ERAS since req #3369, migration 20260809024954. Defined here, after
+-- both the 1.0 and 2.0 plan layers, because it carries a live FK into each.
+-- ---------------------------------------------------------------------------
+-- ONE row per RESERVED SCOPE. The single-orchestrator guarantee, made durable
+-- and shared so it crosses a machine boundary — the machine-local registry
+-- under /tmp cannot, and `kill(pid, 0)` is only answerable on the machine that
+-- owns the pid. The CONFLICT RULE is unchanged: a whole-plan scope owns every
+-- step in its plan and conflicts with any scope on it; two epic scopes conflict
+-- only when they are the same epic (design rule 10 makes step -> orchestrator a
+-- function).
+--
+-- `pipeline_fk` + `epic_fk` ARE the 1.0 scope; there is no `scope` string,
+-- because `pipeline:2` / `epic:7@2` is a RENDERING of those ids (design
+-- rule 1). `epic_key` carries the UNIQUE key because MySQL treats NULLs in a
+-- UNIQUE index as DISTINCT — over `epic_fk` directly, two whole-plan claims
+-- would both insert, which is the collision the constraint exists to stop.
+-- Same device as agent_documents.owned_document_fk.
+--
+-- LIVENESS IS HEARTBEAT AGE ON A DB-STAMPED CLOCK (`update_ts`, falling back to
+-- `claimed_at` before the first heartbeat), never `engine_pid` — that column is
+-- there so a HUMAN can find the process, and reading a remote pid as liveness is
+-- the mistake this table corrects. `polls` is the heartbeat's payload because
+-- ON UPDATE CURRENT_TIMESTAMP only fires when a value actually CHANGES.
+-- Staleness (600 s = ten default engine cycles) is enforced in
+-- darwin-mcp/services/orchestration_claims.py; a schema cannot express it.
+--
+-- DISTINCT FROM PAUSE (req #3223) and deliberately not merged with it: a
+-- reservation is a live claim reclaimed on staleness, a pause is a user
+-- intention that must never be.
+--
+-- SERVES BOTH ERAS (req #3369), and this is TRANSITIONAL — the shape exists
+-- only for the parallel period and dies at eradication (#3356 phase 4 drops
+-- the 1.0 columns and renames the 2.0 ones). `pipeline2_fk` / `epic2_fk` sit
+-- BESIDE the 1.0 pair rather than replacing it — a reservation is a
+-- mutual-exclusion device, so re-pointing the existing FKs would produce a
+-- 2.0-ONLY table and stop 1.0 orchestration outright
+-- (memory/pipeline-2-data-architecture.md § 9.4). `pipeline_fk` becomes
+-- NULLable here too: era is discriminated by WHICH PAIR IS NON-NULL, refused
+-- if it is neither or both — an APPLICATION-LAYER check in
+-- darwin-mcp/services/orchestration_claims.py, not a SQL CHECK constraint
+-- (Darwin does not use them). `epic2_key` is the SAME generated-column trick
+-- as `epic_key`, needed a second time for the 2.0 pair, and it carries its
+-- OWN unique key (`uq_orchestration_claims_scope2`) rather than widening the
+-- 1.0 one: `pipeline_fk` is now nullable on every 2.0 row, and MySQL's
+-- NULL-is-distinct rule would exempt every 2.0 row from a single combined
+-- key regardless of the other columns' equality — identical to the bug
+-- `epic_key` was built to close. THE CROSS-ERA REFUSAL — a 2.0 claim on a
+-- plan whose 1.0 image is already claimed, and vice versa — is also a
+-- service predicate, keyed on the importer's own id map
+-- (scripts/swarm/import_plan_1to2.py): no schema constraint can express a
+-- mapping between two id spaces that is itself data.
+CREATE TABLE IF NOT EXISTS orchestration_claims (
+    id            INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    pipeline_fk   INT          NULL DEFAULT NULL,       -- 1.0 scope; NULL on a 2.0 claim
+    epic_fk       INT          NULL DEFAULT NULL,       -- NULL = 1.0 whole-plan scope
+    epic_key      INT          AS (COALESCE(epic_fk, 0)) VIRTUAL,  -- carries uq_..._scope
+    pipeline2_fk  INT          NULL DEFAULT NULL,       -- 2.0 scope; NULL on a 1.0 claim
+    epic2_fk      INT          NULL DEFAULT NULL,       -- NULL = 2.0 whole-plan scope
+    epic2_key     INT          AS (COALESCE(epic2_fk, 0)) VIRTUAL, -- carries uq_..._scope2
+    machine_fk    INT          NULL DEFAULT NULL,       -- WHERE it runs
+    terminal_pid  INT          NULL DEFAULT NULL,       -- the Claude Code CLI process
+    engine_pid    INT          NULL DEFAULT NULL,       -- DIAGNOSTIC ONLY, never liveness
+    polls         INT          NOT NULL DEFAULT 0,      -- the heartbeat payload
+    claimed_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    creator_fk    VARCHAR(64)  NOT NULL,
+    create_ts     TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts     TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,  -- THE liveness clock
+    UNIQUE KEY uq_orchestration_claims_scope (pipeline_fk, epic_key),
+    UNIQUE KEY uq_orchestration_claims_scope2 (pipeline2_fk, epic2_key),
+    CONSTRAINT fk_oc_pipeline
+        FOREIGN KEY (pipeline_fk) REFERENCES pipelines (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_oc_epic
+        FOREIGN KEY (epic_fk) REFERENCES epics (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_oc_pipeline2
+        FOREIGN KEY (pipeline2_fk) REFERENCES pipeline2_pipelines (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_oc_epic2
+        FOREIGN KEY (epic2_fk) REFERENCES pipeline2_epics (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_oc_machine
+        FOREIGN KEY (machine_fk) REFERENCES machines (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_oc_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE INDEX ix_orchestration_claims_epic_fk ON orchestration_claims (epic_fk);
+CREATE INDEX ix_orchestration_claims_epic2_fk ON orchestration_claims (epic2_fk);

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -1165,45 +1165,6 @@ CREATE TABLE pipeline_step_deps (
 
 CREATE INDEX ix_psd_dep_step_fk ON pipeline_step_deps (dep_step_fk);
 
--- Orchestration reservations (req #3224, migration 20260801150404).
---
--- ADDED BY req #3196, not by #3224: this table reached schema.sql and both live
--- databases but never this file, so a rebuilt darwin_dev came back 12 columns
--- short and every orchestration reservation failed against a table that did not
--- exist. The drift went unseen because the § Schema-of-Record Parity gate that
--- would have caught it could not RUN — both schema.sql and this file were
--- unloadable through load_sql.py until #3196 fixed the statement splitter.
-
-CREATE TABLE orchestration_claims (
-    id            INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    pipeline_fk   INT          NOT NULL,                -- the plan this claim covers
-    epic_fk       INT          NULL DEFAULT NULL,       -- NULL = whole-plan scope
-    epic_key      INT          AS (COALESCE(epic_fk, 0)) VIRTUAL,  -- carries the UNIQUE key
-    machine_fk    INT          NULL DEFAULT NULL,       -- WHERE it runs
-    terminal_pid  INT          NULL DEFAULT NULL,       -- the Claude Code CLI process
-    engine_pid    INT          NULL DEFAULT NULL,       -- DIAGNOSTIC ONLY, never liveness
-    polls         INT          NOT NULL DEFAULT 0,      -- the heartbeat payload
-    claimed_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    creator_fk    VARCHAR(64)  NOT NULL,
-    create_ts     TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
-    update_ts     TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,  -- THE liveness clock
-    UNIQUE KEY uq_orchestration_claims_scope (pipeline_fk, epic_key),
-    CONSTRAINT fk_oc_pipeline
-        FOREIGN KEY (pipeline_fk) REFERENCES pipelines (id)
-        ON UPDATE CASCADE ON DELETE CASCADE,
-    CONSTRAINT fk_oc_epic
-        FOREIGN KEY (epic_fk) REFERENCES epics (id)
-        ON UPDATE CASCADE ON DELETE CASCADE,
-    CONSTRAINT fk_oc_machine
-        FOREIGN KEY (machine_fk) REFERENCES machines (id)
-        ON UPDATE CASCADE ON DELETE RESTRICT,
-    CONSTRAINT fk_oc_creator
-        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
-        ON UPDATE CASCADE ON DELETE CASCADE
-);
-
-CREATE INDEX ix_orchestration_claims_epic_fk ON orchestration_claims (epic_fk);
-
 -- ---------------------------------------------------------------------------
 -- FIVE tables standing BESIDE the 1.0 five, not replacing them. Both eras run
 -- at once until 1.0 is eradicated, and requirements are NOT doubled: one
@@ -1402,3 +1363,57 @@ CREATE TABLE pipeline2_step_deps (
 );
 
 CREATE INDEX ix_p2_psd_dep_step_fk ON pipeline2_step_deps (dep_step_fk);
+
+-- Orchestration reservations (req #3224, migration 20260801150404).
+--
+-- ADDED BY req #3196, not by #3224: this table reached schema.sql and both live
+-- databases but never this file, so a rebuilt darwin_dev came back 12 columns
+-- short and every orchestration reservation failed against a table that did not
+-- exist. The drift went unseen because the § Schema-of-Record Parity gate that
+-- would have caught it could not RUN — both schema.sql and this file were
+-- unloadable through load_sql.py until #3196 fixed the statement splitter.
+--
+-- SERVES BOTH ERAS since req #3369, migration 20260809024954 — see schema.sql
+-- for the full rationale. Placed here, after BOTH plan layers, because it now
+-- carries a live FK into each; `pipeline_fk` is nullable for the same reason.
+
+CREATE TABLE orchestration_claims (
+    id            INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    pipeline_fk   INT          NULL DEFAULT NULL,       -- 1.0 scope; NULL on a 2.0 claim
+    epic_fk       INT          NULL DEFAULT NULL,       -- NULL = 1.0 whole-plan scope
+    epic_key      INT          AS (COALESCE(epic_fk, 0)) VIRTUAL,  -- carries uq_..._scope
+    pipeline2_fk  INT          NULL DEFAULT NULL,       -- 2.0 scope; NULL on a 1.0 claim
+    epic2_fk      INT          NULL DEFAULT NULL,       -- NULL = 2.0 whole-plan scope
+    epic2_key     INT          AS (COALESCE(epic2_fk, 0)) VIRTUAL, -- carries uq_..._scope2
+    machine_fk    INT          NULL DEFAULT NULL,       -- WHERE it runs
+    terminal_pid  INT          NULL DEFAULT NULL,       -- the Claude Code CLI process
+    engine_pid    INT          NULL DEFAULT NULL,       -- DIAGNOSTIC ONLY, never liveness
+    polls         INT          NOT NULL DEFAULT 0,      -- the heartbeat payload
+    claimed_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    creator_fk    VARCHAR(64)  NOT NULL,
+    create_ts     TIMESTAMP    NULL DEFAULT CURRENT_TIMESTAMP,
+    update_ts     TIMESTAMP    NULL ON UPDATE CURRENT_TIMESTAMP,  -- THE liveness clock
+    UNIQUE KEY uq_orchestration_claims_scope (pipeline_fk, epic_key),
+    UNIQUE KEY uq_orchestration_claims_scope2 (pipeline2_fk, epic2_key),
+    CONSTRAINT fk_oc_pipeline
+        FOREIGN KEY (pipeline_fk) REFERENCES pipelines (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_oc_epic
+        FOREIGN KEY (epic_fk) REFERENCES epics (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_oc_pipeline2
+        FOREIGN KEY (pipeline2_fk) REFERENCES pipeline2_pipelines (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_oc_epic2
+        FOREIGN KEY (epic2_fk) REFERENCES pipeline2_epics (id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT fk_oc_machine
+        FOREIGN KEY (machine_fk) REFERENCES machines (id)
+        ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_oc_creator
+        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
+        ON UPDATE CASCADE ON DELETE CASCADE
+);
+
+CREATE INDEX ix_orchestration_claims_epic_fk ON orchestration_claims (epic_fk);
+CREATE INDEX ix_orchestration_claims_epic2_fk ON orchestration_claims (epic2_fk);

--- a/tests/test_orchestration_claims_parallel_era.py
+++ b/tests/test_orchestration_claims_parallel_era.py
@@ -1,0 +1,190 @@
+"""`orchestration_claims` serves BOTH eras (req #3369, migration 20260809024954).
+
+Structural proof, against a live `darwin_dev`, of the additive shape
+`memory/pipeline-2-data-architecture.md` § 9.4 specifies: `pipeline_fk` (1.0)
+became NULLable, `pipeline2_fk` / `epic2_fk` sit beside it, and — the one thing
+a schema-derived Lambda-Rest/darwin-mcp test cannot show — the SECOND
+generated-column UNIQUE key really does refuse a duplicate 2.0 whole-plan claim
+AT THE DATABASE, the same way `uq_orchestration_claims_scope` already does for
+1.0 (req #3224).
+
+# COVERS: ENG-018
+"""
+import uuid
+
+import pymysql
+import pytest
+
+
+@pytest.fixture
+def p2_pipeline(db_connection, test_creator_fk):
+    """One 2.0 pipeline to reserve scopes over. Function-scoped: the duplicate
+    probe below mutates `orchestration_claims`."""
+    with db_connection.cursor() as cur:
+        cur.execute("INSERT INTO pipeline2_pipelines (title, creator_fk) "
+                    "VALUES (%s, %s)",
+                    (f'oc-p2-{uuid.uuid4().hex[:8]}', test_creator_fk))
+        pipeline_id = cur.lastrowid
+    db_connection.commit()
+
+    yield pipeline_id
+
+    with db_connection.cursor() as cur:
+        cur.execute("DELETE FROM orchestration_claims WHERE pipeline2_fk = %s",
+                    (pipeline_id,))
+        cur.execute("DELETE FROM pipeline2_pipelines WHERE id = %s", (pipeline_id,))
+    db_connection.commit()
+
+
+def _columns(cur, table):
+    cur.execute(f"DESCRIBE {table}")
+    return {row['Field']: row for row in cur.fetchall()}
+
+
+# ---------------------------------------------------------------------------
+# Shape
+# ---------------------------------------------------------------------------
+
+def test_pipeline_fk_became_nullable(db_connection):
+    # Era is discriminated by WHICH PAIR IS NON-NULL — meaningless unless the
+    # 1.0 pipeline_fk, NOT NULL since migration 20260801150404, can also be
+    # NULL on a 2.0-only claim.
+    with db_connection.cursor() as cur:
+        cols = _columns(cur, 'orchestration_claims')
+    assert cols['pipeline_fk']['Null'] == 'YES'
+    assert cols['pipeline2_fk']['Null'] == 'YES'
+    assert cols['epic2_fk']['Null'] == 'YES'
+    assert cols['epic2_key']['Extra'] == 'VIRTUAL GENERATED'
+
+
+def test_both_scope_pairs_carry_their_own_unique_key(db_connection):
+    with db_connection.cursor() as cur:
+        cur.execute("SHOW INDEX FROM orchestration_claims "
+                    "WHERE Key_name IN "
+                    "('uq_orchestration_claims_scope', "
+                    "'uq_orchestration_claims_scope2')")
+        rows = cur.fetchall()
+    by_key = {}
+    for row in rows:
+        by_key.setdefault(row['Key_name'], []).append(row['Column_name'])
+    assert by_key['uq_orchestration_claims_scope'] == ['pipeline_fk', 'epic_key']
+    assert by_key['uq_orchestration_claims_scope2'] == ['pipeline2_fk', 'epic2_key']
+
+
+# ---------------------------------------------------------------------------
+# The constraint itself — ENG-018
+# ---------------------------------------------------------------------------
+
+def test_a_second_2_0_whole_plan_claim_is_refused_by_the_database(
+        db_connection, p2_pipeline, test_creator_fk):
+    # THE regression this column exists for, on the 2.0 side: `epic2_fk` is
+    # NULL on both rows, and MySQL treats NULLs in a UNIQUE index as DISTINCT.
+    # A key written directly over `epic2_fk` — or the 1.0 key merely widened to
+    # include the 2.0 columns, which `pipeline_fk` being NULL on every 2.0 row
+    # would exempt from just as completely — would let both inserts succeed.
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO orchestration_claims (pipeline2_fk, creator_fk) "
+            "VALUES (%s, %s)", (p2_pipeline, test_creator_fk))
+    db_connection.commit()
+
+    with pytest.raises(pymysql.err.IntegrityError) as exc:
+        with db_connection.cursor() as cur:
+            cur.execute(
+                "INSERT INTO orchestration_claims (pipeline2_fk, creator_fk) "
+                "VALUES (%s, %s)", (p2_pipeline, test_creator_fk))
+    db_connection.rollback()
+    assert exc.value.args[0] == 1062
+    assert 'uq_orchestration_claims_scope2' in str(exc.value.args[1])
+
+
+def test_the_generated_column_carries_the_key_not_epic2_fk_directly(
+        db_connection, p2_pipeline, test_creator_fk):
+    # Assert the stored key value directly, mirroring
+    # test_pipeline2_behaviours.py's SCH-005 pattern — pins the MECHANISM, not
+    # merely its effect.
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "INSERT INTO orchestration_claims (pipeline2_fk, creator_fk) "
+            "VALUES (%s, %s)", (p2_pipeline, test_creator_fk))
+        cur.execute("SELECT epic2_fk, epic2_key FROM orchestration_claims "
+                    "WHERE pipeline2_fk = %s", (p2_pipeline,))
+        row = cur.fetchone()
+    db_connection.commit()
+    assert row['epic2_fk'] is None
+    assert row['epic2_key'] == 0
+
+
+def test_two_different_2_0_epics_of_one_plan_both_insert(
+        db_connection, p2_pipeline, test_creator_fk):
+    # The mirror of the refusal above: two DIFFERENT epic scopes on the same
+    # 2.0 plan are not a collision — the constraint must not be over-eager.
+    with db_connection.cursor() as cur:
+        cur.execute("INSERT INTO projects (project_name, creator_fk) VALUES (%s, %s)",
+                    (f'oc-proj-{uuid.uuid4().hex[:8]}', test_creator_fk))
+        project_id = cur.lastrowid
+        cur.execute("INSERT INTO categories (category_name, project_fk, creator_fk) "
+                    "VALUES (%s, %s, %s)",
+                    (f'oc-cat-{uuid.uuid4().hex[:8]}', project_id, test_creator_fk))
+        category_id = cur.lastrowid
+        cur.execute("INSERT INTO pipeline2_epics "
+                    "(pipeline_fk, title, category_fk, creator_fk) "
+                    "VALUES (%s, %s, %s, %s)",
+                    (p2_pipeline, f'oc-e2a-{uuid.uuid4().hex[:8]}', category_id,
+                     test_creator_fk))
+        epic_a = cur.lastrowid
+        cur.execute("INSERT INTO pipeline2_epics "
+                    "(pipeline_fk, title, category_fk, creator_fk) "
+                    "VALUES (%s, %s, %s, %s)",
+                    (p2_pipeline, f'oc-e2b-{uuid.uuid4().hex[:8]}', category_id,
+                     test_creator_fk))
+        epic_b = cur.lastrowid
+        cur.execute(
+            "INSERT INTO orchestration_claims (pipeline2_fk, epic2_fk, creator_fk) "
+            "VALUES (%s, %s, %s)", (p2_pipeline, epic_a, test_creator_fk))
+        cur.execute(
+            "INSERT INTO orchestration_claims (pipeline2_fk, epic2_fk, creator_fk) "
+            "VALUES (%s, %s, %s)", (p2_pipeline, epic_b, test_creator_fk))
+        cur.execute("SELECT COUNT(*) AS n FROM orchestration_claims "
+                    "WHERE pipeline2_fk = %s", (p2_pipeline,))
+        count = cur.fetchone()['n']
+    db_connection.commit()
+    assert count == 2
+
+    with db_connection.cursor() as cur:
+        cur.execute("DELETE FROM orchestration_claims WHERE pipeline2_fk = %s",
+                    (p2_pipeline,))
+        cur.execute("DELETE FROM pipeline2_epics WHERE id IN (%s, %s)",
+                    (epic_a, epic_b))
+        cur.execute("DELETE FROM categories WHERE id = %s", (category_id,))
+        cur.execute("DELETE FROM projects WHERE id = %s", (project_id,))
+    db_connection.commit()
+
+
+# ---------------------------------------------------------------------------
+# 1.0 is unaffected — acceptance's explicit demonstration
+# ---------------------------------------------------------------------------
+
+def test_a_1_0_whole_plan_claim_still_succeeds_on_the_migrated_schema(
+        db_connection, test_creator_fk):
+    with db_connection.cursor() as cur:
+        cur.execute("INSERT INTO pipelines (title, creator_fk) VALUES (%s, %s)",
+                    (f'oc-p1-{uuid.uuid4().hex[:8]}', test_creator_fk))
+        pipeline_id = cur.lastrowid
+        cur.execute(
+            "INSERT INTO orchestration_claims (pipeline_fk, creator_fk) "
+            "VALUES (%s, %s)", (pipeline_id, test_creator_fk))
+        cur.execute("SELECT pipeline_fk, pipeline2_fk, epic2_fk "
+                    "FROM orchestration_claims WHERE pipeline_fk = %s",
+                    (pipeline_id,))
+        row = cur.fetchone()
+    db_connection.commit()
+    assert row['pipeline_fk'] == pipeline_id
+    assert row['pipeline2_fk'] is None
+    assert row['epic2_fk'] is None
+
+    with db_connection.cursor() as cur:
+        cur.execute("DELETE FROM orchestration_claims WHERE pipeline_fk = %s",
+                    (pipeline_id,))
+        cur.execute("DELETE FROM pipelines WHERE id = %s", (pipeline_id,))
+    db_connection.commit()


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-08-09T03:34:32Z
- chore: init swarm session feature/3369-pipeline-20-orchestration-claims-1

## Files changed
```
 ...ion_claims_parallel_era_reservation_columns.sql | 127 ++++++++++++++
 schema.sql                                         | 153 ++++++++++-------
 scripts/recreate_darwin_dev.sql                    |  93 +++++-----
 tests/test_orchestration_claims_parallel_era.py    | 190 +++++++++++++++++++++
 4 files changed, 465 insertions(+), 98 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)