### PR TITLE
Pipeline 2.0 - drop the Feature schema: the table, the junction, requirements.feature_fk, four registries and the IAM resource list

### DIFF
--- a/migrations/20260811033413_drop_feature_schema_features_feature_test_cases_requirements.sql
+++ b/migrations/20260811033413_drop_feature_schema_features_feature_test_cases_requirements.sql
@@ -63,6 +63,8 @@
 --
 -- Migration id 20260811033413 is a UTC timestamp allocated by
 -- DarwinSQL/scripts/new-migration.sh (req #3121). Do not renumber it.
+--
+-- darwin:destructive
 
 DROP TABLE feature_test_cases;
 

--- a/migrations/20260811033413_drop_feature_schema_features_feature_test_cases_requirements.sql
+++ b/migrations/20260811033413_drop_feature_schema_features_feature_test_cases_requirements.sql
@@ -1,0 +1,73 @@
+-- 20260811033413_drop_feature_schema_features_feature_test_cases_requirements.sql
+--
+-- Req #3355 (Pipeline 2.0 eradication phase E6): drop the Feature schema now
+-- that nothing needs it — Pipeline 2.0 seats a step under an epic directly
+-- (epic_fk on the step), and the test-case catalog re-homed onto Requirement
+-- via requirement_test_cases (req #3352, migration 20260809002149).
+--
+-- PROBLEM.  `features`, `feature_test_cases` and `requirements.feature_fk`
+--           implement the retired requirement -> feature -> epic chain
+--           (Epic > Feature > Story, req #3111). Nothing authors against it
+--           any more (instruction #92 closed, #95 rewritten for containment,
+--           req #3353) and its two consumers have been re-pointed: the
+--           test-case junction now runs through requirement_test_cases
+--           (verified 2026-08-11 by direct production query — all 28
+--           feature_test_cases rows have a requirement_test_cases row
+--           sharing the same test_case_fk, and darwin_dev the same for its
+--           28 production-equivalent rows plus dogfood extras), and a
+--           Pipeline 2.0 step's epic is read directly off the step
+--           (epic_fk), never walked through Feature.
+--
+-- SHAPE.    Three drops, forced into this order by FK dependency:
+--             1. feature_test_cases  (leaf — PK (feature_fk, test_case_fk),
+--                FKs to features and test_cases, both ON DELETE CASCADE)
+--             2. requirements.feature_fk (+ its FK fk_requirements_feature
+--                and the column itself)
+--             3. features (now referenced by nothing)
+--           No data migration: feature_test_cases' only surviving obligation
+--           (a requirement-junction equivalent for every row) was already
+--           verified before this migration was written. requirements rows
+--           simply lose the feature_fk column; no other column changes.
+--
+-- TARGET.   NEVER write `USE <db>;` or `CREATE DATABASE` into this file. A
+--           `USE` is a statement, not a declaration: it re-points the session
+--           the moment it executes and overrides whatever database the caller
+--           named — which on 2026-08-01 sent a dev-aimed apply to production.
+--           load_sql.py REFUSES a file that names its own database, and
+--           DarwinSQL/tests/test_sql_targets.py fails the build (req #3196).
+--           If this migration may only be applied to ONE database, say so as a
+--           constraint instead: `-- darwin:targets = darwin`.
+--
+-- APPLY.    darwin_dev FIRST, production SECOND. Two separate commands:
+--
+--             python3 DarwinSQL/scripts/load_sql.py \
+--               DarwinSQL/migrations/20260811033413_drop_feature_schema_features_feature_test_cases_requirements.sql darwin_dev
+--
+--             python3 DarwinSQL/scripts/load_sql.py \
+--               DarwinSQL/migrations/20260811033413_drop_feature_schema_features_feature_test_cases_requirements.sql darwin --production
+--
+--           Production is named TWICE — by name and by intent. The loader
+--           refuses `darwin` without --production, and refuses --production on
+--           any other database (req #3196). The production command also
+--           requires `bash scripts/db/rds-snapshot.sh 20260811033413` to report
+--           status=ok first. See memory/database.md § Schema Migration Workflow.
+--
+-- SEQUENCING. darwin-mcp's `TABLE_COLUMNS['requirements']` (services/common.py)
+--           names `feature_fk` in its projected-read field list; Lambda-Rest
+--           validates every `fields=` name against live `DESC requirements`
+--           and 400s the WHOLE READ on an unknown column. The daemon MUST be
+--           running code with `feature_fk` removed from that tuple BEFORE
+--           this migration's production apply, or every `darwin://requirements/*`
+--           read (including /swarm-start, /swarm-resume) 400s until it is
+--           restarted. See memory/database.md § Projected tables.
+--
+-- Migration id 20260811033413 is a UTC timestamp allocated by
+-- DarwinSQL/scripts/new-migration.sh (req #3121). Do not renumber it.
+
+DROP TABLE feature_test_cases;
+
+ALTER TABLE requirements
+    DROP FOREIGN KEY fk_requirements_feature,
+    DROP COLUMN feature_fk;
+
+DROP TABLE features;

--- a/schema.sql
+++ b/schema.sql
@@ -1,5 +1,5 @@
 -- Darwin Database Schema — Current State
--- This file reflects the final state of all 59 tables after all migrations.
+-- This file reflects the final state of all 57 tables after all migrations.
 -- It can be run against a fresh MySQL instance to create the complete schema.
 -- Table order respects FK dependencies.
 --
@@ -222,30 +222,6 @@ CREATE TABLE IF NOT EXISTS epics (
         ON UPDATE CASCADE ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS features (
-    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    title           VARCHAR(256)    NOT NULL,
-    description     TEXT            NOT NULL,
-    feature_status  VARCHAR(16)     NOT NULL DEFAULT 'draft',   -- draft|active|deprecated
-    epic_fk         INT             NULL DEFAULT NULL,
-                                            -- parent epic (req #3111, migration 076); NULL = unfiled
-    category_fk     INT             NOT NULL,
-    creator_fk      VARCHAR(64)     NOT NULL,
-    closed          TINYINT(1)      NOT NULL DEFAULT 0,
-    sort_order      SMALLINT        NULL,
-    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
-    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
-    CONSTRAINT fk_features_category
-        FOREIGN KEY (category_fk) REFERENCES categories (id)
-        ON UPDATE CASCADE ON DELETE RESTRICT,
-    CONSTRAINT fk_features_epic
-        FOREIGN KEY (epic_fk) REFERENCES epics (id)
-        ON UPDATE CASCADE ON DELETE SET NULL,
-    CONSTRAINT fk_features_creator
-        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
-        ON UPDATE CASCADE ON DELETE CASCADE
-);
-
 CREATE TABLE IF NOT EXISTS requirements (
     id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
     title           VARCHAR(256)    NOT NULL,
@@ -272,10 +248,6 @@ CREATE TABLE IF NOT EXISTS requirements (
                                             -- comma-separated sub-repo override (req #2583); NULL = use category default
     machine_fk      INT             NULL DEFAULT NULL,
                                             -- machine pin (req #2978, migration 066); NULL = "Any" machine may run it
-    feature_fk      INT             NULL DEFAULT NULL,
-                                            -- parent feature (req #3111, migration 076); NULL = unfiled.
-                                            -- The story tier of Epic > Feature > Story; SET NULL so deleting a
-                                            -- feature demotes its requirements instead of destroying history.
     tracking        TINYINT(1)      NOT NULL DEFAULT 0,
                                             -- CONTAINER, not work (req #3123, migration 20260731124830).
                                             -- 1 = this requirement HOLDS a plan (or an epic/feature) rather than
@@ -297,10 +269,6 @@ CREATE TABLE IF NOT EXISTS requirements (
         FOREIGN KEY (machine_fk)
         REFERENCES machines (id)
         ON UPDATE CASCADE ON DELETE RESTRICT,
-    CONSTRAINT fk_requirements_feature
-        FOREIGN KEY (feature_fk)
-        REFERENCES features (id)
-        ON UPDATE CASCADE ON DELETE SET NULL,
     FOREIGN KEY (creator_fk)
         REFERENCES profiles (id)
         ON UPDATE CASCADE ON DELETE CASCADE
@@ -839,23 +807,11 @@ CREATE TABLE IF NOT EXISTS test_cases (
         ON UPDATE CASCADE ON DELETE CASCADE
 );
 
-CREATE TABLE IF NOT EXISTS feature_test_cases (
-    feature_fk      INT             NOT NULL,
-    test_case_fk    INT             NOT NULL,
-    PRIMARY KEY (feature_fk, test_case_fk),
-    CONSTRAINT fk_ftc_feature
-        FOREIGN KEY (feature_fk) REFERENCES features (id)
-        ON UPDATE CASCADE ON DELETE CASCADE,
-    CONSTRAINT fk_ftc_case
-        FOREIGN KEY (test_case_fk) REFERENCES test_cases (id)
-        ON UPDATE CASCADE ON DELETE CASCADE
-);
-
 -- requirement_test_cases (req #3352, migration 20260809002149) — Pipeline 2.0
 -- re-homes test cases from Feature onto Requirement: a test case asserts a
 -- deliverable and Requirement, not Feature, is the level that organizes
--- deliverables. Stands BESIDE feature_test_cases, not in place of it, until
--- the Feature-era eradication sequencing (req #3334) retires the old table.
+-- deliverables. feature_test_cases (its predecessor) was dropped by the
+-- Feature-era eradication cutover (req #3355, migration 20260811033413).
 CREATE TABLE IF NOT EXISTS requirement_test_cases (
     requirement_fk  INT             NOT NULL,
     test_case_fk    INT             NOT NULL,

--- a/scripts/recreate_darwin_dev.sql
+++ b/scripts/recreate_darwin_dev.sql
@@ -1,12 +1,13 @@
 -- Recreate darwin_dev test/dev tables from scratch
 -- Uses production-identical table names (same DDL as schema.sql)
 -- Idempotent: safe to run repeatedly to reset darwin_dev to canonical state
--- All 59 tables in FK-dependency order
+-- All 57 tables in FK-dependency order
 --
 -- ============================================================================
--- THIS FILE DROPS 59 TABLES. (req #3196; count corrected to include
+-- THIS FILE DROPS 57 TABLES. (req #3196; count corrected to include
 -- requirement_test_cases, req #3378 — it was missing from this file since
--- req #3352 created it, verify via `grep -c '^CREATE TABLE'` on this file)
+-- req #3352 created it; req #3355 dropped `features` and `feature_test_cases`,
+-- migration 20260811033413 — verify via `grep -c '^CREATE TABLE'` on this file)
 -- ============================================================================
 -- It opened with `USE darwin_dev;`, which LOOKED like protection and was not:
 -- a `USE` is a statement the caller's loader may strip, reorder or never reach,
@@ -37,7 +38,7 @@ DROP TABLE IF EXISTS orchestration_claims,
     agent_documents, agent_instructions,
     architecture_documents, instructions, agents,
     test_results, test_runs, test_plan_cases, test_plans,
-    requirement_test_cases, feature_test_cases, test_cases, features, epics,
+    requirement_test_cases, test_cases, epics,
     user_integrations,
     map_run_partners, map_partners,
     map_views, map_coordinates, map_runs, map_routes,
@@ -202,11 +203,12 @@ CREATE TABLE machines (
         ON UPDATE CASCADE ON DELETE CASCADE
 );
 
--- Agile hierarchy: Epic > Feature > Story(requirement) (req #3111, migration 076).
--- `epics` and `features` are created here, above `requirements`, so that
--- requirements.feature_fk resolves — the same reason `machines` sits above the
--- execution tables. The rest of the validation family stays in the "Swarm Features
--- & Test Cases registry" section below.
+-- Agile hierarchy: Epic tops the containment hierarchy (req #3111, migration
+-- 076); `epics` is created here, above `requirements`, the same reason
+-- `machines` sits above the execution tables. (The Feature tier — Epic >
+-- Feature > Story — and `requirements.feature_fk` were dropped at req #3355,
+-- migration 20260811033413.) The rest of the validation family stays in the
+-- "Swarm Test Cases registry" section below.
 CREATE TABLE epics (
     id           INT          NOT NULL PRIMARY KEY AUTO_INCREMENT,
     title        VARCHAR(256) NOT NULL,
@@ -224,30 +226,6 @@ CREATE TABLE epics (
         FOREIGN KEY (category_fk) REFERENCES categories (id)
         ON UPDATE CASCADE ON DELETE RESTRICT,
     CONSTRAINT fk_epics_creator
-        FOREIGN KEY (creator_fk) REFERENCES profiles (id)
-        ON UPDATE CASCADE ON DELETE CASCADE
-);
-
-CREATE TABLE features (
-    id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    title           VARCHAR(256)    NOT NULL,
-    description     TEXT            NOT NULL,
-    feature_status  VARCHAR(16)     NOT NULL DEFAULT 'draft',   -- draft|active|deprecated
-    epic_fk         INT             NULL DEFAULT NULL,
-                                            -- parent epic (req #3111, migration 076); NULL = unfiled
-    category_fk     INT             NOT NULL,
-    creator_fk      VARCHAR(64)     NOT NULL,
-    closed          TINYINT(1)      NOT NULL DEFAULT 0,
-    sort_order      SMALLINT        NULL,
-    create_ts       TIMESTAMP       NULL DEFAULT CURRENT_TIMESTAMP,
-    update_ts       TIMESTAMP       NULL ON UPDATE CURRENT_TIMESTAMP,
-    CONSTRAINT fk_features_category
-        FOREIGN KEY (category_fk) REFERENCES categories (id)
-        ON UPDATE CASCADE ON DELETE RESTRICT,
-    CONSTRAINT fk_features_epic
-        FOREIGN KEY (epic_fk) REFERENCES epics (id)
-        ON UPDATE CASCADE ON DELETE SET NULL,
-    CONSTRAINT fk_features_creator
         FOREIGN KEY (creator_fk) REFERENCES profiles (id)
         ON UPDATE CASCADE ON DELETE CASCADE
 );
@@ -278,8 +256,6 @@ CREATE TABLE requirements (
                                             -- comma-separated sub-repo override (req #2583); NULL = use category default
     machine_fk      INT             NULL DEFAULT NULL,
                                             -- machine pin (req #2978, migration 066); NULL = "Any" machine may run it
-    feature_fk      INT             NULL DEFAULT NULL,
-                                            -- parent feature (req #3111, migration 076); NULL = unfiled
     tracking        TINYINT(1)      NOT NULL DEFAULT 0,
                                             -- CONTAINER, not work (req #3123): 1 = holds a plan/epic rather than
                                             -- being work inside it, so it is excluded from a pipeline step's
@@ -295,10 +271,6 @@ CREATE TABLE requirements (
         FOREIGN KEY (machine_fk)
         REFERENCES machines (id)
         ON UPDATE CASCADE ON DELETE RESTRICT,
-    CONSTRAINT fk_requirements_feature
-        FOREIGN KEY (feature_fk)
-        REFERENCES features (id)
-        ON UPDATE CASCADE ON DELETE SET NULL,
     FOREIGN KEY (creator_fk)
         REFERENCES profiles (id)
         ON UPDATE CASCADE ON DELETE CASCADE
@@ -649,9 +621,9 @@ CREATE TABLE user_integrations (
     UNIQUE KEY uq_creator_provider (creator_fk, provider)
 );
 
--- Swarm Features & Test Cases registry (req #2380)
--- NOTE: `features` is created ABOVE, next to `epics` — requirements.feature_fk
--- (req #3111, migration 076) forced it above `requirements`.
+-- Swarm Test Cases registry (req #2380). `features` (created here until req
+-- #3355 dropped it, migration 20260811033413) used to force this section
+-- above `requirements`; test_cases has no such dependency of its own.
 
 CREATE TABLE test_cases (
     id              INT             NOT NULL PRIMARY KEY AUTO_INCREMENT,
@@ -675,23 +647,11 @@ CREATE TABLE test_cases (
         ON UPDATE CASCADE ON DELETE CASCADE
 );
 
-CREATE TABLE feature_test_cases (
-    feature_fk      INT             NOT NULL,
-    test_case_fk    INT             NOT NULL,
-    PRIMARY KEY (feature_fk, test_case_fk),
-    CONSTRAINT fk_ftc_feature
-        FOREIGN KEY (feature_fk) REFERENCES features (id)
-        ON UPDATE CASCADE ON DELETE CASCADE,
-    CONSTRAINT fk_ftc_case
-        FOREIGN KEY (test_case_fk) REFERENCES test_cases (id)
-        ON UPDATE CASCADE ON DELETE CASCADE
-);
-
 -- requirement_test_cases (req #3352, migration 20260809002149) — Pipeline 2.0
 -- re-homes test cases from Feature onto Requirement: a test case asserts a
 -- deliverable and Requirement, not Feature, is the level that organizes
--- deliverables. Stands BESIDE feature_test_cases, not in place of it, until
--- the Feature-era eradication sequencing (req #3334) retires the old table.
+-- deliverables. feature_test_cases (its predecessor) was dropped at req #3355,
+-- migration 20260811033413.
 CREATE TABLE requirement_test_cases (
     requirement_fk  INT             NOT NULL,
     test_case_fk    INT             NOT NULL,

--- a/scripts/seed_pipelines_darwin_dev.py
+++ b/scripts/seed_pipelines_darwin_dev.py
@@ -17,6 +17,18 @@ darwin_dev ONLY. NEVER apply the output to production `darwin`. It used to be sa
 to say `darwin` was simply empty; the Primary's live-plan cutover has since landed
 and production carries the real plan, so this fixture's 9001-band rows would sit
 alongside live ones rather than in an empty table (req #3147).
+
+NO FEATURE LAYER (req #3355). This fixture used to emit `features` rows and a
+`requirements.feature_fk` link, because that chain — requirement -> feature ->
+epic — was 1.0's ONLY path from a requirement to its epic, and the fixture
+demonstrated req #3080 design rule 10 (a launch unit spanning epics) through it.
+Migration 20260811033413 DROPPED `features`, `feature_test_cases` and
+`requirements.feature_fk`, and there is nothing in 1.0 to rewire the chain to: a
+bare 1.0 requirement carries no epic of its own, and only Pipeline 2.0's
+`pipeline2_steps.epic_fk` answers the question now. So the demonstration is gone
+rather than reworked — 1.0 itself is being wound down (req #3356). `epics` are
+UNAFFECTED and still emitted: only the Feature layer between them and the
+requirements went away.
 """
 import json
 import os
@@ -30,7 +42,7 @@ CREATOR = '37df7531-000d-4470-8be4-1792d8261f69'          # Bill W
 # The fixture owns its project + category rather than borrowing production ids.
 # The plan's requirements carry PRODUCTION category_fk values (1, 1052, ...) and
 # categories.category_fk is NOT NULL with ON DELETE RESTRICT — the identical
-# cross-database hazard MACHINE_MAP exists for. Borrowing them happens to work on
+# cross-database hazard `machine_ref` exists for. Borrowing them happens to work on
 # today's darwin_dev only because the ids coincide; on a darwin_dev rebuilt from
 # recreate_darwin_dev.sql (categories empty) the requirements INSERT would die
 # with errno 1452 AFTER the teardown had already dropped the previous fixture.
@@ -46,7 +58,6 @@ OUT = os.path.join(HERE, 'seed_pipelines_darwin_dev.sql')
 # Fixture id allocation. Explicit ids (not AUTO_INCREMENT) so the file is
 # idempotent, re-runnable, and its teardown can be scoped precisely.
 EPIC_BASE = 9000        # epics            9001..9004
-FEATURE_BASE = 9000     # features         9001..90NN
 PIPELINE_ID = 9001      # pipelines        9001
 
 # pipeline_steps.id = STEP_BASE + the plan's step id. NOT the bare step id: those
@@ -57,22 +68,52 @@ PIPELINE_ID = 9001      # pipelines        9001
 # trivially readable (plan step 12 -> 9012) and collision-free.
 STEP_BASE = 9000
 
-# Production machine id -> darwin_dev machine id. The plan's requirements carry
-# production machine_fk values; darwin_dev has its own machines table with
-# different ids, and the FK is RESTRICT, so an unmapped value would fail the load.
-MACHINE_MAP = {2: 74, 3: 75}    # Mac Mini -> Mac mini, MCHP Windows -> WSL box
+# The plan's requirements carry PRODUCTION machine_fk values and `machine_fk` is
+# ON DELETE RESTRICT, so a value darwin_dev has no row for fails the whole load
+# with a 1452. This used to be a HARDCODED id map, `{2: 74, 3: 75}` — production
+# id -> the id the same machine happened to hold in darwin_dev — and it broke
+# exactly the way a hardcoded cross-database id map breaks: darwin_dev was rebuilt,
+# its machines re-registered as ids 2 and 3, and 74/75 stopped existing. Measured
+# 2026-08-11: the fixture aborted at the requirements INSERT on
+# `fk_requirements_machine`, having emitted every earlier statement correctly.
+#
+# So the id is not carried across the databases at all any more. The generator
+# reads the machine's HOSTNAME — a natural key, and the key machines register
+# themselves under — and emits a scalar subquery that resolves it against
+# WHICHEVER machines table the file is loaded into:
+#
+#     machine_fk = (SELECT id FROM machines WHERE hostname = 'Macmini')
+#
+# A hostname darwin_dev does not know yields NULL, which is the documented "Any"
+# fallback the old map also produced for an unmapped value — so an unknown machine
+# still degrades to NULL rather than aborting the load.
+PIPELINE_MACHINE = 2            # the plan's own machine, by PRODUCTION id (Mac Mini)
 
-# The one epic membership the plan states in prose rather than in a column.
-# Plan step 19 batches #3080/#3083 (Swarm Orchestration Feature) together with
-# #3105 in ONE swarm-start and says so explicitly: "cross-epic per rule 10".
-# Design rule 10 exists for exactly this shape — a launch unit that spans epics —
-# and the fixture cannot demonstrate the rule unless one requirement actually
-# sits under a different epic than its step's dominant label. #3105 (swarm-complete
-# takes the RDS snapshot without asking) is substrate doctrine, so it is filed
-# under the Swarm Substrate Rebuild epic via a feature that exists for it.
-CROSS_EPIC = {
-    3105: ('Swarm Doctrine', 'Swarm Substrate Rebuild'),
-}
+
+def machine_ref(prod_machine_id, hostnames):
+    """SQL for `requirements.machine_fk` / `pipelines.machine_fk`.
+
+    Resolved at LOAD time against the target database's own `machines` table, so
+    the fixture carries no assumption about which ids darwin_dev holds. NULL
+    ("Any") for a machine the plan does not pin or the target does not know.
+    """
+    host = hostnames.get(prod_machine_id)
+    if not host:
+        return 'NULL'
+    return '(SELECT id FROM machines WHERE hostname = %s)' % q(host)
+
+
+# CROSS_EPIC used to live here (req #3355 removed it). It filed requirement #3105
+# under the Swarm Substrate Rebuild epic through a feature of its own, so the
+# fixture could demonstrate design rule 10 — a launch unit spanning epics, which
+# is only expressible when labels attach at the requirement. `requirements.feature_fk`
+# is gone, so there is no per-requirement label to disagree with the step's epic
+# and nothing left to demonstrate. #3105 is NOT lost from the fixture: plan step 19
+# links it directly (`reqs` = [3080, 3083, 3105]), so it arrives through the same
+# step link as every other requirement here, and the epic it used to add by hand —
+# Swarm Substrate Rebuild — is already the first epic the plan's own rows produce.
+# Verified against the live plan before the constant was deleted: the requirement
+# set is 67 rows with or without it.
 
 # The s0.4 dual-condition gate (req #3080, plan stage 0): "#3050 session completed
 # AND 2h time gate 06:31:38 PDT — DUAL-condition gate, two independent wait
@@ -243,34 +284,46 @@ def main():
             'bounded slices, or narrow the projection, and re-run.' % truncated[0]['_truncated'])
     live = {r['id']: r for r in requirement_rows if isinstance(r, dict) and 'id' in r}
 
+    # ---- machines: production id -> hostname, read LIVE ------------------
+    # ABORT on an empty read rather than generating from it, for the same reason
+    # the truncation guard above exists: every machine would silently resolve to
+    # NULL, the fixture would LOAD CLEAN, and every requirement would claim it is
+    # pinned to no machine. A wrong fixture that loads is worse than no fixture.
+    machine_rows = mcp_read('darwin://machines')
+    machine_hosts = {
+        m['id']: m['hostname']
+        for m in machine_rows
+        if isinstance(m, dict) and m.get('id') is not None and m.get('hostname')
+    }
+    if not machine_hosts:
+        raise SystemExit(
+            'darwin://machines returned no usable rows — refusing to generate a '
+            'fixture in which every machine_fk resolves to NULL. Check the read '
+            'and re-run.')
+    if PIPELINE_MACHINE not in machine_hosts:
+        raise SystemExit(
+            "machine #%d — the machine this plan ran on — is absent from "
+            "darwin://machines, so the pipeline row's own machine_fk cannot be "
+            "resolved. Check the machines registry and re-run." % PIPELINE_MACHINE)
+
     # ---- epics: first-appearance order in the plan ----------------------
+    # Each plan row still carries a `feature` label as well as an `epic` one, and
+    # it is now deliberately UNREAD (req #3355) — there is no table to put it in.
+    # Left in the PLAN-JSON rather than stripped: the plan is the user's document
+    # and this generator is only a reader of it.
     epic_names = []
     for row in rows:
         if row['epic'] not in epic_names:
             epic_names.append(row['epic'])
-    for _, epic in CROSS_EPIC.values():
-        if epic not in epic_names:
-            epic_names.append(epic)
     epic_id = {name: EPIC_BASE + i + 1 for i, name in enumerate(epic_names)}
 
-    # ---- features: (feature label, epic) pairs, first-appearance order ---
-    feature_pairs = []
-    for row in rows:
-        pair = (row['feature'], row['epic'])
-        if pair not in feature_pairs:
-            feature_pairs.append(pair)
-    for pair in CROSS_EPIC.values():
-        if pair not in feature_pairs:
-            feature_pairs.append(pair)
-    feature_id = {pair: FEATURE_BASE + i + 1 for i, pair in enumerate(feature_pairs)}
-
-    # ---- requirement -> feature ------------------------------------------
-    req_feature = {}
-    for row in rows:
-        for rid in row['reqs']:
-            req_feature.setdefault(rid, (row['feature'], row['epic']))
-    req_feature.update(CROSS_EPIC)
-    req_ids = sorted(req_feature)
+    # ---- the requirement set: every requirement a step actually links ----
+    # Derived straight from the step links, which is the only association left
+    # after req #3355 dropped `requirements.feature_fk`. It used to be derived
+    # from the requirement -> feature map, which carried the same set plus
+    # whatever CROSS_EPIC added by hand; the plan links #3105 on step 19 anyway,
+    # so the two agree row-for-row on the live plan.
+    req_ids = sorted({rid for row in rows for rid in row['reqs']})
 
     # ---- shape facts the header REPORTS ---------------------------------
     # Computed, never spelled out in prose: the plan grows, and a header that
@@ -348,12 +401,17 @@ def main():
     w('--')
     w('-- Source plan: requirement #%d, %d rows, %d distinct requirements,'
       % (REQ_ID, len(rows), len(req_ids)))
-    w('--              %d epics, %d features.' % (len(epic_names), len(feature_pairs)))
+    w('--              %d epics.' % len(epic_names))
+    w('--')
+    w('-- NO FEATURE LAYER (req #3355). Migration 20260811033413 dropped `features`,')
+    w('-- `feature_test_cases` and `requirements.feature_fk`, so this fixture emits')
+    w('-- neither the feature rows nor the requirement->feature link it used to. A')
+    w('-- requirement reaches this plan through its STEP LINK and nothing else. Epics')
+    w('-- are unaffected and still emitted.')
     w('--')
     w('-- ## Id allocation (explicit, so this file is idempotent and self-scoping)')
     w('--')
     w('--   epics                %d..%d' % (EPIC_BASE + 1, EPIC_BASE + len(epic_names)))
-    w('--   features             %d..%d' % (FEATURE_BASE + 1, FEATURE_BASE + len(feature_pairs)))
     w('--   pipelines            %d' % PIPELINE_ID)
     w('--   pipeline_steps       %d + the plan step id (see below)' % STEP_BASE)
     w('--   projects/categories  %d / %d — owned by the fixture, created idempotently'
@@ -399,18 +457,18 @@ def main():
     # list of counts would make the reader zip them across a line break.
     for line in wrap_comment(', '.join('%s(%d)' % pair for pair in multi_req_steps) + '.'):
         w('--                          ' + line)
-    w('--   * cross-epic step      step 19 — #3105 sits under a different epic than the')
-    w('--                          step\'s dominant label, which is why labels attach at')
-    w('--                          the requirement (design rule 10).')
     w('--   * dropped-without-     requirements the user pulled from the plan (#3065/#3074')
     w('--     residue              era) simply are not here — no tombstones, no residue.')
     w('--')
     w('-- Requirement rows are upserted with their LIVE metadata (title, status, model,')
     w('-- effort) because step state is DERIVED from requirement status (design rule 1):')
     w('-- without real statuses the fixture would render every step Scheduled and prove')
-    w('-- nothing. machine_fk is remapped production->darwin_dev (%s); unmappable values'
-      % ', '.join(f'{k}->{v}' for k, v in sorted(MACHINE_MAP.items())))
-    w('-- become NULL ("Any").')
+    w('-- nothing. machine_fk carries no cross-database id: the plan\'s production')
+    w('-- machine is emitted as a HOSTNAME lookup resolved against whichever `machines`')
+    w('-- table this file is loaded into (%s), so a rebuilt darwin_dev'
+      % ', '.join('#%d=%s' % (k, v) for k, v in sorted(machine_hosts.items())))
+    w('-- re-registering its machines under new ids cannot break the load. A hostname')
+    w('-- the target does not know resolves to NULL ("Any").')
     w('--')
     w('-- ## DERIVED STATE vs the plan\'s stored `state`')
     w('--')
@@ -536,18 +594,16 @@ def main():
       '(SELECT id FROM pipeline_steps WHERE pipeline_fk = %d);' % PIPELINE_ID)
     w('DELETE FROM pipeline_steps WHERE pipeline_fk = %d;' % PIPELINE_ID)
     w('DELETE FROM pipelines WHERE id = %d;' % PIPELINE_ID)
-    w('-- Detach requirements before features go, so fk_requirements_feature (SET NULL)')
-    w('-- never has to fire mid-load and leave a half-linked state.')
+    w('--')
+    w('-- There is no `features` teardown any more, and no requirement detach before it')
+    w('-- (req #3355): migration 20260811033413 dropped the table and the')
+    w('-- `requirements.feature_fk` column that used to need clearing first.')
     w('--')
     w('-- Scoped to the EXACT ids this file is about to insert, never a BETWEEN range.')
     w('-- Explicit ids at %d+ leave AUTO_INCREMENT immediately above the fixture band, so'
-      % (FEATURE_BASE + 1))
+      % (EPIC_BASE + 1))
     w('-- the next organically-created row lands exactly where a growing range would')
-    w('-- expand — and a later plan with one more feature label would delete it.')
-    w('UPDATE requirements SET feature_fk = NULL WHERE feature_fk IN (%s);'
-      % ', '.join(str(feature_id[pair]) for pair in feature_pairs))
-    w('DELETE FROM features WHERE id IN (%s);'
-      % ', '.join(str(feature_id[pair]) for pair in feature_pairs))
+    w('-- expand — and a later plan with one more epic label would delete it.')
     w('DELETE FROM epics WHERE id IN (%s);'
       % ', '.join(str(epic_id[name]) for name in epic_names))
     w('')
@@ -579,7 +635,9 @@ def main():
 
     # ---- epics ----------------------------------------------------------
     w('-- ---------------------------------------------------------------------------')
-    w('-- Epics (%d) — the top of Epic > Feature > Story.' % len(epic_names))
+    w('-- Epics (%d) — one per distinct epic label in the plan. Since req #3355 dropped' % len(epic_names))
+    w('-- the Feature layer, nothing in this fixture points at them: a requirement now')
+    w('-- reaches its epic only through the step that links it.')
     w('-- ---------------------------------------------------------------------------')
     w('INSERT INTO epics (id, title, description, category_fk, creator_fk, sort_order) VALUES')
     values = []
@@ -591,31 +649,10 @@ def main():
     w(',\n'.join(values) + ';')
     w('')
 
-    # ---- features -------------------------------------------------------
-    w('-- ---------------------------------------------------------------------------')
-    w('-- Features (%d) — one per distinct feature label, linked to its epic.' % len(feature_pairs))
-    w('-- ---------------------------------------------------------------------------')
-    w('INSERT INTO features (id, title, description, feature_status, epic_fk, '
-      'category_fk, creator_fk, sort_order) VALUES')
-    values = []
-    for i, pair in enumerate(feature_pairs):
-        label, epic = pair
-        note = ('Feature under epic "%s", from the Substrate Rebuild plan (req #%d).'
-                % (epic, REQ_ID))
-        if pair in CROSS_EPIC.values():
-            note = ('Carries the cross-epic requirement in plan step 19 — the launch unit '
-                    'spans epics, which is why labels attach at the requirement '
-                    '(req #3080 design rule 10).')
-        values.append('  (%d, %s, %s, %s, %d, %d, %s, %d)' % (
-            feature_id[pair], q(label), q(note), q('active'),
-            epic_id[epic], FIXTURE_CATEGORY, q(CREATOR), i))
-    w(',\n'.join(values) + ';')
-    w('')
-
     # ---- requirement stubs ----------------------------------------------
     w('-- ---------------------------------------------------------------------------')
-    w('-- Requirements (%d) — upserted with live metadata, then filed under their' % len(req_ids))
-    w('-- feature. pipeline_step_requirements.requirement_fk is ON DELETE RESTRICT, so')
+    w('-- Requirements (%d) — every requirement some step links, upserted with live' % len(req_ids))
+    w('-- metadata. pipeline_step_requirements.requirement_fk is ON DELETE RESTRICT, so')
     w('-- every referenced requirement must exist before the junction rows load.')
     w('--')
     w('-- ON DUPLICATE KEY UPDATE, not plain INSERT: darwin_dev already holds some of')
@@ -623,14 +660,14 @@ def main():
     w('-- from it) without disturbing anything else about the row.')
     w('-- ---------------------------------------------------------------------------')
     w('INSERT INTO requirements (id, title, requirement_status, coordination_type, '
-      'ai_model, effort, category_fk, creator_fk, machine_fk, feature_fk, '
+      'ai_model, effort, category_fk, creator_fk, machine_fk, '
       'tracking, started_at, completed_at) VALUES')
     values = []
     for rid in req_ids:
         src = live.get(rid, {})
         title = src.get('title') or f'Requirement #{rid} (not resolvable at fixture-generation time)'
-        machine = MACHINE_MAP.get(src.get('machine_fk'))
-        values.append('  (%d, %s, %s, %s, %s, %s, %d, %s, %s, %d, %d, %s, %s)' % (
+        machine = machine_ref(src.get('machine_fk'), machine_hosts)
+        values.append('  (%d, %s, %s, %s, %s, %s, %d, %s, %s, %d, %s, %s)' % (
             rid,
             q(title[:256]),
             q(src.get('requirement_status') or 'authoring'),
@@ -639,8 +676,7 @@ def main():
             q(src.get('effort') or 'high'),
             FIXTURE_CATEGORY,
             q(CREATOR),
-            q(machine),
-            feature_id[req_feature[rid]],
+            machine,
             1 if rid in tracking_ids else 0,
             q(src.get('started_at')),
             q(src.get('completed_at'))))
@@ -652,7 +688,6 @@ def main():
     w('  ai_model = new.ai_model,')
     w('  effort = new.effort,')
     w('  machine_fk = new.machine_fk,')
-    w('  feature_fk = new.feature_fk,')
     # In the UPDATE arm too, not just the INSERT arm: darwin_dev already holds
     # most of these ids, so a fixture that only set the flag on first insert
     # would leave a stale 0 on the very row the exemption is about.
@@ -671,9 +706,10 @@ def main():
             'max-parallel feature DAG. Source of truth: requirement #%d.' % REQ_ID)
     w('INSERT INTO pipelines (id, title, description, pipeline_status, machine_fk, '
       'creator_fk, started_at) VALUES')
-    w('  (%d, %s, %s, %s, %d, %s, %s);' % (
+    w('  (%d, %s, %s, %s, %s, %s, %s);' % (
         PIPELINE_ID, q(plan['plan']), q(goal), q('active'),
-        MACHINE_MAP[2], q(CREATOR), q('2026-07-24 00:00:00')))
+        machine_ref(PIPELINE_MACHINE, machine_hosts),
+        q(CREATOR), q('2026-07-24 00:00:00')))
     w('')
 
     # ---- steps ----------------------------------------------------------
@@ -783,9 +819,8 @@ def main():
         with open(OUT, 'w') as handle:
             handle.write(sql)
         print(f'wrote {OUT}')
-        print(f'  {len(epic_names)} epics, {len(feature_pairs)} features, '
-              f'{len(req_ids)} requirements, {len(rows)} steps, '
-              f'{len(links)} links, {len(step_deps)} deps')
+        print(f'  {len(epic_names)} epics, {len(req_ids)} requirements, '
+              f'{len(rows)} steps, {len(links)} links, {len(step_deps)} deps')
 
 
 if __name__ == '__main__':

--- a/scripts/seed_pipelines_darwin_dev.sql
+++ b/scripts/seed_pipelines_darwin_dev.sql
@@ -14,12 +14,17 @@
 -- (req #3147).
 --
 -- Source plan: requirement #3083, 42 rows, 67 distinct requirements,
---              4 epics, 23 features.
+--              4 epics.
+--
+-- NO FEATURE LAYER (req #3355). Migration 20260811033413 dropped `features`,
+-- `feature_test_cases` and `requirements.feature_fk`, so this fixture emits
+-- neither the feature rows nor the requirement->feature link it used to. A
+-- requirement reaches this plan through its STEP LINK and nothing else. Epics
+-- are unaffected and still emitted.
 --
 -- ## Id allocation (explicit, so this file is idempotent and self-scoping)
 --
 --   epics                9001..9004
---   features             9001..9023
 --   pipelines            9001
 --   pipeline_steps       9000 + the plan step id (see below)
 --   projects/categories  9001 / 9001 — owned by the fixture, created idempotently
@@ -51,21 +56,21 @@
 --                          pairs (design rule 2):
 --                          1(5), 33(2), 12(7), 13(5), 19(3), 38(3), 39(2),
 --                          40(4), 47(2), 49(3), 51(2).
---   * cross-epic step      step 19 — #3105 sits under a different epic than the
---                          step's dominant label, which is why labels attach at
---                          the requirement (design rule 10).
 --   * dropped-without-     requirements the user pulled from the plan (#3065/#3074
 --     residue              era) simply are not here — no tombstones, no residue.
 --
 -- Requirement rows are upserted with their LIVE metadata (title, status, model,
 -- effort) because step state is DERIVED from requirement status (design rule 1):
 -- without real statuses the fixture would render every step Scheduled and prove
--- nothing. machine_fk is remapped production->darwin_dev (2->74, 3->75); unmappable values
--- become NULL ("Any").
+-- nothing. machine_fk carries no cross-database id: the plan's production
+-- machine is emitted as a HOSTNAME lookup resolved against whichever `machines`
+-- table this file is loaded into (#2=Macmini, #3=SJO-LT-C72929B), so a rebuilt darwin_dev
+-- re-registering its machines under new ids cannot break the load. A hostname
+-- the target does not know resolves to NULL ("Any").
 --
 -- ## DERIVED STATE vs the plan's stored `state`
 --
--- Deriving state from this fixture reproduces the plan's own `state` field for 37
+-- Deriving state from this fixture reproduces the plan's own `state` field for 35
 -- of 42 rows.
 --
 -- ### RESOLVED — the tracking-requirement divergence (req #3123)
@@ -98,15 +103,17 @@
 --
 --   step 31  plan says pending  derivation says done
 --   step 18  plan says pending  derivation says done
+--   step 20  plan says pending  derivation says done
 --   step 43  plan says pending  derivation says done
 --   step 45  plan says active   derivation says done
 --   step 47  plan says pending  derivation says done
+--   step 51  plan says pending  derivation says done
 --
 -- The fixture is NOT adjusted to match. It stores no state at all, by design,
 -- and hand-correcting the inputs to make a rule come out right is exactly the
 -- move design rule 1 forbids. Causes found in THIS list:
 --
---   * PLAN LAG — steps 31, 18, 43, 45, 47. Here the DERIVATION is the correct value: the stored
+--   * PLAN LAG — steps 31, 18, 20, 43, 45, 47, 51. Here the DERIVATION is the correct value: the stored
 --     `state` field is hand-maintained and drifts the moment a session
 --     starts or closes. That lag is the exact failure design rule 1 names
 --     (plan row 13 read "Scheduled" while five sessions ran), so these rows
@@ -142,15 +149,15 @@ DELETE FROM pipeline_step_deps WHERE step_fk IN (SELECT id FROM pipeline_steps W
 DELETE FROM pipeline_step_requirements WHERE step_fk IN (SELECT id FROM pipeline_steps WHERE pipeline_fk = 9001);
 DELETE FROM pipeline_steps WHERE pipeline_fk = 9001;
 DELETE FROM pipelines WHERE id = 9001;
--- Detach requirements before features go, so fk_requirements_feature (SET NULL)
--- never has to fire mid-load and leave a half-linked state.
+--
+-- There is no `features` teardown any more, and no requirement detach before it
+-- (req #3355): migration 20260811033413 dropped the table and the
+-- `requirements.feature_fk` column that used to need clearing first.
 --
 -- Scoped to the EXACT ids this file is about to insert, never a BETWEEN range.
 -- Explicit ids at 9001+ leave AUTO_INCREMENT immediately above the fixture band, so
 -- the next organically-created row lands exactly where a growing range would
--- expand — and a later plan with one more feature label would delete it.
-UPDATE requirements SET feature_fk = NULL WHERE feature_fk IN (9001, 9002, 9003, 9004, 9005, 9006, 9007, 9008, 9009, 9010, 9011, 9012, 9013, 9014, 9015, 9016, 9017, 9018, 9019, 9020, 9021, 9022, 9023);
-DELETE FROM features WHERE id IN (9001, 9002, 9003, 9004, 9005, 9006, 9007, 9008, 9009, 9010, 9011, 9012, 9013, 9014, 9015, 9016, 9017, 9018, 9019, 9020, 9021, 9022, 9023);
+-- expand — and a later plan with one more epic label would delete it.
 DELETE FROM epics WHERE id IN (9001, 9002, 9003, 9004);
 
 -- ---------------------------------------------------------------------------
@@ -176,7 +183,9 @@ INSERT INTO categories (id, category_name, project_fk, creator_fk) VALUES
 AS new ON DUPLICATE KEY UPDATE category_name = new.category_name;
 
 -- ---------------------------------------------------------------------------
--- Epics (4) — the top of Epic > Feature > Story.
+-- Epics (4) — one per distinct epic label in the plan. Since req #3355 dropped
+-- the Feature layer, nothing in this fixture points at them: a requirement now
+-- reaches its epic only through the step that links it.
 -- ---------------------------------------------------------------------------
 INSERT INTO epics (id, title, description, category_fk, creator_fk, sort_order) VALUES
   (9001, 'Swarm Substrate Rebuild', 'Epic from the 2026-07-25 Substrate Rebuild plan (req #3083).', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 0),
@@ -185,110 +194,82 @@ INSERT INTO epics (id, title, description, category_fk, creator_fk, sort_order) 
   (9004, 'Primary and Swarm Agentic Integration', 'Epic from the 2026-07-25 Substrate Rebuild plan (req #3083).', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 3);
 
 -- ---------------------------------------------------------------------------
--- Features (23) — one per distinct feature label, linked to its epic.
--- ---------------------------------------------------------------------------
-INSERT INTO features (id, title, description, feature_status, epic_fk, category_fk, creator_fk, sort_order) VALUES
-  (9001, 'Session Drain', 'Feature under epic "Swarm Substrate Rebuild", from the Substrate Rebuild plan (req #3083).', 'active', 9001, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 0),
-  (9002, 'MCP Hardening', 'Feature under epic "Swarm Substrate Rebuild", from the Substrate Rebuild plan (req #3083).', 'active', 9001, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 1),
-  (9003, 'Substrate Safety', 'Feature under epic "Swarm Substrate Rebuild", from the Substrate Rebuild plan (req #3083).', 'active', 9001, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 2),
-  (9004, 'Green Baseline', 'Feature under epic "Swarm Substrate Rebuild", from the Substrate Rebuild plan (req #3083).', 'active', 9001, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 3),
-  (9005, 'WSL Parity', 'Feature under epic "Swarm Substrate Rebuild", from the Substrate Rebuild plan (req #3083).', 'active', 9001, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 4),
-  (9006, 'WSL Backlog', 'Feature under epic "Application Backlog", from the Substrate Rebuild plan (req #3083).', 'active', 9002, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 5),
-  (9007, 'Agentic Telemetry', 'Feature under epic "Application Backlog", from the Substrate Rebuild plan (req #3083).', 'active', 9002, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 6),
-  (9008, 'Clone Substrate', 'Feature under epic "Swarm Substrate Rebuild", from the Substrate Rebuild plan (req #3083).', 'active', 9001, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 7),
-  (9009, 'Backlog Wave', 'Feature under epic "Application Backlog", from the Substrate Rebuild plan (req #3083).', 'active', 9002, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 8),
-  (9010, 'Post-Wave Batch', 'Feature under epic "Application Backlog", from the Substrate Rebuild plan (req #3083).', 'active', 9002, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 9),
-  (9011, 'Primary Parity', 'Feature under epic "Swarm Substrate Rebuild", from the Substrate Rebuild plan (req #3083).', 'active', 9001, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 10),
-  (9012, 'Swarm Orchestration Feature', 'Feature under epic "Swarm Orchestration Feature", from the Substrate Rebuild plan (req #3083).', 'active', 9003, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 11),
-  (9013, 'Agent Infra Leverage', 'Feature under epic "Primary and Swarm Agentic Integration", from the Substrate Rebuild plan (req #3083).', 'active', 9004, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 12),
-  (9014, 'Foundation Wave', 'Feature under epic "Swarm Orchestration Feature", from the Substrate Rebuild plan (req #3083).', 'active', 9003, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 13),
-  (9015, 'API & Table Wave', 'Feature under epic "Swarm Orchestration Feature", from the Substrate Rebuild plan (req #3083).', 'active', 9003, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 14),
-  (9016, 'Visualizer & Doctrine Wave', 'Feature under epic "Swarm Orchestration Feature", from the Substrate Rebuild plan (req #3083).', 'active', 9003, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 15),
-  (9017, 'Acceptance', 'Feature under epic "Swarm Orchestration Feature", from the Substrate Rebuild plan (req #3083).', 'active', 9003, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 16),
-  (9018, 'Polish & Showcase', 'Feature under epic "Swarm Orchestration Feature", from the Substrate Rebuild plan (req #3083).', 'active', 9003, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 17),
-  (9019, 'Design Discussion', 'Feature under epic "Swarm Orchestration Feature", from the Substrate Rebuild plan (req #3083).', 'active', 9003, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 18),
-  (9020, 'Substrate Hygiene', 'Feature under epic "Swarm Substrate Rebuild", from the Substrate Rebuild plan (req #3083).', 'active', 9001, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 19),
-  (9021, 'Data Integrity', 'Feature under epic "Application Backlog", from the Substrate Rebuild plan (req #3083).', 'active', 9002, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 20),
-  (9022, 'Agentic Refactor', 'Feature under epic "Primary and Swarm Agentic Integration", from the Substrate Rebuild plan (req #3083).', 'active', 9004, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 21),
-  (9023, 'Swarm Doctrine', 'Carries the cross-epic requirement in plan step 19 — the launch unit spans epics, which is why labels attach at the requirement (req #3080 design rule 10).', 'active', 9001, 9001, '37df7531-000d-4470-8be4-1792d8261f69', 22);
-
--- ---------------------------------------------------------------------------
--- Requirements (67) — upserted with live metadata, then filed under their
--- feature. pipeline_step_requirements.requirement_fk is ON DELETE RESTRICT, so
+-- Requirements (67) — every requirement some step links, upserted with live
+-- metadata. pipeline_step_requirements.requirement_fk is ON DELETE RESTRICT, so
 -- every referenced requirement must exist before the junction rows load.
 --
 -- ON DUPLICATE KEY UPDATE, not plain INSERT: darwin_dev already holds some of
 -- these ids, and the fixture must refresh their status (step state is derived
 -- from it) without disturbing anything else about the row.
 -- ---------------------------------------------------------------------------
-INSERT INTO requirements (id, title, requirement_status, coordination_type, ai_model, effort, category_fk, creator_fk, machine_fk, feature_fk, tracking, started_at, completed_at) VALUES
-  (3041, 'Make the DarwinAI-Config base clone handled commonly with all sub-repos: hygiene preconditions must be ff-only SYNC, never SAVE. No operation may commit/push the live base clone except the primary''s own /save-primary-claude.', 'wontfix', 'implemented', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 9003, 0, NULL, '2026-07-25T11:03:58'),
-  (3045, 'Collect agent telemetry ', 'met', 'deployed', 'sonnet', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9009, 0, NULL, '2026-07-26T08:55:39'),
-  (3050, 'darwin-mcp rearchitecture: Lambda-Rest as single DB gateway (clean-sheet REST transport)', 'met', 'implemented', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 9001, 0, NULL, '2026-07-25T17:34:59'),
-  (3051, 'Documents page becomes editable', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9009, 0, NULL, '2026-07-26T10:41:50'),
-  (3056, 'Views show autonomy', 'met', 'implemented', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 75, 9001, 0, NULL, '2026-07-25T10:05:13'),
-  (3057, 'Junction POST returns 500 after committing the row (breaks Features linking)', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9009, 0, NULL, '2026-07-26T09:15:30'),
-  (3058, 'memory/api-gateway.md route tables are stale — full reconciliation', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9008, 0, NULL, '2026-07-26T08:24:48'),
-  (3059, 'Map pymysql IntegrityError to HTTP 409 in Lambda-Rest', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9009, 0, NULL, '2026-07-26T10:04:37'),
-  (3060, 'E2E coverage for the editable agent instruction registry', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9010, 0, NULL, '2026-07-26T11:46:23'),
-  (3061, 'Two stale backend test files fail on schema drift', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9004, 0, NULL, '2026-07-26T00:59:00'),
-  (3063, 'Instruction Edit In Place', 'met', 'implemented', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 9001, 0, NULL, '2026-07-25T11:26:25'),
-  (3064, 'Aggregator Card Polish', 'met', 'implemented', 'sonnet', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 75, 9001, 0, NULL, '2026-07-25T09:54:20'),
-  (3065, 'Agent Context Polish', 'met', 'implemented', 'sonnet', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 75, 9006, 0, NULL, '2026-07-26T11:03:04'),
-  (3067, 'Instructions Table View — hardened generic edit-in-place table pattern', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9009, 0, NULL, '2026-07-26T23:30:27'),
-  (3068, 'Instructions need proper English titles, not kebab-case slugs', 'met', 'planned', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 9001, 0, NULL, '2026-07-25T11:26:26'),
-  (3069, 'Statusline DevServ indicator never shows on dash-based /bin/sh (WSL/Linux) — works on macOS only', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9003, 0, NULL, '2026-07-25T22:45:09'),
-  (3071, 'Replace remaining window.confirm calls under /agents with the house dialog pattern', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9009, 0, NULL, '2026-07-26T09:13:37'),
-  (3072, 'Swarm substrate Phase 0+1 — eliminate shared-clone git corruption class (de-symlink, Primary-only sync, remove worker-to-Primary writes, full git audit)', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9003, 0, NULL, '2026-07-25T20:49:24'),
-  (3074, 'Primary and Swarm AI leverage Agent Infra', 'authoring', 'discuss', 'fable', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9013, 0, NULL, NULL),
-  (3075, 'agent_instructions.sort_order has no per-agent uniqueness guard — decide the invariant', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9009, 0, NULL, '2026-07-26T09:49:34'),
-  (3076, 'Test InstructionDeleteDialog data-loss vs boot-impact wording', 'met', 'deployed', 'opus', 'low', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9009, 0, NULL, '2026-07-26T08:53:14'),
-  (3077, 'Swarm substrate Phases 2-4 — per-session clone provisioning from local mirrors; retire git-worktree machinery (full worker independence)', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9008, 0, NULL, '2026-07-26T02:53:18'),
-  (3078, 'darwin-mcp: bounded list reads — Lambda 6 MB response ceiling 502s large resources', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9002, 0, NULL, '2026-07-25T19:03:14'),
-  (3079, 'WSL: migrate mcp_credentials.sh to the #3050 Cognito variable set (new darwin-mcp daemon fails with ''DB_HOST'' error until done)', 'met', 'discuss', 'sonnet', 'medium', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 75, 9005, 0, NULL, '2026-07-26T02:14:10'),
-  (3080, 'Swarm Orchestration Feature: discuss session to spec and file the requirements for a durable pipeline data type (plans stored in Darwin, rendered in SwarmView, executed by Primary AI)', 'met', 'discuss', 'fable', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9012, 0, NULL, '2026-07-27T01:25:19'),
-  (3082, 'Primary AI substrate parity - relocate Primary to ~/darwin/primary via the unified clone pattern (pipeline Stage 5)', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9011, 0, NULL, '2026-07-27T07:10:46'),
-  (3083, 'Substrate Rebuild Pipeline - plan tracking (single source of truth for the plan page)', 'met', 'implemented', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9012, 1, NULL, '2026-07-27T10:53:33'),
-  (3084, 'WSL verification 1 of 3: full MCP validation', 'met', 'implemented', 'sonnet', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 75, 9005, 0, NULL, '2026-07-26T03:19:32'),
-  (3085, 'WSL verification 2 of 3: full swarm session independence', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 75, 9005, 0, NULL, '2026-07-26T09:42:38'),
-  (3086, 'WSL verification 3 of 3: full primary session independence', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 75, 9005, 0, NULL, '2026-07-31T09:19:49'),
-  (3087, 'Primary gate execution + B5a cutover for clone substrate (#3077 Stage 3/4)', 'met', 'implemented', 'fable', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9008, 0, NULL, '2026-07-26T06:01:35'),
-  (3088, 'Substrate remediation: R18 freshness contract, R19 no-hardlinks, B3 skill cutover, R6 attribution coverage + gap tests', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9008, 0, NULL, '2026-07-26T05:25:08'),
-  (3089, 'provision-repo.sh venv step uses system python3 (3.9) — fastmcp needs 3.10+; canary-1 venv=failed', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9010, 0, NULL, '2026-07-26T11:28:16'),
-  (3090, 'Clone substrate canary-2: multi-repo session lifecycle validation (throwaway)', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9008, 0, NULL, '2026-07-26T08:14:15'),
-  (3091, 'Clone sessions hit the Claude Code folder-trust dialog — pre-trust session dirs at launch (blocks all autonomous workers)', 'met', 'implemented', 'fable', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9008, 0, NULL, '2026-07-26T08:00:25'),
-  (3092, 'Persist per-repo provisioning telemetry (mirror_action, venv) into the swarm session record', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9010, 0, NULL, '2026-07-26T11:48:11'),
-  (3093, '/swarm-complete Step 5.6 worker guard never fires — mcp-restart-if-stale.sh reads $PWD, but Step 0(d) cd s to mainRepoPath', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9010, 0, NULL, '2026-07-26T11:29:45'),
-  (3094, 'POST /profiles read-back returns other users rows (WHERE id=0 on a non-auto-increment id)', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9010, 0, NULL, '2026-07-26T11:33:28'),
-  (3095, 'Ground-truth breakdown of the Claude Code base token figure', 'met', 'planned', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 75, 9007, 0, NULL, '2026-07-27T04:12:53'),
-  (3096, 'Per-document actual-token capture for architecture/autoload docs', 'met', 'deployed', 'sonnet', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 9007, 0, NULL, '2026-07-26T12:43:30'),
-  (3097, 'Post-relocation Primary verification battery (Mac mini) — executed by the NEW primary session', 'met', 'implemented', 'fable', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9011, 0, NULL, '2026-07-27T18:56:50'),
-  (3098, 'Capture machine, model, and effort for agent telemetry runs', 'met', 'deployed', 'sonnet', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 9007, 0, NULL, '2026-07-26T22:06:34'),
-  (3105, 'Swarm-Complete can RDS Snapshot', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9023, 0, NULL, '2026-07-27T00:33:55'),
-  (3108, 'Cooperative inter-Claude message system: proactive status communication between Primary(s) and workers — design discussion', 'deferred', 'discuss', 'fable', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 9019, 0, NULL, NULL),
-  (3110, 'Swarm Orchestration: groom the full design intent into Swarm Architect documentation', 'met', 'deployed', 'fable', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9014, 0, NULL, '2026-07-27T01:52:32'),
-  (3111, 'Swarm Orchestration: schema foundation - epic hierarchy + pipelines data type (migration, routes, darwin_dev fixtures)', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9014, 0, NULL, '2026-07-27T02:48:28'),
-  (3112, 'Swarm Orchestration: ordering & derivation engine - pure JS module with self-checking invariants (vitest)', 'met', 'deployed', 'fable', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9014, 0, NULL, '2026-07-27T02:14:14'),
-  (3113, 'Swarm Orchestration: MCP pipelines API - bounded resources + echo-verified mutation tools', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9015, 0, NULL, '2026-07-27T04:43:18'),
-  (3114, 'Swarm Orchestration: SwarmView pipelines UI - hooks, routes, list page + plan-rows table view', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9015, 0, NULL, '2026-07-27T03:47:50'),
-  (3115, 'Swarm Orchestration: Plan visualizer (no time anchor) - epic bands, swim lanes, batch boxes, drag-pan + three-level zoom', 'met', 'deployed', 'fable', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9016, 0, NULL, '2026-07-27T05:53:33'),
-  (3116, 'Swarm Orchestration: Primary execution doctrine + fail-loud pipeline watchdog', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9016, 0, NULL, '2026-07-27T06:08:09'),
-  (3117, 'Swarm Orchestration: cost rollup - server-side precompute at session completion + Time/Tokens display', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9016, 0, NULL, '2026-07-27T06:17:49'),
-  (3118, 'Swarm Orchestration: E2E + mutation-case acceptance battery', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9017, 0, NULL, '2026-07-27T07:38:52'),
-  (3119, 'Swarm Orchestration: final polish & showcase - full live 3083 plan in darwin_dev, dev-server walkthrough, executive summary', 'met', 'implemented', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9018, 0, NULL, '2026-07-27T10:53:28'),
-  (3121, 'DarwinSQL migration-number allocation collides across concurrent sessions (046/050/074x3) - decide scheme + normalize + enforce', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9020, 0, NULL, '2026-07-27T05:16:29'),
-  (3122, 'Pipeline junction scoping: creator_fk authorization call for pipeline_step_deps surrogate-id addressability (pre/post #3113 MCP exposure)', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9016, 0, NULL, '2026-07-27T06:04:54'),
-  (3124, 'darwin_dev schema tests vs concurrent session DDL - shared-mutable-state isolation policy', 'deferred', 'discuss', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 9021, 0, NULL, NULL),
-  (3125, 'Cross-tenant FK grief-lock: ownership-check FK targets on all creator_fk-bearing tables (test_runs.test_plan_fk + 10 siblings)', 'met', 'implemented', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 9021, 0, NULL, '2026-07-27T09:12:47'),
-  (3126, 'STRICT_TRANS_TABLES decision: enable strict sql_mode on RDS (parameter-group change + staged regression)', 'met', 'discuss', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 9021, 0, NULL, '2026-07-27T08:54:00'),
-  (3127, 'Primary cutover execution P3-P6: relocate Primary to ~/darwin/primary per runbook (follow-on to 3082)', 'met', 'discuss', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', 74, 9011, 0, NULL, '2026-07-27T18:56:51'),
-  (3128, 'Instruction: executive summary', 'met', 'discuss', 'fable', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 9022, 0, NULL, '2026-07-27T08:21:04'),
-  (3129, 'Instructions refactor', 'met', 'discuss', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 9022, 0, NULL, '2026-07-27T10:00:27'),
-  (3130, 'instruction: Polish pattern', 'met', 'discuss', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 9022, 0, NULL, '2026-07-27T08:34:18'),
-  (3131, 'instruction: Reflection Pattern', 'met', 'discuss', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 9022, 0, NULL, '2026-07-27T08:30:05'),
-  (3132, 'swarm-complete closeout gate: refuse session completion that leaves its requirement non-terminal (from 3082 breach)', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 9020, 0, NULL, '2026-07-27T08:00:48'),
-  (3136, 'AWS Architect guiding principles document', 'authoring', 'discuss', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 9022, 0, NULL, NULL),
-  (3137, 'Agents Architect guiding principles document', 'authoring', 'discuss', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 9022, 0, NULL, NULL)
+INSERT INTO requirements (id, title, requirement_status, coordination_type, ai_model, effort, category_fk, creator_fk, machine_fk, tracking, started_at, completed_at) VALUES
+  (3041, 'Make the DarwinAI-Config base clone handled commonly with all sub-repos: hygiene preconditions must be ff-only SYNC, never SAVE. No operation may commit/push the live base clone except the primary''s own /save-primary-claude.', 'wontfix', 'implemented', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 0, NULL, '2026-07-25T11:03:58'),
+  (3045, 'Collect agent telemetry ', 'met', 'deployed', 'sonnet', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-26T08:55:39'),
+  (3050, 'darwin-mcp rearchitecture: Lambda-Rest as single DB gateway (clean-sheet REST transport)', 'met', 'implemented', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 0, NULL, '2026-07-25T17:34:59'),
+  (3051, 'Documents page becomes editable', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-26T10:41:50'),
+  (3056, 'Views show autonomy', 'met', 'implemented', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'SJO-LT-C72929B'), 0, NULL, '2026-07-25T10:05:13'),
+  (3057, 'Junction POST returns 500 after committing the row (breaks Features linking)', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-26T09:15:30'),
+  (3058, 'memory/api-gateway.md route tables are stale — full reconciliation', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-26T08:24:48'),
+  (3059, 'Map pymysql IntegrityError to HTTP 409 in Lambda-Rest', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-26T10:04:37'),
+  (3060, 'E2E coverage for the editable agent instruction registry', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-26T11:46:23'),
+  (3061, 'Two stale backend test files fail on schema drift', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-26T00:59:00'),
+  (3063, 'Instruction Edit In Place', 'met', 'implemented', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 0, NULL, '2026-07-25T11:26:25'),
+  (3064, 'Aggregator Card Polish', 'met', 'implemented', 'sonnet', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'SJO-LT-C72929B'), 0, NULL, '2026-07-25T09:54:20'),
+  (3065, 'Agent Context Polish', 'met', 'implemented', 'sonnet', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'SJO-LT-C72929B'), 0, NULL, '2026-07-26T11:03:04'),
+  (3067, 'Instructions Table View — hardened generic edit-in-place table pattern', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-26T23:30:27'),
+  (3068, 'Instructions need proper English titles, not kebab-case slugs', 'met', 'planned', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 0, NULL, '2026-07-25T11:26:26'),
+  (3069, 'Statusline DevServ indicator never shows on dash-based /bin/sh (WSL/Linux) — works on macOS only', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-25T22:45:09'),
+  (3071, 'Replace remaining window.confirm calls under /agents with the house dialog pattern', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-26T09:13:37'),
+  (3072, 'Swarm substrate Phase 0+1 — eliminate shared-clone git corruption class (de-symlink, Primary-only sync, remove worker-to-Primary writes, full git audit)', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-25T20:49:24'),
+  (3074, 'Agent Harness for Primary AI and Swarm', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 0, NULL, '2026-08-09T00:27:00'),
+  (3075, 'agent_instructions.sort_order has no per-agent uniqueness guard — decide the invariant', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-26T09:49:34'),
+  (3076, 'Test InstructionDeleteDialog data-loss vs boot-impact wording', 'met', 'deployed', 'opus', 'low', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-26T08:53:14'),
+  (3077, 'Swarm substrate Phases 2-4 — per-session clone provisioning from local mirrors; retire git-worktree machinery (full worker independence)', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-26T02:53:18'),
+  (3078, 'darwin-mcp: bounded list reads — Lambda 6 MB response ceiling 502s large resources', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-25T19:03:14'),
+  (3079, 'WSL: migrate mcp_credentials.sh to the #3050 Cognito variable set (new darwin-mcp daemon fails with ''DB_HOST'' error until done)', 'met', 'discuss', 'sonnet', 'medium', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'SJO-LT-C72929B'), 0, NULL, '2026-07-26T02:14:10'),
+  (3080, 'Swarm Orchestration Feature: discuss session to spec and file the requirements for a durable pipeline data type (plans stored in Darwin, rendered in SwarmView, executed by Primary AI)', 'met', 'discuss', 'fable', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-27T01:25:19'),
+  (3082, 'Primary AI substrate parity - relocate Primary to ~/darwin/primary via the unified clone pattern (pipeline Stage 5)', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-27T07:10:46'),
+  (3083, 'Substrate Rebuild Pipeline - plan tracking (single source of truth for the plan page)', 'met', 'implemented', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 1, NULL, '2026-07-27T10:53:33'),
+  (3084, 'WSL verification 1 of 3: full MCP validation', 'met', 'implemented', 'sonnet', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'SJO-LT-C72929B'), 0, NULL, '2026-07-26T03:19:32'),
+  (3085, 'WSL verification 2 of 3: full swarm session independence', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'SJO-LT-C72929B'), 0, NULL, '2026-07-26T09:42:38'),
+  (3086, 'WSL verification 3 of 3: full primary session independence', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'SJO-LT-C72929B'), 0, NULL, '2026-07-31T09:19:49'),
+  (3087, 'Primary gate execution + B5a cutover for clone substrate (#3077 Stage 3/4)', 'met', 'implemented', 'fable', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-26T06:01:35'),
+  (3088, 'Substrate remediation: R18 freshness contract, R19 no-hardlinks, B3 skill cutover, R6 attribution coverage + gap tests', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-26T05:25:08'),
+  (3089, 'provision-repo.sh venv step uses system python3 (3.9) — fastmcp needs 3.10+; canary-1 venv=failed', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-26T11:28:16'),
+  (3090, 'Clone substrate canary-2: multi-repo session lifecycle validation (throwaway)', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-26T08:14:15'),
+  (3091, 'Clone sessions hit the Claude Code folder-trust dialog — pre-trust session dirs at launch (blocks all autonomous workers)', 'met', 'implemented', 'fable', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-26T08:00:25'),
+  (3092, 'Persist per-repo provisioning telemetry (mirror_action, venv) into the swarm session record', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-26T11:48:11'),
+  (3093, '/swarm-complete Step 5.6 worker guard never fires — mcp-restart-if-stale.sh reads $PWD, but Step 0(d) cd s to mainRepoPath', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-26T11:29:45'),
+  (3094, 'POST /profiles read-back returns other users rows (WHERE id=0 on a non-auto-increment id)', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-26T11:33:28'),
+  (3095, 'Ground-truth breakdown of the Claude Code base token figure', 'met', 'planned', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'SJO-LT-C72929B'), 0, NULL, '2026-07-27T04:12:53'),
+  (3096, 'Per-document actual-token capture for architecture/autoload docs', 'met', 'deployed', 'sonnet', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 0, NULL, '2026-07-26T12:43:30'),
+  (3097, 'Post-relocation Primary verification battery (Mac mini) — executed by the NEW primary session', 'met', 'implemented', 'fable', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-27T18:56:50'),
+  (3098, 'Capture machine, model, and effort for agent telemetry runs', 'met', 'deployed', 'sonnet', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 0, NULL, '2026-07-26T22:06:34'),
+  (3105, 'Swarm-Complete can RDS Snapshot', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-27T00:33:55'),
+  (3108, 'Cooperative inter-Claude message system: proactive status communication between Primary(s) and workers — design discussion', 'deferred', 'discuss', 'fable', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 0, NULL, NULL),
+  (3110, 'Swarm Orchestration: groom the full design intent into Swarm Architect documentation', 'met', 'deployed', 'fable', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-27T01:52:32'),
+  (3111, 'Swarm Orchestration: schema foundation - epic hierarchy + pipelines data type (migration, routes, darwin_dev fixtures)', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-27T02:48:28'),
+  (3112, 'Swarm Orchestration: ordering & derivation engine - pure JS module with self-checking invariants (vitest)', 'met', 'deployed', 'fable', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-27T02:14:14'),
+  (3113, 'Swarm Orchestration: MCP pipelines API - bounded resources + echo-verified mutation tools', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-27T04:43:18'),
+  (3114, 'Swarm Orchestration: SwarmView pipelines UI - hooks, routes, list page + plan-rows table view', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-27T03:47:50'),
+  (3115, 'Swarm Orchestration: Plan visualizer (no time anchor) - epic bands, swim lanes, batch boxes, drag-pan + three-level zoom', 'met', 'deployed', 'fable', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-27T05:53:33'),
+  (3116, 'Swarm Orchestration: Primary execution doctrine + fail-loud pipeline watchdog', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-27T06:08:09'),
+  (3117, 'Swarm Orchestration: cost rollup - server-side precompute at session completion + Time/Tokens display', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-27T06:17:49'),
+  (3118, 'Swarm Orchestration: E2E + mutation-case acceptance battery', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-27T07:38:52'),
+  (3119, 'Swarm Orchestration: final polish & showcase - full live 3083 plan in darwin_dev, dev-server walkthrough, executive summary', 'met', 'implemented', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-27T10:53:28'),
+  (3121, 'DarwinSQL migration-number allocation collides across concurrent sessions (046/050/074x3) - decide scheme + normalize + enforce', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-27T05:16:29'),
+  (3122, 'Pipeline junction scoping: creator_fk authorization call for pipeline_step_deps surrogate-id addressability (pre/post #3113 MCP exposure)', 'met', 'deployed', 'opus', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-27T06:04:54'),
+  (3124, 'darwin_dev schema tests vs concurrent session DDL - shared-mutable-state isolation policy', 'deferred', 'discuss', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 0, NULL, NULL),
+  (3125, 'Cross-tenant FK grief-lock: ownership-check FK targets on all creator_fk-bearing tables (test_runs.test_plan_fk + 10 siblings)', 'met', 'implemented', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 0, NULL, '2026-07-27T09:12:47'),
+  (3126, 'STRICT_TRANS_TABLES decision: enable strict sql_mode on RDS (parameter-group change + staged regression)', 'met', 'discuss', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 0, NULL, '2026-07-27T08:54:00'),
+  (3127, 'Primary cutover execution P3-P6: relocate Primary to ~/darwin/primary per runbook (follow-on to 3082)', 'met', 'discuss', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', (SELECT id FROM machines WHERE hostname = 'Macmini'), 0, NULL, '2026-07-27T18:56:51'),
+  (3128, 'Instruction: executive summary', 'met', 'discuss', 'fable', 'xhigh', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 0, NULL, '2026-07-27T08:21:04'),
+  (3129, 'Instructions refactor', 'met', 'discuss', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 0, NULL, '2026-07-27T10:00:27'),
+  (3130, 'instruction: Polish pattern', 'met', 'discuss', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 0, NULL, '2026-07-27T08:34:18'),
+  (3131, 'instruction: Reflection Pattern', 'met', 'discuss', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 0, NULL, '2026-07-27T08:30:05'),
+  (3132, 'swarm-complete closeout gate: refuse session completion that leaves its requirement non-terminal (from 3082 breach)', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 0, NULL, '2026-07-27T08:00:48'),
+  (3136, 'AWS Architect guiding principles document', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 0, NULL, '2026-08-02T12:14:40'),
+  (3137, 'Agents Architect guiding principles document', 'met', 'deployed', 'opus', 'high', 9001, '37df7531-000d-4470-8be4-1792d8261f69', NULL, 0, NULL, '2026-08-02T12:04:32')
 AS new ON DUPLICATE KEY UPDATE
   title = new.title,
   requirement_status = new.requirement_status,
@@ -296,7 +277,6 @@ AS new ON DUPLICATE KEY UPDATE
   ai_model = new.ai_model,
   effort = new.effort,
   machine_fk = new.machine_fk,
-  feature_fk = new.feature_fk,
   tracking = new.tracking,
   started_at = new.started_at,
   completed_at = new.completed_at;
@@ -306,7 +286,7 @@ AS new ON DUPLICATE KEY UPDATE
 -- intent about the plan as a whole — the only hand-set lifecycle in the feature.
 -- ---------------------------------------------------------------------------
 INSERT INTO pipelines (id, title, description, pipeline_status, machine_fk, creator_fk, started_at) VALUES
-  (9001, 'Substrate Rebuild Pipeline', 'Recover from the .git/index corruption incident, eliminate the shared-clone corruption class, rebuild provisioning on per-session clones, then run the max-parallel feature DAG. Source of truth: requirement #3083.', 'active', 74, '37df7531-000d-4470-8be4-1792d8261f69', '2026-07-24 00:00:00');
+  (9001, 'Substrate Rebuild Pipeline', 'Recover from the .git/index corruption incident, eliminate the shared-clone corruption class, rebuild provisioning on per-session clones, then run the max-parallel feature DAG. Source of truth: requirement #3083.', 'active', (SELECT id FROM machines WHERE hostname = 'Macmini'), '37df7531-000d-4470-8be4-1792d8261f69', '2026-07-24 00:00:00');
 
 -- ---------------------------------------------------------------------------
 -- Steps (42) — one per plan row, id = plan step id.

--- a/scripts/verify-lambda-policy.sh
+++ b/scripts/verify-lambda-policy.sh
@@ -32,11 +32,16 @@ REGION="us-west-1"
 STAGE="eng"
 BASE_URL="https://${API_ID}.execute-api.${REGION}.amazonaws.com/${STAGE}"
 
-# The 23 Sids req #3002 removes — the redundant apigateway-darwin-<table>
+# The 21 Sids req #3002 removes — the redundant apigateway-darwin-<table>
 # statements, all fully subsumed by apigateway-darwin-wildcard.
+# `apigateway-darwin-features` and `apigateway-darwin-feature_test_cases` left
+# this list at req #3355 (migration 20260811033413): the `features` and
+# `feature_test_cases` tables — and their `/darwin/*`, `/darwin_dev/*` gateway
+# resources — no longer exist, so there is nothing left to verify the absence
+# of a redundant statement FOR.
 REMOVED_SIDS=(
-    apigateway-darwin-features apigateway-darwin-test_cases
-    apigateway-darwin-feature_test_cases apigateway-darwin-test_plans
+    apigateway-darwin-test_cases
+    apigateway-darwin-test_plans
     apigateway-darwin-test_plan_cases apigateway-darwin-test_runs
     apigateway-darwin-test_results apigateway-darwin-swarm_starts
     apigateway-darwin-swarm_start_sessions apigateway-darwin-agents
@@ -82,9 +87,9 @@ ADDED_ACTUAL=$(comm -13 <(echo "$BEFORE_SIDS") <(echo "$AFTER_SIDS"))
 EXPECTED_REMOVED=$(printf '%s\n' "${REMOVED_SIDS[@]}" | sort)
 
 if [ "$REMOVED_ACTUAL" = "$EXPECTED_REMOVED" ]; then
-    pass "exactly the 23 target Sids were removed, nothing more / nothing less"
+    pass "exactly the 21 target Sids were removed, nothing more / nothing less"
 else
-    fail "removed-Sid set does not match the expected 23 — diff:"
+    fail "removed-Sid set does not match the expected 21 — diff:"
     diff <(echo "$EXPECTED_REMOVED") <(echo "$REMOVED_ACTUAL") >&2 || true
 fi
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,21 +150,21 @@ def seed_test_profile(db_connection, test_creator_fk):
         cur.execute("DELETE FROM instructions WHERE creator_fk = %s", (test_creator_fk,))
         cur.execute("DELETE FROM architecture_documents WHERE creator_fk = %s",
                     (test_creator_fk,))
-        # Req #2380: features/test_cases/test_plans RESTRICT on categories,
-        # so delete these BEFORE categories. test_results and test_runs also
-        # clean up explicitly to handle tests that commit mid-run.
+        # Req #2380: test_cases/test_plans RESTRICT on categories, so delete
+        # these BEFORE categories. test_results and test_runs also clean up
+        # explicitly to handle tests that commit mid-run. `features` and
+        # `feature_test_cases` were dropped at req #3355 (migration
+        # 20260811033413) — test cases now re-home onto Requirement via
+        # `requirement_test_cases`, cleaned up above with `requirements`
+        # (ON DELETE CASCADE).
         cur.execute("DELETE FROM test_results WHERE creator_fk = %s", (test_creator_fk,))
         cur.execute("DELETE FROM test_runs WHERE creator_fk = %s", (test_creator_fk,))
         cur.execute("DELETE FROM test_plan_cases WHERE test_plan_fk IN "
                     "(SELECT id FROM test_plans WHERE creator_fk = %s)", (test_creator_fk,))
         cur.execute("DELETE FROM test_plans WHERE creator_fk = %s", (test_creator_fk,))
-        cur.execute("DELETE FROM feature_test_cases WHERE feature_fk IN "
-                    "(SELECT id FROM features WHERE creator_fk = %s)", (test_creator_fk,))
         cur.execute("DELETE FROM test_cases WHERE creator_fk = %s", (test_creator_fk,))
-        cur.execute("DELETE FROM features WHERE creator_fk = %s", (test_creator_fk,))
         # Req #3111: epics -> categories is RESTRICT, so epics must go before
-        # categories. features.epic_fk is SET NULL, so features may go either
-        # side; deleted just above for readability.
+        # categories.
         cur.execute("DELETE FROM epics WHERE creator_fk = %s", (test_creator_fk,))
         cur.execute("DELETE FROM categories WHERE creator_fk = %s", (test_creator_fk,))
         cur.execute("DELETE FROM projects WHERE creator_fk = %s", (test_creator_fk,))

--- a/tests/test_cascades.py
+++ b/tests/test_cascades.py
@@ -838,6 +838,10 @@ def test_delete_area_does_not_affect_sibling_areas(db_connection):
 
 # ---------------------------------------------------------------------------
 # Req #2380 — Swarm Features & Test Cases registry CASCADE/RESTRICT
+# `features` and `feature_test_cases` were dropped at req #3355 (migration
+# 20260811033413); their cascade coverage is superseded by
+# test_delete_requirement_cascades_to_requirement_test_cases and
+# test_delete_test_case_cascades_to_requirement_test_cases below.
 # ---------------------------------------------------------------------------
 
 def _setup_validation_creator(cur, prefix):
@@ -867,20 +871,6 @@ def _setup_validation_creator(cur, prefix):
     return creator, project_id, category_id
 
 
-def test_delete_category_with_features_rejected(db_connection):
-    """DELETE category with live features → IntegrityError (ON DELETE RESTRICT)."""
-    with db_connection.cursor() as cur:
-        creator, _project, category_id = _setup_validation_creator(cur, 'cascade-feat-cat')
-        cur.execute(
-            "INSERT INTO features (title, description, category_fk, creator_fk) "
-            "VALUES (%s, %s, %s, %s)",
-            ('blocker feature', 'd', category_id, creator)
-        )
-        with pytest.raises(pymysql.IntegrityError):
-            cur.execute("DELETE FROM categories WHERE id = %s", (category_id,))
-    db_connection.rollback()
-
-
 def test_delete_category_with_test_cases_rejected(db_connection):
     """DELETE category with live test_cases → IntegrityError (ON DELETE RESTRICT)."""
     with db_connection.cursor() as cur:
@@ -908,87 +898,10 @@ def test_delete_category_with_test_plans_rejected(db_connection):
     db_connection.rollback()
 
 
-def test_delete_feature_cascades_to_feature_test_cases(db_connection):
-    """DELETE feature → CASCADE removes its feature_test_cases rows."""
-    with db_connection.cursor() as cur:
-        creator, _project, category_id = _setup_validation_creator(cur, 'cascade-feat-del')
-        cur.execute(
-            "INSERT INTO features (title, description, category_fk, creator_fk) "
-            "VALUES (%s, %s, %s, %s)",
-            ('feat', 'd', category_id, creator)
-        )
-        cur.execute("SELECT LAST_INSERT_ID() AS id")
-        feature_id = cur.fetchone()['id']
-
-        cur.execute(
-            "INSERT INTO test_cases (title, steps, expected, category_fk, creator_fk) "
-            "VALUES (%s, %s, %s, %s, %s)",
-            ('case', '1', 'ok', category_id, creator)
-        )
-        cur.execute("SELECT LAST_INSERT_ID() AS id")
-        case_id = cur.fetchone()['id']
-
-        cur.execute(
-            "INSERT INTO feature_test_cases (feature_fk, test_case_fk) VALUES (%s, %s)",
-            (feature_id, case_id)
-        )
-
-        cur.execute("DELETE FROM features WHERE id = %s", (feature_id,))
-
-        cur.execute(
-            "SELECT COUNT(*) AS c FROM feature_test_cases "
-            "WHERE feature_fk = %s OR test_case_fk = %s",
-            (feature_id, case_id)
-        )
-        assert cur.fetchone()['c'] == 0  # CASCADE removed the junction row
-        # Test case itself is untouched
-        cur.execute("SELECT id FROM test_cases WHERE id = %s", (case_id,))
-        assert cur.fetchone() is not None
-    db_connection.rollback()
-
-
-def test_delete_test_case_cascades_to_feature_test_cases(db_connection):
-    """DELETE test_case → CASCADE removes its feature_test_cases rows."""
-    with db_connection.cursor() as cur:
-        creator, _project, category_id = _setup_validation_creator(cur, 'cascade-case-del')
-        cur.execute(
-            "INSERT INTO features (title, description, category_fk, creator_fk) "
-            "VALUES (%s, %s, %s, %s)",
-            ('feat', 'd', category_id, creator)
-        )
-        cur.execute("SELECT LAST_INSERT_ID() AS id")
-        feature_id = cur.fetchone()['id']
-
-        cur.execute(
-            "INSERT INTO test_cases (title, steps, expected, category_fk, creator_fk) "
-            "VALUES (%s, %s, %s, %s, %s)",
-            ('case', '1', 'ok', category_id, creator)
-        )
-        cur.execute("SELECT LAST_INSERT_ID() AS id")
-        case_id = cur.fetchone()['id']
-
-        cur.execute(
-            "INSERT INTO feature_test_cases (feature_fk, test_case_fk) VALUES (%s, %s)",
-            (feature_id, case_id)
-        )
-
-        cur.execute("DELETE FROM test_cases WHERE id = %s", (case_id,))
-
-        cur.execute(
-            "SELECT COUNT(*) AS c FROM feature_test_cases WHERE test_case_fk = %s",
-            (case_id,)
-        )
-        assert cur.fetchone()['c'] == 0
-        # Feature itself untouched
-        cur.execute("SELECT id FROM features WHERE id = %s", (feature_id,))
-        assert cur.fetchone() is not None
-    db_connection.rollback()
-
-
 # COVERS: SCH-031
 def test_delete_requirement_cascades_to_requirement_test_cases(db_connection):
     """req #3352 — DELETE requirement → CASCADE removes its requirement_test_cases
-    rows. Mirrors test_delete_feature_cascades_to_feature_test_cases above."""
+    rows (the successor of the now-dropped feature_test_cases junction)."""
     with db_connection.cursor() as cur:
         creator, _project, category_id = _setup_validation_creator(cur, 'cascade-req-del')
         cur.execute(
@@ -1029,7 +942,7 @@ def test_delete_requirement_cascades_to_requirement_test_cases(db_connection):
 # COVERS: SCH-031
 def test_delete_test_case_cascades_to_requirement_test_cases(db_connection):
     """req #3352 — DELETE test_case → CASCADE removes its requirement_test_cases
-    rows. Mirrors test_delete_test_case_cascades_to_feature_test_cases above."""
+    rows (the successor of the now-dropped feature_test_cases junction)."""
     with db_connection.cursor() as cur:
         creator, _project, category_id = _setup_validation_creator(cur, 'cascade-req-case-del')
         cur.execute(

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -751,33 +751,11 @@ def test_map_run_stopped_time_default(db_connection, test_creator_fk):
 
 # ---------------------------------------------------------------------------
 # Req #2380 — Swarm Features & Test Cases registry (migrations 042/043/044)
+# `features` was dropped at req #3355 (migration 20260811033413); its FK/NOT
+# NULL/default coverage went with it.
 # ---------------------------------------------------------------------------
 
 # FK invalid-parent rejection tests
-
-def test_feature_fk_invalid_category(db_connection, test_creator_fk, seed_test_profile):
-    """INSERT feature with non-existent category_fk → IntegrityError"""
-    with db_connection.cursor() as cur:
-        with pytest.raises(pymysql.IntegrityError):
-            cur.execute(
-                "INSERT INTO features (title, description, category_fk, creator_fk) "
-                "VALUES (%s, %s, %s, %s)",
-                ('orphan feature', 'desc', 999999, test_creator_fk)
-            )
-    db_connection.rollback()
-
-
-def test_feature_fk_invalid_creator(db_connection, test_category_id):
-    """INSERT feature with non-existent creator_fk → IntegrityError"""
-    with db_connection.cursor() as cur:
-        with pytest.raises(pymysql.IntegrityError):
-            cur.execute(
-                "INSERT INTO features (title, description, category_fk, creator_fk) "
-                "VALUES (%s, %s, %s, %s)",
-                ('orphan', 'desc', test_category_id, 'nonexistent-profile-id')
-            )
-    db_connection.rollback()
-
 
 def test_test_case_fk_invalid_category(db_connection, test_creator_fk, seed_test_profile):
     """INSERT test_case with non-existent category_fk → IntegrityError"""
@@ -830,30 +808,6 @@ def test_test_result_fk_invalid_run(db_connection, test_creator_fk, seed_test_pr
 
 # NOT NULL constraint tests
 
-def test_feature_title_not_null(db_connection, test_creator_fk, test_category_id):
-    """INSERT feature with title=NULL → IntegrityError"""
-    with db_connection.cursor() as cur:
-        with pytest.raises(pymysql.IntegrityError):
-            cur.execute(
-                "INSERT INTO features (title, description, category_fk, creator_fk) "
-                "VALUES (%s, %s, %s, %s)",
-                (None, 'desc', test_category_id, test_creator_fk)
-            )
-    db_connection.rollback()
-
-
-def test_feature_description_not_null(db_connection, test_creator_fk, test_category_id):
-    """INSERT feature with description=NULL → IntegrityError (features.description is NOT NULL)."""
-    with db_connection.cursor() as cur:
-        with pytest.raises(pymysql.IntegrityError):
-            cur.execute(
-                "INSERT INTO features (title, description, category_fk, creator_fk) "
-                "VALUES (%s, %s, %s, %s)",
-                ('title', None, test_category_id, test_creator_fk)
-            )
-    db_connection.rollback()
-
-
 def test_test_case_steps_not_null(db_connection, test_creator_fk, test_category_id):
     """INSERT test_case with steps=NULL → IntegrityError"""
     with db_connection.cursor() as cur:
@@ -879,22 +833,6 @@ def test_test_case_expected_not_null(db_connection, test_creator_fk, test_catego
 
 
 # Default value tests
-
-def test_feature_status_default(db_connection, test_creator_fk, test_category_id):
-    """INSERT feature without feature_status → defaults to 'draft'."""
-    with db_connection.cursor() as cur:
-        cur.execute(
-            "INSERT INTO features (title, description, category_fk, creator_fk) "
-            "VALUES (%s, %s, %s, %s)",
-            ('default-status-check', 'desc', test_category_id, test_creator_fk)
-        )
-        cur.execute("SELECT LAST_INSERT_ID() AS id")
-        feature_id = cur.fetchone()['id']
-        cur.execute("SELECT feature_status FROM features WHERE id = %s", (feature_id,))
-        row = cur.fetchone()
-        assert row['feature_status'] == 'draft'
-    db_connection.rollback()
-
 
 def test_test_case_type_default(db_connection, test_creator_fk, test_category_id):
     """INSERT test_case without test_type → defaults to 'manual'."""
@@ -1016,41 +954,11 @@ def test_test_results_unique_run_case(db_connection, test_creator_fk, test_categ
 
 # Junction-table composite PK uniqueness
 
-def test_feature_test_cases_composite_pk(db_connection, test_creator_fk, test_category_id):
-    """Second INSERT feature_test_cases with same (feature_fk, test_case_fk) → IntegrityError."""
-    with db_connection.cursor() as cur:
-        cur.execute(
-            "INSERT INTO features (title, description, category_fk, creator_fk) "
-            "VALUES (%s, %s, %s, %s)",
-            ('f-dup', 'd', test_category_id, test_creator_fk)
-        )
-        cur.execute("SELECT LAST_INSERT_ID() AS id")
-        f_id = cur.fetchone()['id']
-        cur.execute(
-            "INSERT INTO test_cases (title, steps, expected, category_fk, creator_fk) "
-            "VALUES (%s, %s, %s, %s, %s)",
-            ('tc-dup', '1', 'ok', test_category_id, test_creator_fk)
-        )
-        cur.execute("SELECT LAST_INSERT_ID() AS id")
-        tc_id = cur.fetchone()['id']
-
-        cur.execute(
-            "INSERT INTO feature_test_cases (feature_fk, test_case_fk) VALUES (%s, %s)",
-            (f_id, tc_id)
-        )
-        with pytest.raises(pymysql.IntegrityError):
-            cur.execute(
-                "INSERT INTO feature_test_cases (feature_fk, test_case_fk) VALUES (%s, %s)",
-                (f_id, tc_id)
-            )
-    db_connection.rollback()
-
-
 # COVERS: SCH-031
 def test_requirement_test_cases_composite_pk(db_connection, test_creator_fk, test_category_id):
     """req #3352 — Second INSERT requirement_test_cases with same
-    (requirement_fk, test_case_fk) → IntegrityError. Mirrors
-    test_feature_test_cases_composite_pk above."""
+    (requirement_fk, test_case_fk) → IntegrityError (the successor of the
+    now-dropped feature_test_cases junction, req #3355)."""
     with db_connection.cursor() as cur:
         cur.execute(
             "INSERT INTO requirements (title, category_fk, creator_fk, "
@@ -1664,9 +1572,8 @@ def test_agent_instructions_delete_then_repost_swap_is_legal(
 #               and a requirement in a plan cannot be deleted.
 #   CASCADE   — the delete must take the children (pipeline -> steps, step ->
 #               its links and its own dep conditions).
-#   SET NULL  — the delete must DEMOTE, not destroy (epic -> features,
-#               feature -> requirements). Deleting an epic must never take
-#               requirement history with it.
+#   SET NULL  — the delete must DEMOTE, not destroy (e.g. requirements.project_fk).
+#               Deleting a parent must never take child history with it.
 # ---------------------------------------------------------------------------
 
 def _insert_epic(cur, creator_fk, category_fk, title=None):
@@ -1677,19 +1584,11 @@ def _insert_epic(cur, creator_fk, category_fk, title=None):
     return cur.lastrowid
 
 
-def _insert_feature(cur, creator_fk, category_fk, epic_fk=None):
+def _insert_requirement(cur, creator_fk, category_fk):
     cur.execute(
-        "INSERT INTO features (title, description, category_fk, creator_fk, epic_fk) "
-        "VALUES (%s, %s, %s, %s, %s)",
-        (f'feat-{uuid.uuid4().hex[:6]}', 'fixture feature', category_fk, creator_fk, epic_fk))
-    return cur.lastrowid
-
-
-def _insert_requirement(cur, creator_fk, category_fk, feature_fk=None):
-    cur.execute(
-        "INSERT INTO requirements (title, category_fk, creator_fk, ai_model, effort, feature_fk) "
-        "VALUES (%s, %s, %s, 'opus', 'high', %s)",
-        (f'req-{uuid.uuid4().hex[:6]}', category_fk, creator_fk, feature_fk))
+        "INSERT INTO requirements (title, category_fk, creator_fk, ai_model, effort) "
+        "VALUES (%s, %s, %s, 'opus', 'high')",
+        (f'req-{uuid.uuid4().hex[:6]}', category_fk, creator_fk))
     return cur.lastrowid
 
 
@@ -1723,7 +1622,7 @@ def test_epics_category_fk_invalid_rejected(db_connection, test_creator_fk):
 
 def test_epics_category_delete_restricted(db_connection, test_creator_fk, seed_test_profile):
     """epics -> categories is RESTRICT: you cannot orphan an epic by deleting its
-    category. Move it first. Same policy as requirements/features."""
+    category. Move it first. Same policy as requirements."""
     with db_connection.cursor() as cur:
         cur.execute("INSERT INTO projects (project_name, creator_fk) VALUES (%s, %s)",
                     ('epic-restrict proj', test_creator_fk))
@@ -1738,59 +1637,10 @@ def test_epics_category_delete_restricted(db_connection, test_creator_fk, seed_t
     db_connection.rollback()
 
 
-# --- features.epic_fk (SET NULL) -------------------------------------------
-
-def test_feature_epic_fk_set_null_on_epic_delete(
-        db_connection, test_creator_fk, test_category_id):
-    """Deleting an epic DEMOTES its features to unfiled — it must never delete
-    them. SET NULL is the only policy that allows the delete to succeed while
-    keeping the feature."""
-    with db_connection.cursor() as cur:
-        epic = _insert_epic(cur, test_creator_fk, test_category_id)
-        feature = _insert_feature(cur, test_creator_fk, test_category_id, epic_fk=epic)
-
-        cur.execute("DELETE FROM epics WHERE id = %s", (epic,))
-
-        cur.execute("SELECT epic_fk FROM features WHERE id = %s", (feature,))
-        row = cur.fetchone()
-        assert row is not None, 'deleting an epic must not delete its features'
-        assert row['epic_fk'] is None
-    db_connection.rollback()
-
-
-def test_feature_epic_fk_invalid_rejected(db_connection, test_creator_fk, test_category_id):
-    with db_connection.cursor() as cur:
-        with pytest.raises(pymysql.IntegrityError):
-            _insert_feature(cur, test_creator_fk, test_category_id, epic_fk=999999)
-    db_connection.rollback()
-
-
-# --- requirements.feature_fk (SET NULL) ------------------------------------
-
-def test_requirement_feature_fk_set_null_on_feature_delete(
-        db_connection, test_creator_fk, test_category_id):
-    """Deleting a feature must not delete requirement history — the requirement
-    is demoted to unfiled."""
-    with db_connection.cursor() as cur:
-        feature = _insert_feature(cur, test_creator_fk, test_category_id)
-        req = _insert_requirement(cur, test_creator_fk, test_category_id, feature_fk=feature)
-
-        cur.execute("DELETE FROM features WHERE id = %s", (feature,))
-
-        cur.execute("SELECT feature_fk FROM requirements WHERE id = %s", (req,))
-        row = cur.fetchone()
-        assert row is not None, 'deleting a feature must not delete its requirements'
-        assert row['feature_fk'] is None
-    db_connection.rollback()
-
-
-def test_requirement_feature_fk_invalid_rejected(
-        db_connection, test_creator_fk, test_category_id):
-    with db_connection.cursor() as cur:
-        with pytest.raises(pymysql.IntegrityError):
-            _insert_requirement(cur, test_creator_fk, test_category_id, feature_fk=999999)
-    db_connection.rollback()
-
+# `features` and `requirements.feature_fk` were dropped at req #3355
+# (migration 20260811033413) — the Feature tier's SET NULL/FK coverage went
+# with them. Pipeline 2.0 seats a step under an epic directly (epic_fk on the
+# step), never through Feature.
 
 # --- pipelines -------------------------------------------------------------
 

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -5,6 +5,8 @@ Verifies that DESCRIBE output for each table matches the expected schema.sql
 definitions. Uses darwin_dev test database (profiles, domains, areas, tasks).
 """
 
+import pytest
+
 
 def test_profiles_columns(db_connection):
     """Verify profiles column definitions match schema.sql.
@@ -433,12 +435,9 @@ def test_requirements_columns(db_connection):
     # Tolerate both pre- and post-migration-066 state (req #2978 added machine_fk).
     if 'machine_fk' in columns:
         expected_fields.append('machine_fk')
-    # Req #3111, migration 076 — the story tier of Epic > Feature > Story.
-    # Asserted unconditionally: 076 lands in darwin_dev and production together
-    # (coordination_type=deployed), so there is no window in which a live
-    # database legitimately lacks it — unlike the tolerated columns above, which
-    # were added by dev-first migrations that could lag.
-    expected_fields.append('feature_fk')
+    # `feature_fk` (req #3111, migration 076 — the story tier of Epic > Feature
+    # > Story) was dropped at req #3355 (migration 20260811033413), so it is no
+    # longer asserted here.
     # Req #3123, migration 20260731124830 — the CONTAINER flag. Asserted
     # unconditionally for the same reason feature_fk is: the migration lands in
     # darwin_dev and production together, so no live database legitimately lacks
@@ -1519,52 +1518,6 @@ def test_map_run_partners_columns(db_connection):
     assert 'timestamp' in columns['create_ts']['Type']
 
 
-def test_features_columns(db_connection):
-    """Verify features column definitions match schema.sql (migration 042)."""
-    with db_connection.cursor() as cur:
-        cur.execute("DESCRIBE features")
-        columns = {row['Field']: row for row in cur.fetchall()}
-
-    expected_fields = ['id', 'title', 'description', 'feature_status',
-                       'epic_fk',   # req #3111, migration 076 — parent epic
-                       'category_fk', 'creator_fk', 'closed', 'sort_order',
-                       'create_ts', 'update_ts']
-    assert set(columns.keys()) == set(expected_fields), \
-        f"Unexpected columns: {set(columns.keys()) - set(expected_fields)}"
-
-    assert columns['id']['Type'] == 'int'
-    assert columns['id']['Key'] == 'PRI'
-    assert columns['id']['Extra'] == 'auto_increment'
-
-    assert columns['title']['Type'] == 'varchar(256)'
-    assert columns['title']['Null'] == 'NO'
-
-    assert columns['description']['Type'] == 'text'
-    assert columns['description']['Null'] == 'NO'
-
-    assert columns['feature_status']['Type'] == 'varchar(16)'
-    assert columns['feature_status']['Null'] == 'NO'
-    assert columns['feature_status']['Default'] == 'draft'
-
-    assert columns['category_fk']['Type'] == 'int'
-    assert columns['category_fk']['Null'] == 'NO'
-
-    assert columns['creator_fk']['Type'] == 'varchar(64)'
-    assert columns['creator_fk']['Null'] == 'NO'
-
-    assert 'tinyint' in columns['closed']['Type']
-    assert columns['closed']['Null'] == 'NO'
-    assert columns['closed']['Default'] == '0'
-
-    assert columns['sort_order']['Type'] == 'smallint'
-    assert columns['sort_order']['Null'] == 'YES'
-
-    assert 'timestamp' in columns['create_ts']['Type']
-    assert columns['create_ts']['Default'] == 'CURRENT_TIMESTAMP'
-    assert 'timestamp' in columns['update_ts']['Type']
-    assert columns['update_ts']['Extra'] == 'on update CURRENT_TIMESTAMP'
-
-
 def test_test_cases_columns(db_connection):
     """Verify test_cases column definitions match schema.sql (migration 042)."""
     with db_connection.cursor() as cur:
@@ -1612,32 +1565,12 @@ def test_test_cases_columns(db_connection):
     assert columns['sort_order']['Null'] == 'YES'
 
 
-def test_feature_test_cases_columns(db_connection):
-    """Verify feature_test_cases junction (migration 042) — composite PK, no id."""
-    with db_connection.cursor() as cur:
-        cur.execute("DESCRIBE feature_test_cases")
-        columns = {row['Field']: row for row in cur.fetchall()}
-
-    expected_fields = ['feature_fk', 'test_case_fk']
-    assert set(columns.keys()) == set(expected_fields), \
-        f"Unexpected columns: {set(columns.keys()) - set(expected_fields)}"
-
-    # Both FKs are primary key parts (composite PK)
-    assert columns['feature_fk']['Type'] == 'int'
-    assert columns['feature_fk']['Null'] == 'NO'
-    assert columns['feature_fk']['Key'] == 'PRI'
-
-    assert columns['test_case_fk']['Type'] == 'int'
-    assert columns['test_case_fk']['Null'] == 'NO'
-    # MySQL reports non-leading composite PK columns as 'MUL'
-    assert columns['test_case_fk']['Key'] in ('PRI', 'MUL')
-
-
 # COVERS: SCH-031, SCH-034
 def test_requirement_test_cases_columns(db_connection):
     """req #3352 — requirement_test_cases junction (migration 20260809002149),
-    composite PK, no id. Mirrors test_feature_test_cases_columns above — both
-    junctions exist at once, feature_test_cases is not dropped by this one."""
+    composite PK, no id. Its predecessor, feature_test_cases, was dropped at
+    req #3355 (migration 20260811033413) — this is now the only test-case
+    junction."""
     with db_connection.cursor() as cur:
         cur.execute("DESCRIBE requirement_test_cases")
         columns = {row['Field']: row for row in cur.fetchall()}
@@ -1656,12 +1589,50 @@ def test_requirement_test_cases_columns(db_connection):
     # MySQL reports non-leading composite PK columns as 'MUL'
     assert columns['test_case_fk']['Key'] in ('PRI', 'MUL')
 
-    # feature_test_cases still exists — both eras run at once (req #3334's
-    # eradication sequencing is what would eventually drop it, not this one).
+    # feature_test_cases is gone — req #3355 dropped it in the same migration
+    # that this test's own requirement's precondition (a) verified every one
+    # of its rows had a requirement_test_cases equivalent.
     with db_connection.cursor() as cur:
         cur.execute("SHOW TABLES LIKE 'feature_test_cases'")
-        assert cur.fetchone() is not None, \
-            "feature_test_cases must not be dropped by the junction requirement"
+        assert cur.fetchone() is None, \
+            "feature_test_cases must be dropped by req #3355"
+
+
+# COVERS: ERA-008
+def test_requirement_test_cases_carries_the_pre_drop_migration(db_connection):
+    """req #3355 precondition (a) — verified 2026-08-11 by direct PRODUCTION
+    query before the drop (the durable proof; this test cannot re-run that
+    query, `feature_test_cases` no longer exists to compare against): all 28
+    production `feature_test_cases` rows had a `requirement_test_cases` row
+    sharing the same `test_case_fk`, spread across four requirements
+    (3158:9, 3159:7, 3163:7, 3174:5) that darwin_dev's own migration carried
+    identically at measurement time.
+
+    This test regression-locks darwin_dev's copy of that outcome — but
+    darwin_dev is rebuilt from `recreate_darwin_dev.sql` (schema only, no
+    data) with some regularity, and nothing under `DarwinSQL/scripts/`
+    re-seeds this junction afterward. A CLEAN reset — all four requirements
+    at zero — is that expected, harmless case and is SKIPPED rather than
+    failed. A PARTIAL count (some but not all rows present, or a nonzero
+    count short of what was measured) is never expected from a clean reset
+    and fails loudly: that shape means the migrated data was damaged, not
+    that darwin_dev was rebuilt."""
+    with db_connection.cursor() as cur:
+        cur.execute(
+            "SELECT requirement_fk, COUNT(*) AS c FROM requirement_test_cases "
+            "WHERE requirement_fk IN (3158, 3159, 3163, 3174) "
+            "GROUP BY requirement_fk")
+        counts = {row['requirement_fk']: row['c'] for row in cur.fetchall()}
+    expected = {3158: 9, 3159: 7, 3163: 7, 3174: 5}
+    if not counts:
+        pytest.skip('requirement_test_cases carries none of the four measured '
+                    'requirements — darwin_dev was likely reset from '
+                    'recreate_darwin_dev.sql (schema only, no data) since this '
+                    'junction was last backfilled; nothing to regression-lock')
+    for rid, want in expected.items():
+        assert counts.get(rid, 0) >= want, (
+            f'requirement #{rid} carries {counts.get(rid, 0)} requirement_test_cases '
+            f'rows, expected at least {want} — the pre-drop migration may have lost data')
 
 
 def test_test_plans_columns(db_connection):
@@ -1847,8 +1818,9 @@ def test_table_count(db_connection):
         'map_routes', 'map_runs', 'map_coordinates', 'map_views',
         'map_partners', 'map_run_partners',
         'user_integrations',  # Migration 036
-        # Req #2380 — Swarm Features & Test Cases registry
-        'features', 'test_cases', 'feature_test_cases',
+        # Req #2380 — Swarm Features & Test Cases registry. `features` and
+        # `feature_test_cases` dropped at req #3355 (migration 20260811033413).
+        'test_cases',
         'test_plans', 'test_plan_cases',
         'test_runs', 'test_results',
         # Req #2422 — swarm-start data type
@@ -1873,8 +1845,9 @@ def test_table_count(db_connection):
         # Req #3096 — per-document actual-token rows (child of agent_telemetry_rows)
         'agent_telemetry_row_docs',
         # Req #3111 — Swarm Orchestration schema foundation (migration 076).
-        # epics tops the agile hierarchy (Epic > Feature > Story); the four
-        # pipeline tables are the execution artifact.
+        # epics tops the containment hierarchy; the four pipeline tables are
+        # the execution artifact. (Epic > Feature > Story's Feature tier was
+        # retired at req #3355 — a step seats an epic directly.)
         'epics',
         'pipelines', 'pipeline_steps',
         'pipeline_step_requirements', 'pipeline_step_deps',
@@ -1888,9 +1861,8 @@ def test_table_count(db_connection):
         'pipeline2_pipelines', 'pipeline2_epics', 'pipeline2_steps',
         'pipeline2_step_requirements', 'pipeline2_step_deps',
         # Req #3352 — Pipeline 2.0 Feature retirement: test cases re-home onto
-        # Requirement (migration 20260809002149). Stands beside
-        # feature_test_cases above, not in its place, until req #3334's
-        # eradication sequencing.
+        # Requirement (migration 20260809002149). The sole test-case junction
+        # since req #3355 dropped feature_test_cases.
         'requirement_test_cases',
     }
     assert expected_tables == tables, \
@@ -2504,10 +2476,10 @@ def test_epics_status_is_suppression_not_lifecycle(db_connection):
     launching yesterday stops launching because a column appeared.
 
     VARCHAR(16), matching `pipelines.pipeline_status` /
-    `requirements.requirement_status` / `features.feature_status` rather than an
-    ENUM, because every status column in this schema is a VARCHAR whose value set
-    is enforced in the service layer — an ENUM here would be the one table where
-    adding a value needs DDL.
+    `requirements.requirement_status` rather than an ENUM, because every status
+    column in this schema is a VARCHAR whose value set is enforced in the
+    service layer — an ENUM here would be the one table where adding a value
+    needs DDL.
     """
     with db_connection.cursor() as cur:
         cols = _columns(cur, 'epics')
@@ -2519,29 +2491,20 @@ def test_epics_status_is_suppression_not_lifecycle(db_connection):
     assert cols['epic_status']['Key'] == ''
 
 
-def test_features_epic_fk_column(db_connection):
-    """features.epic_fk — the middle tier. NULL-able because features predate
-    epics and an unfiled feature is legitimate."""
+def test_features_table_dropped(db_connection):
+    """`features`, `feature_test_cases` and `requirements.feature_fk` (the
+    Epic > Feature > Story chain) were dropped at req #3355, migration
+    20260811033413. A step's epic is now read directly off the step
+    (`epic_fk`) — see test_features_epic_fk_column's and
+    test_requirements_feature_fk_column's history for the columns this
+    replaces."""
     with db_connection.cursor() as cur:
-        cols = _columns(cur, 'features')
-    assert 'epic_fk' in cols
-    assert cols['epic_fk']['Type'] == 'int'
-    assert cols['epic_fk']['Null'] == 'YES'
-    assert cols['epic_fk']['Default'] is None
-    assert cols['epic_fk']['Key'] == 'MUL'          # indexed FK
-
-
-def test_requirements_feature_fk_column(db_connection):
-    """requirements.feature_fk — the story tier, and the ONLY place epic/feature
-    labels attach (req #3080 design rule 10). NULL-able: the overwhelming
-    majority of Darwin's requirements have no feature and never will."""
-    with db_connection.cursor() as cur:
+        cur.execute("SHOW TABLES LIKE 'features'")
+        assert cur.fetchone() is None
+        cur.execute("SHOW TABLES LIKE 'feature_test_cases'")
+        assert cur.fetchone() is None
         cols = _columns(cur, 'requirements')
-    assert 'feature_fk' in cols
-    assert cols['feature_fk']['Type'] == 'int'
-    assert cols['feature_fk']['Null'] == 'YES'
-    assert cols['feature_fk']['Default'] is None
-    assert cols['feature_fk']['Key'] == 'MUL'       # indexed FK
+    assert 'feature_fk' not in cols
 
 
 def test_requirements_tracking_column(db_connection):

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -584,8 +584,12 @@ def test_migration_sequence_applies(db_connection, migration_test_prefix):
             'map_routes', 'map_runs', 'map_coordinates',
             'map_views', 'map_partners', 'map_run_partners',
             'user_integrations',
-            # Req #2380 — Swarm Features & Test Cases registry
-            'features', 'test_cases', 'feature_test_cases',
+            # Req #2380 — Swarm Features & Test Cases registry. `features` and
+            # `feature_test_cases` are CREATED by migration 042 then DROPPED by
+            # req #3355 (migration 20260811033413 — Feature schema eradication),
+            # so — like the Build Visualizer tables below — they do NOT appear
+            # in the final replay state.
+            'test_cases',
             'test_plans', 'test_plan_cases',
             'test_runs', 'test_results',
             # Req #2422 — swarm-start data type
@@ -619,8 +623,9 @@ def test_migration_sequence_applies(db_connection, migration_test_prefix):
             # parallel era. Stands beside the 1.0 five above; not a replacement.
             'pipeline2_pipelines', 'pipeline2_epics', 'pipeline2_steps',
             'pipeline2_step_requirements', 'pipeline2_step_deps',
-            # Req #3352 — requirement_test_cases (migration 20260809002149).
-            # Stands beside feature_test_cases above; not a replacement.
+            # Req #3352 — requirement_test_cases (migration 20260809002149),
+            # the sole test-case junction since req #3355 dropped
+            # feature_test_cases.
             'requirement_test_cases',
         ]
     }

--- a/tests/test_seed_pipelines_fixture.py
+++ b/tests/test_seed_pipelines_fixture.py
@@ -40,11 +40,11 @@ re-derives them from the SQL's own INSERT tuples, with a quote- and comment-awar
 parser, and fails on any disagreement. Seven families are covered — a closed
 enumeration, matching the table in `memory/database.md` § Seed data:
 
-  1. `-- Source plan:` header — plan rows, distinct requirements, epics, features
-  2. `-- ## Id allocation` — the epics / features / pipelines id ranges
+  1. `-- Source plan:` header — plan rows, distinct requirements, epics
+  2. `-- ## Id allocation` — the epics / pipelines id ranges
   3. `-- ## plan step id -> pipeline_steps.id` — the whole offset map
   4. `-- * multi-req steps ... 1(5), 33(2), ...` — the launch-unit pairs
-  5. `-- Epics (N)` / `-- Features (N)` / ... — the per-INSERT block captions
+  5. `-- Epics (N)` / `-- Requirements (N)` / ... — the per-INSERT block captions
   6. `-- reproduces the plan's own state field for N of M rows` + the exception list
   7. `-- (this plan has N of them)` and the footer `SELECT COUNT(*) ... -- N` crib
 
@@ -64,10 +64,25 @@ deliberately outside that boundary, so do not read a green run as covering them:
     dep target passes green — and status is exactly what derived step state reads
     (design rule 1).
   * The structural acceptance criteria the header narrates: `req-less step 7`,
-    `dual-condition gate step 3`, `cross-epic step 19`, `Flagged as containers in
-    this generation: #3083`, and the `machine_fk` remap `(2->74, 3->75)`.
+    `dual-condition gate step 3`, `Flagged as containers in this generation:
+    #3083`, and the `machine_fk` remap `(2->74, 3->75)`.
 
 The defence for both is regenerating rather than hand-editing.
+
+NO FEATURE LAYER (req #3355)
+---------------------------
+Migration 20260811033413 dropped `features`, `feature_test_cases` and
+`requirements.feature_fk`, so the fixture emits no `features` INSERT block, no
+`features` id range, no feature count in the `-- Source plan:` header, and no
+`feature_fk` column in the requirements upsert. The `cross-epic step 19` claim
+went with them: it demonstrated req #3080 design rule 10, which is only
+expressible while a requirement carries its own epic label, and 1.0 has nothing
+left to carry one. Requirement #3105 is still in the fixture — plan step 19
+links it directly — so the requirement count is unchanged; only the label is
+gone. `epics` are untouched and still asserted below, and
+`test_fixture_no_longer_emits_the_feature_layer` pins the absence so a
+regeneration against an old generator fails loudly instead of re-emitting rows
+for a table the database no longer has.
 """
 import os
 import re
@@ -373,18 +388,17 @@ def test_header_source_plan_counts_match_the_rows(seed_sql, rows):
     match = re.search(
         r'--\s*Source plan:\s*requirement\s*#(\d+),\s*(\d+)\s*rows,\s*'
         r'(\d+)\s*distinct requirements,\s*\n'
-        r'--\s*(\d+)\s*epics,\s*(\d+)\s*features\.',
+        r'--\s*(\d+)\s*epics\.',
         seed_sql,
     )
     assert match, "header `-- Source plan:` block not found or reformatted"
 
-    _req_id, steps, requirements, epics, features = (int(g) for g in match.groups())
+    _req_id, steps, requirements, epics = (int(g) for g in match.groups())
 
     for label, claimed, table in (
         ('plan rows', steps, 'pipeline_steps'),
         ('distinct requirements', requirements, 'requirements'),
         ('epics', epics, 'epics'),
-        ('features', features, 'features'),
     ):
         assert claimed == len(rows[table]), (
             f"header says {claimed} {label}, file inserts {len(rows[table])} "
@@ -440,8 +454,8 @@ def test_header_states_production_carries_the_live_plan(seed_sql):
 # ---------------------------------------------------------------------------
 
 def test_id_allocation_ranges_match_the_rows(seed_sql, by_table):
-    """`--   features   9001..9023` must be the range the file actually inserts."""
-    for table in ('epics', 'features'):
+    """`--   epics   9001..9004` must be the range the file actually inserts."""
+    for table in ('epics',):
         match = re.search(rf'--\s+{table}\s+(\d+)\.\.(\d+)\s*$', seed_sql, re.M)
         assert match, f"id-allocation line for `{table}` not found or reformatted"
         low, high = int(match.group(1)), int(match.group(2))
@@ -540,7 +554,6 @@ def test_multi_req_step_pairs_match_the_links(seed_sql, by_table):
 # silently re-point a caption at the wrong block.
 BLOCK_CAPTIONS = (
     (r'--\s*Epics \((\d+)\)', 'epics'),
-    (r'--\s*Features \((\d+)\)', 'features'),
     (r'--\s*Requirements \((\d+)\)', 'requirements'),
     (r'--\s*Steps \((\d+)\)', 'pipeline_steps'),
     (r'--\s*Step -> requirement links \((\d+)\)', 'pipeline_step_requirements'),
@@ -704,6 +717,72 @@ def test_fixture_owns_its_project_and_category(by_table):
     for table in ('projects', 'categories'):
         ids = [i for block in by_table[table] for i in _ints(block, 'id')]
         assert ids == [9001], f"{table} fixture row ids are {ids}, expected [9001]"
+
+
+# ---------------------------------------------------------------------------
+# The Feature layer is gone (req #3355)
+# ---------------------------------------------------------------------------
+
+DROPPED_TABLES = ('features', 'feature_test_cases')
+DROPPED_COLUMN = 'feature_fk'
+
+
+def test_fixture_no_longer_emits_the_feature_layer(seed_sql, blocks):
+    """Migration 20260811033413 dropped `features` / `feature_test_cases` /
+    `requirements.feature_fk`, so a fixture naming any of them cannot LOAD.
+
+    Asserted on the EXECUTABLE body, not the raw text: comments legitimately
+    explain what was removed and why, and requirement titles legitimately say
+    "Features" (`#3057`, "breaks Features linking"). Both are blanked first, so
+    what remains is table names, column names and structure — the only places a
+    dropped object would actually reach the database from.
+
+    This is the positive replacement for the feature assertions this module used
+    to carry. They checked that a `features` block existed and agreed with its
+    caption; the same claim, after the drop, is that no such block exists — which
+    is what catches a regeneration run against a stale generator.
+    """
+    body = _blank_literals(_blank_comments(seed_sql))
+
+    for table in DROPPED_TABLES:
+        hit = [b.table for b in blocks if b.table.split('.')[-1] == table]
+        assert not hit, (
+            f"the fixture still INSERTs into `{table}`, which migration "
+            f"20260811033413 dropped — regenerate with "
+            f"scripts/seed_pipelines_darwin_dev.py"
+        )
+        assert not re.search(rf'\b{table}\b', body), (
+            f"`{table}` is still referenced in the executable body of the fixture"
+        )
+
+    offenders = sorted({
+        b.table for b in blocks if DROPPED_COLUMN in b.columns
+    })
+    assert not offenders, (
+        f"`{DROPPED_COLUMN}` is still an INSERT column on {offenders}; the "
+        f"column was dropped from `requirements` by migration 20260811033413"
+    )
+    assert not re.search(rf'\b{DROPPED_COLUMN}\b', body), (
+        f"`{DROPPED_COLUMN}` still appears in the executable body of the fixture"
+    )
+
+
+def test_header_makes_no_feature_claims(seed_sql):
+    """The header must not advertise counts or id ranges for rows it cannot emit.
+
+    Pinned separately from the block-caption table above, which only checks the
+    captions it lists: a re-introduced `-- Features (N)` caption would sit there
+    unread otherwise.
+    """
+    for pattern, what in (
+        (r'--\s*Features \(\d+\)', 'a `-- Features (N)` INSERT-block caption'),
+        (r'--\s+features\s+\d+\.\.\d+', 'a `features` id-allocation range'),
+        (r'\d+\s*epics,\s*\d+\s*features', 'a feature count in `-- Source plan:`'),
+    ):
+        assert not re.search(pattern, seed_sql, re.M), (
+            f"the fixture header still carries {what}, but the Feature layer was "
+            f"dropped by migration 20260811033413 (req #3355)"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-08-11T05:45:21Z
- Pipeline 2.0 - drop the Feature schema: features, feature_test_cases, requirements.feature_fk (req #3355)
- chore: init swarm session feature/3355-pipeline-20-drop-the-feature-schema

## Files changed
```
 ...ma_features_feature_test_cases_requirements.sql |  75 +++++++
 schema.sql                                         |  50 +----
 scripts/recreate_darwin_dev.sql                    |  72 ++-----
 scripts/seed_pipelines_darwin_dev.py               | 215 ++++++++++++---------
 scripts/seed_pipelines_darwin_dev.sql              | 210 +++++++++-----------
 scripts/verify-lambda-policy.sh                    |  15 +-
 tests/conftest.py                                  |  16 +-
 tests/test_cascades.py                             |  99 +---------
 tests/test_constraints.py                          | 180 ++---------------
 tests/test_data_types.py                           | 185 +++++++-----------
 tests/test_migrations.py                           |  13 +-
 tests/test_seed_pipelines_fixture.py               | 101 ++++++++--
 12 files changed, 526 insertions(+), 705 deletions(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)