### PR TITLE
req #3472

### DIFF
--- a/migrations/20260813092839_agent_telemetry_deferred_category_columns.sql
+++ b/migrations/20260813092839_agent_telemetry_deferred_category_columns.sql
@@ -1,0 +1,71 @@
+-- 20260813092839_agent_telemetry_deferred_category_columns.sql
+--
+-- Req #3472: record the DEFERRED halves of Claude Code's split `/context` categories,
+--            distinctly from the resident figures they were split off from.
+--
+-- PROBLEM.  Claude Code 2.1.226 split two `/context` categories in two. It now emits
+--           `System tools (deferred)` and `MCP tools (deferred)` alongside the resident
+--           `System tools` / `MCP tools` rows, and EXCLUDES both deferred rows from the
+--           session total. Measured on this harness 2026-08-10: MCP tools 0 resident +
+--           40,200 deferred, system tools 12,700 resident + 14,400 deferred.
+--
+--           `agent_telemetry_rows` has no column for either figure, so a capture taken
+--           today records 54,600 measured tokens nowhere at all. Worse, the row it DOES
+--           write is indistinguishable from a pre-split one: production run 9's
+--           `mcp_tools_tokens` is a whole-category figure, a fresh run's is a
+--           resident-only figure (or NULL — the probe matched labels exactly and simply
+--           did not see the renamed row), and nothing in the data says the definition
+--           moved between them.
+--
+-- SHAPE.    Two nullable INT columns beside the five req #3095 breakdown columns:
+--           `system_tools_deferred_tokens`, `mcp_tools_deferred_tokens`.
+--
+--           SEPARATE columns rather than folding the deferred figure into the resident
+--           one, because a deferred tool schema is NOT consumption — it is an index the
+--           model may expand on demand. Claude Code excludes it from its own total, and
+--           real API `usage` for the billed seed turn (61,126 tokens) matched the
+--           resident-only sum to 0.12%. Summing the two would break the real-usage
+--           cross-check the breakdown columns exist to support.
+--
+--           NULLABLE and with no default, so an existing row keeps NULL — the same
+--           never-fabricate-a-zero rule migration 074 followed for the five columns it
+--           added. That NULL is also the DISTINGUISHER the requirement asks for: a
+--           pre-split capture has NULL here, a post-split one has integers, and a
+--           post-split capture on a harness that defers nothing has NULL because
+--           nothing was deferred — in which case the old and new definitions agree and
+--           the two captures genuinely are comparable.
+--
+--           No version/marker column was added. One would encode in a flag what the
+--           measurements already state, and would have to be maintained by hand at every
+--           future harness change; the probe's own unrecognized-label warning (req #3472)
+--           is what detects the NEXT relabelling, and it lands on the row as a footnote.
+--
+-- TARGET.   NEVER write `USE <db>;` or `CREATE DATABASE` into this file. A
+--           `USE` is a statement, not a declaration: it re-points the session
+--           the moment it executes and overrides whatever database the caller
+--           named — which on 2026-08-01 sent a dev-aimed apply to production.
+--           load_sql.py REFUSES a file that names its own database, and
+--           DarwinSQL/tests/test_sql_targets.py fails the build (req #3196).
+--           This migration applies to BOTH databases, so it declares no target
+--           constraint.
+--
+-- APPLY.    darwin_dev FIRST, production SECOND. Two separate commands:
+--
+--             python3 DarwinSQL/scripts/load_sql.py \
+--               DarwinSQL/migrations/20260813092839_agent_telemetry_deferred_category_columns.sql darwin_dev
+--
+--             python3 DarwinSQL/scripts/load_sql.py \
+--               DarwinSQL/migrations/20260813092839_agent_telemetry_deferred_category_columns.sql darwin --production
+--
+--           Production is named TWICE — by name and by intent. The loader
+--           refuses `darwin` without --production, and refuses --production on
+--           any other database (req #3196). The production command also
+--           requires `bash scripts/db/rds-snapshot.sh 20260813092839` to report
+--           status=ok first. See memory/database.md § Schema Migration Workflow.
+--
+-- Migration id 20260813092839 is a UTC timestamp allocated by
+-- DarwinSQL/scripts/new-migration.sh (req #3121). Do not renumber it.
+
+ALTER TABLE agent_telemetry_rows
+    ADD COLUMN system_tools_deferred_tokens INT NULL AFTER custom_agents_tokens,
+    ADD COLUMN mcp_tools_deferred_tokens    INT NULL AFTER system_tools_deferred_tokens;

--- a/schema.sql
+++ b/schema.sql
@@ -1176,6 +1176,15 @@ CREATE TABLE IF NOT EXISTS agent_telemetry_rows (
     mcp_tools_tokens            INT          NULL,   -- MCP tools/resources listing (req #3095, migration 074)
     skills_tokens               INT          NULL,   -- available-skills listing (req #3095, migration 074)
     custom_agents_tokens        INT          NULL,   -- other-custom-agent listing (req #3095, migration 074)
+    -- req #3472, migration 20260813 — the DEFERRED halves Claude Code 2.1.226 split off
+    -- `System tools` and `MCP tools`. NOT consumption: a deferred tool schema is an index the
+    -- model may expand on demand, Claude Code excludes both from the session total, and real
+    -- API `usage` for a billed turn matched the resident-only sum to 0.12%. Kept beside the
+    -- resident figures and never summed into them. NULL on every row captured before the split
+    -- (and on any harness that defers nothing), which is what keeps a pre-deferral capture from
+    -- being silently compared against a post-deferral one.
+    system_tools_deferred_tokens INT         NULL,   -- deferred built-in tool schemas (req #3472)
+    mcp_tools_deferred_tokens   INT          NULL,   -- deferred MCP tool schemas (req #3472)
     claude_md_tokens            INT          NULL,
     charter_stub_tokens         INT          NULL,
     boot_payload_tokens         INT          NULL,

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -2397,6 +2397,9 @@ def test_agent_telemetry_rows_columns(db_connection):
                 'boot_time_ms', 'cc_base_tokens',
                 'system_prompt_tokens', 'system_tools_tokens', 'mcp_tools_tokens',
                 'skills_tokens', 'custom_agents_tokens',
+                # req #3472, migration 20260813092839 — the DEFERRED halves of two of
+                # those categories under cc-2.1.226+
+                'system_tools_deferred_tokens', 'mcp_tools_deferred_tokens',
                 'claude_md_tokens',
                 'charter_stub_tokens', 'boot_payload_tokens', 'autoload_tokens',
                 'docs_loaded', 'docs_expected', 'start_work_context_tokens',
@@ -2419,9 +2422,15 @@ def test_agent_telemetry_rows_columns(db_connection):
               # ground-truth CC-base breakdown (req #3095, migration 074) — nullable,
               # a row's breakdown may not have been captured
               'system_prompt_tokens', 'system_tools_tokens', 'mcp_tools_tokens',
-              'skills_tokens', 'custom_agents_tokens'):
+              'skills_tokens', 'custom_agents_tokens',
+              # req #3472 — deferred halves; nullable for a SECOND reason beyond
+              # "not captured": NULL is also how a pre-deferral capture (and a
+              # harness that defers nothing) is told apart from a post-deferral one,
+              # so a DEFAULT 0 here would erase exactly the distinction it exists for
+              'system_tools_deferred_tokens', 'mcp_tools_deferred_tokens'):
         assert cols[c]['Null'] == 'YES', c
         assert cols[c]['Type'] in ('int', 'int(11)'), (c, cols[c]['Type'])
+        assert cols[c]['Default'] is None, c
     assert cols['footnote']['Type'] == 'varchar(512)'
     assert cols['footnote']['Null'] == 'YES'
     assert cols['creator_fk']['Null'] == 'NO'


### PR DESCRIPTION
## Summary
- wip(DarwinSQL): 2026-08-13T10:09:01Z
- chore: init swarm session feature/3472-context-breakdown-probepy-silently-1

## Files changed
```
 ...9_agent_telemetry_deferred_category_columns.sql | 71 ++++++++++++++++++++++
 schema.sql                                         |  9 +++
 tests/test_data_types.py                           | 11 +++-
 3 files changed, 90 insertions(+), 1 deletion(-)
```

## Testing
No automated tests run for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Related PRs (req #3472): DarwinAI-Config#967, DarwinSQL#143, Darwin#1039